### PR TITLE
Add userinfo endpoint support

### DIFF
--- a/samples/Mvc/Mvc.Server/Controllers/ProfileController.cs
+++ b/samples/Mvc/Mvc.Server/Controllers/ProfileController.cs
@@ -1,0 +1,20 @@
+﻿using System.Security.Claims;
+using AspNet.Security.OpenIdConnect.Extensions;
+using AspNet.Security.OpenIdConnect.Server;
+using Microsoft.AspNet.Authorization;
+using Microsoft.AspNet.Mvc;
+
+namespace Mvc.Server.Controllers {
+    public class ProfileController : Controller {
+        // Note: make sure to always specify ActiveAuthenticationSchemes = "oidc-server"
+        // or use AutomaticAuthentication = true in the OpenID Connect server middleware options.
+        [Authorize(ActiveAuthenticationSchemes = OpenIdConnectServerDefaults.AuthenticationScheme)]
+        [HttpGet("/connect/userinfo")]
+        public IActionResult Get() {
+            return Json(new {
+                sub = User.GetClaim(ClaimTypes.NameIdentifier),
+                name = User.GetClaim(ClaimTypes.Name)
+            });
+        }
+    }
+}

--- a/samples/Mvc/Mvc.Server/Providers/AuthorizationProvider.cs
+++ b/samples/Mvc/Mvc.Server/Providers/AuthorizationProvider.cs
@@ -104,6 +104,16 @@ namespace Mvc.Server.Providers {
             return Task.FromResult<object>(null);
         }
 
+        public override Task ProfileEndpoint(ProfileEndpointContext context) {
+            // Note: by default, OpenIdConnectServerHandler automatically handles userinfo requests and directly
+            // writes the JSON response to the response stream. This sample uses a custom ProfileController that
+            // handles userinfo requests: context.SkipToNextMiddleware() is called to bypass the default
+            // request processing executed by OpenIdConnectServerHandler.
+            context.SkipToNextMiddleware();
+
+            return Task.FromResult<object>(null);
+        }
+
         public override Task ValidateTokenRequest(ValidateTokenRequestContext context) {
             // Note: OpenIdConnectServerHandler supports authorization code, refresh token, client credentials
             // and resource owner password credentials grant types but this authorization server uses a safer policy

--- a/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
+++ b/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
@@ -45,6 +45,8 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
         public static class Scopes {
             public const string OpenId = "openid";
             public const string OfflineAccess = "offline_access";
+            public const string Profile = "profile";
+            public const string Email = "email";
         }
 
         public static class GrantTypes {
@@ -92,6 +94,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             public const string ScopesSupported = "scopes_supported";
             public const string SubjectTypesSupported = "subject_types_supported";
             public const string TokenEndpoint = "token_endpoint";
+            public const string UserinfoEndpoint = "userinfo_endpoint";
         }
 
         public static class SubjectTypes {

--- a/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -441,6 +441,34 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             return identity;
         }
 
+        /// <summary>
+        /// Gets the claim value corresponding to the given type.
+        /// </summary>
+        /// <param name="identity">The identity.</param>
+        /// <param name="type">The type associated with the claim.</param>
+        /// <returns>The claim value.</returns>
+        public static string GetClaim(this ClaimsIdentity identity, string type) {
+            if (identity == null) {
+                throw new ArgumentNullException(nameof(identity));
+            }
+
+            return identity.FindFirst(type)?.Value;
+        }
+
+        /// <summary>
+        /// Gets the claim value corresponding to the given type.
+        /// </summary>
+        /// <param name="principal">The principal.</param>
+        /// <param name="type">The type associated with the claim.</param>
+        /// <returns>The claim value.</returns>
+        public static string GetClaim(this ClaimsPrincipal principal, string type) {
+            if (principal == null) {
+                throw new ArgumentNullException(nameof(principal));
+            }
+
+            return principal.FindFirst(type)?.Value;
+        }
+
         private static bool HasValue(string source, string value) {
             if (string.IsNullOrEmpty(source)) {
                 return false;

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ConfigurationEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ConfigurationEndpointContext.cs
@@ -34,6 +34,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public string CryptographyEndpoint { get; set; }
 
         /// <summary>
+        /// Gets or sets the userinfo endpoint address.
+        /// </summary>
+        public string ProfileEndpoint { get; set; }
+
+        /// <summary>
         /// Gets or sets the token endpoint address.
         /// </summary>
         public string TokenEndpoint { get; set; }

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/MatchEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/MatchEndpointContext.cs
@@ -48,6 +48,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public bool IsTokenEndpoint { get; private set; }
 
         /// <summary>
+        /// Gets whether or not the endpoint is an userinfo endpoint.
+        /// </summary>
+        public bool IsProfileEndpoint { get; private set; }
+
+        /// <summary>
         /// Gets whether or not the endpoint is a validation endpoint.
         /// </summary>
         public bool IsValidationEndpoint { get; private set; }
@@ -65,6 +70,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
             IsTokenEndpoint = false;
+            IsProfileEndpoint = false;
             IsValidationEndpoint = false;
             IsLogoutEndpoint = false;
         }
@@ -77,6 +83,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsConfigurationEndpoint = true;
             IsCryptographyEndpoint = false;
             IsTokenEndpoint = false;
+            IsProfileEndpoint = false;
             IsValidationEndpoint = false;
             IsLogoutEndpoint = false;
         }
@@ -89,6 +96,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = true;
             IsTokenEndpoint = false;
+            IsProfileEndpoint = false;
             IsValidationEndpoint = false;
             IsLogoutEndpoint = false;
         }
@@ -101,6 +109,20 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
             IsTokenEndpoint = true;
+            IsProfileEndpoint = false;
+            IsValidationEndpoint = false;
+            IsLogoutEndpoint = false;
+        }
+
+        /// <summary>
+        /// Sets the endpoint type to userinfo endpoint.
+        /// </summary>
+        public void MatchesProfileEndpoint() {
+            IsAuthorizationEndpoint = false;
+            IsConfigurationEndpoint = false;
+            IsCryptographyEndpoint = false;
+            IsTokenEndpoint = false;
+            IsProfileEndpoint = true;
             IsValidationEndpoint = false;
             IsLogoutEndpoint = false;
         }
@@ -113,6 +135,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
             IsTokenEndpoint = false;
+            IsProfileEndpoint = false;
             IsValidationEndpoint = true;
             IsLogoutEndpoint = false;
         }
@@ -125,6 +148,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
             IsTokenEndpoint = false;
+            IsProfileEndpoint = false;
             IsValidationEndpoint = false;
             IsLogoutEndpoint = true;
         }
@@ -137,6 +161,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
             IsTokenEndpoint = false;
+            IsProfileEndpoint = false;
             IsValidationEndpoint = false;
             IsLogoutEndpoint = false;
         }

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ProfileEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ProfileEndpointContext.cs
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Collections.Generic;
+using Microsoft.AspNet.Authentication;
+using Microsoft.AspNet.Http;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace AspNet.Security.OpenIdConnect.Server {
+    /// <summary>
+    /// An event raised after the Authorization Server has processed the request, but before it is passed on to the web application.
+    /// Calling RequestCompleted will prevent the request from passing on to the web application.
+    /// </summary>
+    public sealed class ProfileEndpointContext : BaseControlContext<OpenIdConnectServerOptions> {
+        /// <summary>
+        /// Creates an instance of this context
+        /// </summary>
+        internal ProfileEndpointContext(
+            HttpContext context,
+            OpenIdConnectServerOptions options,
+            OpenIdConnectMessage request,
+            AuthenticationTicket ticket)
+            : base(context, options) {
+            AuthenticationTicket = ticket;
+            Request = request;
+        }
+
+        /// <summary>
+        /// Gets the userinfo request.
+        /// </summary>
+        public new OpenIdConnectMessage Request { get; }
+
+        /// <summary>
+        /// Gets the list of claims returned to the client application.
+        /// </summary>
+        public IDictionary<string, string> Claims { get; } = new Dictionary<string, string>();
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ProfileEndpointResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ProfileEndpointResponseContext.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using Microsoft.AspNet.Authentication;
+using Microsoft.AspNet.Http;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Newtonsoft.Json.Linq;
+
+namespace AspNet.Security.OpenIdConnect.Server {
+    /// <summary>
+    /// Provides context information used at the end of a userinfo request.
+    /// </summary>
+    public sealed class ProfileEndpointResponseContext : BaseControlContext<OpenIdConnectServerOptions> {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProfileEndpointResponseContext"/> class
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="options"></param>
+        /// <param name="request"></param>
+        /// <param name="payload"></param>
+        internal ProfileEndpointResponseContext(
+            HttpContext context,
+            OpenIdConnectServerOptions options,
+            OpenIdConnectMessage request,
+            JObject payload)
+            : base(context, options) {
+            Request = request;
+            Payload = payload;
+        }
+
+        /// <summary>
+        /// Gets the token request. 
+        /// </summary>
+        public new OpenIdConnectMessage Request { get; }
+
+        /// <summary>
+        /// Gets the JSON payload returned to the client application.
+        /// </summary>
+        public JObject Payload { get; }
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Server/IOpenIdConnectServerProvider.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/IOpenIdConnectServerProvider.cs
@@ -188,6 +188,26 @@ namespace AspNet.Security.OpenIdConnect.Server {
         Task LogoutEndpointResponse(LogoutEndpointResponseContext context);
 
         /// <summary>
+        /// Called at the final stage of an incoming userinfo endpoint request before the execution continues on to the web application component 
+        /// responsible for producing the JSON response. Anything present in the OWIN pipeline following the Authorization Server may produce the
+        /// response for the userinfo response. If the web application wishes to produce the response directly in the ProfileEndpoint call it
+        /// may write to the context.Response directly and should call context.HandleResponse to stop other handlers from executing.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        Task ProfileEndpoint(ProfileEndpointContext context);
+
+        /// <summary>
+        /// Called before the ProfileEndpoint endpoint starts writing to the response stream.
+        /// If the web application wishes to produce the userinfo response directly in the ProfileEndpoint call it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
+        /// This call may also be used to add additional response parameters to the authorization response.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        Task ProfileEndpointResponse(ProfileEndpointResponseContext context);
+
+        /// <summary>
         /// Called by the client applications to retrieve the OpenID Connect configuration associated with this instance.
         /// An application may implement this call in order to do any final modification to the configuration metadata.
         /// </summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerDefaults.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerDefaults.cs
@@ -37,6 +37,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public const string TokenEndpointPath = "/connect/token";
 
         /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.ProfileEndpointPath"/>.
+        /// </summary>
+        public const string ProfileEndpointPath = "/connect/userinfo";
+
+        /// <summary>
         /// Default value for <see cref="OpenIdConnectServerOptions.ValidationEndpointPath"/>.
         /// </summary>
         public const string ValidationEndpointPath = "/connect/token_validation";

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
@@ -71,6 +71,13 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public PathString TokenEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.TokenEndpointPath);
 
         /// <summary>
+        /// The request path client applications communicate with to retrieve user information. 
+        /// Must begin with a leading slash, like "/connect/userinfo".
+        /// You can set it to <see cref="PathString.Empty"/> to disable the profile endpoint.
+        /// </summary>
+        public PathString ProfileEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.ProfileEndpointPath);
+
+        /// <summary>
         /// The request path client applications communicate with to validate identity or access tokens. 
         /// Must begin with a leading slash, like "/connect/token_validation".
         /// You can set it to <see cref="PathString.Empty"/> to disable the validation endpoint.

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
@@ -163,6 +163,22 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public Func<LogoutEndpointResponseContext, Task> OnLogoutEndpointResponse { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
+        /// Called at the final stage of an incoming userinfo endpoint request before the execution continues on to the web application component 
+        /// responsible for producing the JSON response. Anything present in the OWIN pipeline following the Authorization Server may produce the
+        /// response for the userinfo response. If the web application wishes to produce the response directly in the ProfileEndpoint call it
+        /// may write to the context.Response directly and should call context.HandleResponse to stop other handlers from executing.
+        /// </summary>
+        public Func<ProfileEndpointContext, Task> OnProfileEndpoint { get; set; } = context => Task.FromResult<object>(null);
+
+        /// <summary>
+        /// Called before the ProfileEndpoint endpoint starts writing to the response stream.
+        /// If the web application wishes to produce the userinfo response directly in the ProfileEndpoint call it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
+        /// This call may also be used to add additional response parameters to the authorization response.
+        /// </summary>
+        public Func<ProfileEndpointResponseContext, Task> OnProfileEndpointResponse { get; set; } = context => Task.FromResult<object>(null);
+
+        /// <summary>
         /// Called by the client applications to retrieve the OpenID Connect configuration associated with this instance.
         /// An application may implement this call in order to do any final modification to the configuration metadata.
         /// </summary>
@@ -443,6 +459,26 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
         public virtual Task LogoutEndpointResponse(LogoutEndpointResponseContext context) => OnLogoutEndpointResponse(context);
+
+        /// <summary>
+        /// Called at the final stage of an incoming userinfo endpoint request before the execution continues on to the web application component 
+        /// responsible for producing the JSON response. Anything present in the OWIN pipeline following the Authorization Server may produce the
+        /// response for the userinfo response. If the web application wishes to produce the response directly in the ProfileEndpoint call it
+        /// may write to the context.Response directly and should call context.HandleResponse to stop other handlers from executing.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task ProfileEndpoint(ProfileEndpointContext context) => OnProfileEndpoint(context);
+
+        /// <summary>
+        /// Called before the ProfileEndpoint endpoint starts writing to the response stream.
+        /// If the web application wishes to produce the userinfo response directly in the ProfileEndpoint call it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
+        /// This call may also be used to add additional response parameters to the authorization response.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task ProfileEndpointResponse(ProfileEndpointResponseContext context) => OnProfileEndpointResponse(context);
 
         /// <summary>
         /// Called by the client applications to retrieve the OpenID Connect configuration associated with this instance.


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/8 and https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/93.

For this new userinfo/profile endpoint, I've opted for an hybrid approach:
* By default, it will automatically handle userinfo requests, try to extract common claims from the access token and write the JSON payload directly to the response body.
* The new `ProfileEndpoint` notification can be used to add new claims to the userinfo response, without modifying the default request processing.
* But it can also be used to bypass the default processing:
  * You can provide your own response by calling `notification.HandleResponse()` from the `ProfileEndpoint` notification.
  * You can also skip the default logic applied by `OpenIdConnectServerHandler` and let the request continue to the next middleware using `notification.SkipToNextMiddleware()`. This allows advanced scenarios like serving the userinfo response from an MVC 6 controller or a Nancy module. I've updated the `Mvc.Server` sample to demonstrate how this can be done.

Note: there's currently an undesired behavior: returning a 401 response from the userinfo/profile endpoint causes the cookie middleware to redirect the user agent to the login endpoint, which is obviously not what we want. I'll try to find a fix with the ASP.NET team. 

/cc @AlexZeitler