### PR TITLE
Migrate to the new notification model and remove TryGetBasicCredentials and TryGetFormCredentials

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/AuthorizationEndpointNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/AuthorizationEndpointNotification.cs
@@ -13,7 +13,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised after the Authorization Server has processed the request, but before it is passed on to the web application.
     /// Calling RequestCompleted will prevent the request from passing on to the web application.
     /// </summary>
-    public sealed class AuthorizationEndpointNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class AuthorizationEndpointNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Creates an instance of this context
         /// </summary>
@@ -22,12 +22,12 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)
             : base(context, options) {
-            AuthorizationRequest = request;
+            Request = request;
         }
 
         /// <summary>
         /// Gets the authorization request.
         /// </summary>
-        public OpenIdConnectMessage AuthorizationRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/AuthorizationEndpointResponseNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/AuthorizationEndpointResponseNotification.cs
@@ -3,20 +3,16 @@
  * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
  * for more information concerning the license and the contributors participating to this project.
  */
-
-using System;
-using System.Security.Claims;
-using Microsoft.AspNet.Authentication;
+ 
 using Microsoft.AspNet.Authentication.Notifications;
 using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Http.Authentication;
 using Microsoft.IdentityModel.Protocols;
 
 namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information when processing an Authorization Response
     /// </summary>
-    public sealed class AuthorizationEndpointResponseNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class AuthorizationEndpointResponseNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthorizationEndpointResponseNotification"/> class
         /// </summary>
@@ -31,32 +27,32 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request,
             OpenIdConnectMessage response)
             : base(context, options) {
-            AuthorizationRequest = request;
-            AuthorizationResponse = response;
+            Request = request;
+            Response = response;
         }
 
         /// <summary>
         /// Gets the authorization request. 
         /// </summary>
-        public OpenIdConnectMessage AuthorizationRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets the authorization response. 
         /// </summary>
-        public OpenIdConnectMessage AuthorizationResponse { get; }
+        public new OpenIdConnectMessage Response { get; }
 
         /// <summary>
         /// Get the access code expected to
         /// be returned to the client application.
         /// Depending on the flow, it can be null.
         /// </summary>
-        public string AccessToken => AuthorizationResponse.AccessToken;
+        public string AccessToken => Response.AccessToken;
 
         /// <summary>
         /// Get the authorization code expected to
         /// be returned to the client application.
         /// Depending on the flow, it can be null.
         /// </summary>
-        public string AuthorizationCode => AuthorizationResponse.Code;
+        public string AuthorizationCode => Response.Code;
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/BaseValidatingClientNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/BaseValidatingClientNotification.cs
@@ -20,13 +20,13 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)
             : base(context, options) {
-            AuthorizationRequest = request;
+            Request = request;
         }
 
         /// <summary>
         /// Gets the authorization request. 
         /// </summary>
-        public OpenIdConnectMessage AuthorizationRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// The "client_id" parameter for the current request.
@@ -34,8 +34,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// validating this value to ensure it identifies a registered client.
         /// </summary>
         public string ClientId {
-            get { return AuthorizationRequest.ClientId; }
-            set { AuthorizationRequest.ClientId = value; }
+            get { return Request.ClientId; }
+            set { Request.ClientId = value; }
         }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/BaseValidatingClientNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/BaseValidatingClientNotification.cs
@@ -37,5 +37,15 @@ namespace AspNet.Security.OpenIdConnect.Server {
             get { return Request.ClientId; }
             set { Request.ClientId = value; }
         }
+
+        /// <summary>
+        /// The "client_secret" parameter for the current request.
+        /// The authorization server application is responsible for 
+        /// validating this value to ensure it identifies a registered client.
+        /// </summary>
+        public string ClientSecret {
+            get { return Request.ClientSecret; }
+            set { Request.ClientSecret = value; }
+        }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/BaseValidatingNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/BaseValidatingNotification.cs
@@ -12,7 +12,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Base class used for certain event contexts
     /// </summary>
-    public abstract class BaseValidatingNotification<TOptions> : BaseContext<TOptions> {
+    public abstract class BaseValidatingNotification<TOptions> : BaseNotification<TOptions> {
         /// <summary>
         /// Initializes base class used for certain event contexts
         /// </summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ConfigurationEndpointNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ConfigurationEndpointNotification.cs
@@ -13,7 +13,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server handles
     /// the request made to the configuration metadata endpoint.
     /// </summary>
-    public sealed class ConfigurationEndpointNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class ConfigurationEndpointNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ConfigurationEndpointResponseNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ConfigurationEndpointResponseNotification.cs
@@ -15,7 +15,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server starts
     /// writing the configuration metadata to the response stream.
     /// </summary>
-    public sealed class ConfigurationEndpointResponseNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class ConfigurationEndpointResponseNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/CreateAccessTokenNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/CreateAccessTokenNotification.cs
@@ -29,20 +29,20 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage response,
             AuthenticationTicket ticket)
             : base(context, options) {
-            TokenRequest = request;
-            TokenResponse = response;
+            Request = request;
+            Response = response;
             AuthenticationTicket = ticket;
         }
 
         /// <summary>
         /// Gets the authorization or token request.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets the authorization or token response.
         /// </summary>
-        public OpenIdConnectMessage TokenResponse { get; }
+        public new OpenIdConnectMessage Response { get; }
 
         /// <summary>
         /// Gets or sets the access token

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/CreateAuthorizationCodeNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/CreateAuthorizationCodeNotification.cs
@@ -29,20 +29,20 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage response,
             AuthenticationTicket ticket)
             : base(context, options) {
-            AuthorizationRequest = request;
-            AuthorizationResponse = response;
+            Request = request;
+            Response = response;
             AuthenticationTicket = ticket;
         }
 
         /// <summary>
         /// Gets the authorization request.
         /// </summary>
-        public OpenIdConnectMessage AuthorizationRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets the authorization response.
         /// </summary>
-        public OpenIdConnectMessage AuthorizationResponse { get; }
+        public new OpenIdConnectMessage Response { get; }
 
         /// <summary>
         /// Gets or sets the authorization code

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/CreateIdentityTokenNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/CreateIdentityTokenNotification.cs
@@ -29,20 +29,20 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage response,
             AuthenticationTicket ticket)
             : base(context, options) {
-            TokenRequest = request;
-            TokenResponse = response;
+            Request = request;
+            Response = response;
             AuthenticationTicket = ticket;
         }
 
         /// <summary>
         /// Gets the authorization or token request.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets the authorization or token response.
         /// </summary>
-        public OpenIdConnectMessage TokenResponse { get; }
+        public new OpenIdConnectMessage Response { get; }
 
         /// <summary>
         /// Gets or sets the identity token

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/CreateRefreshTokenNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/CreateRefreshTokenNotification.cs
@@ -29,18 +29,20 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage response,
             AuthenticationTicket ticket)
             : base(context, options) {
+            Request = request;
+            Response = response;
             AuthenticationTicket = ticket;
         }
 
         /// <summary>
         /// Gets the authorization or token request.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets the authorization or token response.
         /// </summary>
-        public OpenIdConnectMessage TokenResponse { get; }
+        public new OpenIdConnectMessage Response { get; }
 
         /// <summary>
         /// Gets or sets the refresh token

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/CryptographyEndpointNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/CryptographyEndpointNotification.cs
@@ -14,7 +14,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server handles
     /// the request made to the JWKS metadata endpoint.
     /// </summary>
-    public sealed class CryptographyEndpointNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class CryptographyEndpointNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/CryptographyEndpointResponseNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/CryptographyEndpointResponseNotification.cs
@@ -14,7 +14,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server starts
     /// writing the JWKS metadata to the response stream.
     /// </summary>
-    public sealed class CryptographyEndpointResponseNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class CryptographyEndpointResponseNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/GrantAuthorizationCodeNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/GrantAuthorizationCodeNotification.cs
@@ -24,14 +24,15 @@ namespace AspNet.Security.OpenIdConnect.Server {
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,
-            AuthenticationTicket ticket) : base(context, options, ticket) {
-            TokenRequest = request;
+            AuthenticationTicket ticket)
+            : base(context, options, ticket) {
+            Request = request;
             Validated();
         }
 
         /// <summary>
         /// Gets the token request.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/GrantClientCredentialsNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/GrantClientCredentialsNotification.cs
@@ -25,30 +25,30 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)
             : base(context, options, null) {
-            TokenRequest = request;
+            Request = request;
         }
 
         /// <summary>
         /// Gets the client_id parameter.
         /// </summary>
-        public string ClientId => TokenRequest.ClientId;
+        public string ClientId => Request.ClientId;
 
         /// <summary>
         /// Gets the list of scopes requested by the client application.
         /// </summary>
         public IEnumerable<string> Scope {
             get {
-                if (string.IsNullOrEmpty(TokenRequest.Scope)) {
+                if (string.IsNullOrEmpty(Request.Scope)) {
                     return Enumerable.Empty<string>();
                 }
 
-                return TokenRequest.Scope.Split(' ');
+                return Request.Scope.Split(' ');
             }
         }
 
         /// <summary>
         /// Gets the token request.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/GrantCustomExtensionNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/GrantCustomExtensionNotification.cs
@@ -23,22 +23,22 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)
             : base(context, options, null) {
-            TokenRequest = request;
+            Request = request;
         }
 
         /// <summary>
         /// Gets the client_id parameter.
         /// </summary>
-        public string ClientId => TokenRequest.ClientId;
+        public string ClientId => Request.ClientId;
 
         /// <summary>
         /// Gets the grant_type parameter.
         /// </summary>
-        public string GrantType => TokenRequest.GrantType;
+        public string GrantType => Request.GrantType;
 
         /// <summary>
         /// Gets the token request.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/GrantRefreshTokenNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/GrantRefreshTokenNotification.cs
@@ -26,18 +26,18 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request,
             AuthenticationTicket ticket)
             : base(context, options, ticket) {
-            TokenRequest = request;
+            Request = request;
             Validated();
         }
 
         /// <summary>
         /// The OpenIdConnect client id.
         /// </summary>
-        public string ClientId => TokenRequest.ClientId;
+        public string ClientId => Request.ClientId;
 
         /// <summary>
         /// Gets the token request.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/GrantResourceOwnerCredentialsNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/GrantResourceOwnerCredentialsNotification.cs
@@ -25,40 +25,40 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)
             : base(context, options, null) {
-            TokenRequest = request;
+            Request = request;
         }
 
         /// <summary>
         /// OpenIdConnect client id.
         /// </summary>
-        public string ClientId => TokenRequest.ClientId;
+        public string ClientId => Request.ClientId;
 
         /// <summary>
         /// Resource owner username.
         /// </summary>
-        public string UserName => TokenRequest.Username;
+        public string UserName => Request.Username;
 
         /// <summary>
         /// Resource owner password.
         /// </summary>
-        public string Password => TokenRequest.Password;
+        public string Password => Request.Password;
 
         /// <summary>
         /// Gets the list of scopes requested by the client application.
         /// </summary>
         public IEnumerable<string> Scope {
             get {
-                if (string.IsNullOrEmpty(TokenRequest.Scope)) {
+                if (string.IsNullOrEmpty(Request.Scope)) {
                     return Enumerable.Empty<string>();
                 }
 
-                return TokenRequest.Scope.Split(' ');
+                return Request.Scope.Split(' ');
             }
         }
 
         /// <summary>
         /// Gets the token request.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/LogoutEndpointNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/LogoutEndpointNotification.cs
@@ -13,7 +13,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised after the Authorization Server has processed the logout request, but before it is passed on to the web application.
     /// Calling RequestCompleted will prevent the request from passing on to the web application.
     /// </summary>
-    public sealed class LogoutEndpointNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class LogoutEndpointNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Creates an instance of this context
         /// </summary>
@@ -22,12 +22,12 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)
             : base(context, options) {
-            LogoutRequest = request;
+            Request = request;
         }
 
         /// <summary>
         /// Gets the logout request.
         /// </summary>
-        public OpenIdConnectMessage LogoutRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/LogoutEndpointResponseNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/LogoutEndpointResponseNotification.cs
@@ -12,7 +12,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information when processing a logout response.
     /// </summary>
-    public sealed class LogoutEndpointResponseNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class LogoutEndpointResponseNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Initializes a new instance of the <see cref="LogoutEndpointResponseNotification"/> class
         /// </summary>
@@ -24,12 +24,12 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)
             : base(context, options) {
-            LogoutRequest = request;
+            Request = request;
         }
 
         /// <summary>
         /// Gets the authorization request. 
         /// </summary>
-        public OpenIdConnectMessage LogoutRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/MatchEndpointNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/MatchEndpointNotification.cs
@@ -11,7 +11,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when determining the OpenIdConnect flow type based on the request.
     /// </summary>
-    public sealed class MatchEndpointNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class MatchEndpointNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Initializes a new instance of the <see cref="MatchEndpointNotification"/> class
         /// </summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ReceiveAccessTokenNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ReceiveAccessTokenNotification.cs
@@ -27,14 +27,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request,
             string token)
             : base(context, options) {
-            TokenRequest = request;
+            Request = request;
             AccessToken = token;
         }
 
         /// <summary>
         /// Gets the authorization or token request.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets the access token used by the client application.

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ReceiveAuthorizationCodeNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ReceiveAuthorizationCodeNotification.cs
@@ -27,14 +27,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request,
             string code)
             : base(context, options) {
-            AuthorizationRequest = request;
+            Request = request;
             AuthorizationCode = code;
         }
 
         /// <summary>
         /// Gets the authorization request.
         /// </summary>
-        public OpenIdConnectMessage AuthorizationRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets the authorization code

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ReceiveIdentityTokenNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ReceiveIdentityTokenNotification.cs
@@ -27,14 +27,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request,
             string token)
             : base(context, options) {
-            TokenRequest = request;
+            Request = request;
             IdentityToken = token;
         }
 
         /// <summary>
         /// Gets the authorization or token request.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets the identity token used by the client application.

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ReceiveRefreshTokenNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ReceiveRefreshTokenNotification.cs
@@ -27,14 +27,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request,
             string token)
             : base(context, options) {
-            TokenRequest = request;
+            Request = request;
             RefreshToken = token;
         }
 
         /// <summary>
         /// Gets the authorization or token request.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets the refresh code used

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/TokenEndpointNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/TokenEndpointNotification.cs
@@ -16,7 +16,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when processing an OpenIdConnect token request.
     /// </summary>
-    public sealed class TokenEndpointNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class TokenEndpointNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenEndpointNotification"/> class
         /// </summary>
@@ -30,8 +30,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request,
             AuthenticationTicket ticket)
             : base(context, options) {
+            Request = request;
             Ticket = ticket;
-            TokenRequest = request;
         }
 
         /// <summary>
@@ -42,6 +42,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <summary>
         /// Gets information about the token endpoint request. 
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/TokenEndpointResponseNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/TokenEndpointResponseNotification.cs
@@ -4,29 +4,21 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Security.Claims;
-using Microsoft.AspNet.Authentication;
 using Microsoft.AspNet.Authentication.Notifications;
 using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Http.Authentication;
-using Microsoft.IdentityModel.Protocols;
 using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used at the end of a token-endpoint-request.
     /// </summary>
-    public sealed class TokenEndpointResponseNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class TokenEndpointResponseNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenEndpointResponseNotification"/> class
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
-        /// <param name="ticket"></param>
-        /// <param name="request"></param>
-        /// <param name="response"></param>
+        /// <param name="payload"></param>
         internal TokenEndpointResponseNotification(
             HttpContext context,
             OpenIdConnectServerOptions options,

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateAuthorizationRequestNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateAuthorizationRequestNotification.cs
@@ -25,15 +25,15 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request,
             ValidateClientRedirectUriNotification clientContext)
             : base(context, options) {
+            Request = request;
             ClientContext = clientContext;
-            AuthorizationRequest = request;
             Validated();
         }
 
         /// <summary>
         /// Gets the authorization request.
         /// </summary>
-        public OpenIdConnectMessage AuthorizationRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets the client context. 

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateClientAuthenticationNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateClientAuthenticationNotification.cs
@@ -50,7 +50,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public bool TryGetBasicCredentials(out string clientId, out string clientSecret) {
             // Client Authentication http://tools.ietf.org/html/rfc6749#section-2.3
             // Client Authentication Password http://tools.ietf.org/html/rfc6749#section-2.3.1
-            string authorization = Request.Headers.Get("Authorization");
+            string authorization = HttpContext.Request.Headers.Get("Authorization");
             if (!string.IsNullOrEmpty(authorization) && authorization.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase)) {
                 try {
                     byte[] data = Convert.FromBase64String(authorization.Substring("Basic ".Length).Trim());
@@ -87,7 +87,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public bool TryGetFormCredentials(out string clientId, out string clientSecret) {
             clientId = ClientId;
             if (!string.IsNullOrEmpty(clientId)) {
-                clientSecret = AuthorizationRequest.ClientSecret;
+                clientSecret = Request.ClientSecret;
                 return true;
             }
             clientId = null;

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateClientAuthenticationNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateClientAuthenticationNotification.cs
@@ -4,12 +4,8 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
-using Microsoft.IdentityModel.Protocols;
-using Microsoft.AspNet;
 using Microsoft.AspNet.Http;
+using Microsoft.IdentityModel.Protocols;
 
 namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
@@ -30,7 +26,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
         }
 
         /// <summary>
-        /// Sets the client id and marks the context as validated by the application.
+        /// Sets client_id and marks the context
+        /// as validated by the application.
         /// </summary>
         /// <param name="clientId"></param>
         /// <returns></returns>
@@ -41,58 +38,17 @@ namespace AspNet.Security.OpenIdConnect.Server {
         }
 
         /// <summary>
-        /// Extracts HTTP basic authentication credentials from the HTTP authenticate header.
+        /// Sets client_id and client_secret and marks
+        /// the context as validated by the application.
         /// </summary>
         /// <param name="clientId"></param>
         /// <param name="clientSecret"></param>
         /// <returns></returns>
-        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "0#", Justification = "Optimized for usage")]
-        public bool TryGetBasicCredentials(out string clientId, out string clientSecret) {
-            // Client Authentication http://tools.ietf.org/html/rfc6749#section-2.3
-            // Client Authentication Password http://tools.ietf.org/html/rfc6749#section-2.3.1
-            string authorization = HttpContext.Request.Headers.Get("Authorization");
-            if (!string.IsNullOrEmpty(authorization) && authorization.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase)) {
-                try {
-                    byte[] data = Convert.FromBase64String(authorization.Substring("Basic ".Length).Trim());
-                    string text = Encoding.UTF8.GetString(data);
-                    int delimiterIndex = text.IndexOf(':');
-                    if (delimiterIndex >= 0) {
-                        clientId = text.Substring(0, delimiterIndex);
-                        clientSecret = text.Substring(delimiterIndex + 1);
-                        ClientId = clientId;
+        public bool Validated(string clientId, string clientSecret) {
+            ClientId = clientId;
+            ClientSecret = clientSecret;
 
-                        return true;
-                    }
-                }
-                catch (FormatException) {
-                    // Bad Base64 string
-                }
-                catch (ArgumentException) {
-                    // Bad utf-8 string
-                }
-            }
-
-            clientId = null;
-            clientSecret = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Extracts forms authentication credentials from the HTTP request body.
-        /// </summary>
-        /// <param name="clientId"></param>
-        /// <param name="clientSecret"></param>
-        /// <returns></returns>
-        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "0#", Justification = "Optimized for usage")]
-        public bool TryGetFormCredentials(out string clientId, out string clientSecret) {
-            clientId = ClientId;
-            if (!string.IsNullOrEmpty(clientId)) {
-                clientSecret = Request.ClientSecret;
-                return true;
-            }
-            clientId = null;
-            clientSecret = null;
-            return false;
+            return Validated();
         }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateClientLogoutRedirectUriNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateClientLogoutRedirectUriNotification.cs
@@ -33,8 +33,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// Gets the post logout redirect URI.
         /// </summary>
         public string PostLogoutRedirectUri {
-            get { return AuthorizationRequest.PostLogoutRedirectUri; }
-            set { AuthorizationRequest.PostLogoutRedirectUri = value; }
+            get { return Request.PostLogoutRedirectUri; }
+            set { Request.PostLogoutRedirectUri = value; }
         }
 
         /// <summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateClientRedirectUriNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateClientRedirectUriNotification.cs
@@ -36,8 +36,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
             "CA1056:UriPropertiesShouldNotBeStrings",
             Justification = "redirect_uri is a string parameter")]
         public string RedirectUri {
-            get { return AuthorizationRequest.RedirectUri; }
-            set { AuthorizationRequest.RedirectUri = value; }
+            get { return Request.RedirectUri; }
+            set { Request.RedirectUri = value; }
         }
 
         /// <summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateTokenRequestNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidateTokenRequestNotification.cs
@@ -25,7 +25,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request,
             BaseValidatingClientNotification notification)
             : base(context, options) {
-            TokenRequest = request;
+            Request = request;
             ClientContext = notification;
             Validated();
         }
@@ -33,7 +33,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <summary>
         /// Gets the token request data.
         /// </summary>
-        public OpenIdConnectMessage TokenRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets information about the client.

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidationEndpointNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidationEndpointNotification.cs
@@ -16,7 +16,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server handles
     /// the request made to the token validation endpoint.
     /// </summary>
-    public sealed class ValidationEndpointNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class ValidationEndpointNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>
@@ -26,19 +26,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request,
             AuthenticationTicket ticket)
             : base(context, options) {
-            ValidationRequest = request;
+            Request = request;
             AuthenticationTicket = ticket;
         }
 
         /// <summary>
-        /// Gets or sets the authentication ticket.
-        /// </summary>
-        public AuthenticationTicket AuthenticationTicket { get; set; }
-
-        /// <summary>
         /// Gets the validation request.
         /// </summary>
-        public OpenIdConnectMessage ValidationRequest { get; }
+        public new OpenIdConnectMessage Request { get; }
 
         /// <summary>
         /// Gets the list of claims returned to the caller.

--- a/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidationEndpointResponseNotification.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Notifications/ValidationEndpointResponseNotification.cs
@@ -14,7 +14,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server starts
     /// writing the token validation to the response stream.
     /// </summary>
-    public sealed class ValidationEndpointResponseNotification : EndpointContext<OpenIdConnectServerOptions> {
+    public sealed class ValidationEndpointResponseNotification : BaseNotification<OpenIdConnectServerOptions> {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -1070,6 +1070,28 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 RequestType = OpenIdConnectRequestType.TokenRequest
             };
 
+            // When client_id and client_secret are both null, try to extract them from the Authorization header.
+            // See http://tools.ietf.org/html/rfc6749#section-2.3.1 and
+            // http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
+            if (string.IsNullOrEmpty(request.ClientId) && string.IsNullOrEmpty(request.ClientSecret)) {
+                var header = Request.Headers.Get("Authorization");
+                if (!string.IsNullOrEmpty(header) && header.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase)) {
+                    try {
+                        var value = header.Substring("Basic ".Length).Trim();
+                        var data = Encoding.UTF8.GetString(Convert.FromBase64String(value));
+
+                        var index = data.IndexOf(':');
+                        if (index >= 0) {
+                            request.ClientId = data.Substring(0, index);
+                            request.ClientSecret = data.Substring(index + 1);
+                        }
+                    }
+
+                    catch (FormatException) { }
+                    catch (ArgumentException) { }
+                }
+            }
+
             var clientNotification = new ValidateClientAuthenticationNotification(Context, Options, request);
             await Options.Provider.ValidateClientAuthentication(clientNotification);
 
@@ -1213,7 +1235,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
                     properties.ExpiresUtc = ticket.Properties.ExpiresUtc;
                 }
 
-                // Make sure to create a copy of the authentication properties to avoid modifying the properties set on the original ticket.
                 response.IdToken = await CreateIdentityTokenAsync(ticket.Principal, properties, request, response);
             }
 


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/96 and https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/102.

`*Request` and `*Response` properties (e.g `AuthorizationRequest` and `AuthorizationResponse`) have all been renamed to `Request` and `Response` to encourage people to use the `OpenIdConnectMessage` primitive instead of manually extracting parameters from the query string or from the request form. The HTTP request/response can still be accessed using the `HttpContext` property.