### PR TITLE
Use "Microsoft.Owin.Security.OAuth" for DataProtector 

### DIFF
--- a/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
+++ b/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Owin.Security.OpenIdConnect.Server {
 
             if (Options.AccessTokenFormat == null) {
                 IDataProtector dataProtector = app.CreateDataProtector(
-                    typeof(OpenIdConnectServerMiddleware).Namespace,
+                    "Microsoft.Owin.Security.OAuth",
                     "Access_Token", "v1");
 
                 Options.AccessTokenFormat = new TicketDataFormat(dataProtector);


### PR DESCRIPTION
to be compatible with Katana's OAuth-Server.

I think, it's ok to just do the for the data-protector that is used for the access-token, cause the refresh-token and the access-code isn't transparent to the client.
