### PR TITLE
Refactor certificate Use* extensions

### DIFF
--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
@@ -5,6 +5,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens;
 using System.IO;
 using System.Linq;
@@ -84,7 +85,32 @@ namespace Owin {
                 throw new InvalidOperationException("The certificate doesn't contain the required private key.");
             }
 
-            return builder.UseKey(new X509SecurityKey(certificate));
+            builder.Options.SigningCredentials.AddCertificate(certificate);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a specific <see cref="X509Certificate2"/> to sign tokens issued by the OpenID Connect server.
+        /// </summary>
+        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="certificate">The certificate used to sign security tokens issued by the server.</param>
+        /// <returns>The options used to configure the OpenID Connect server.</returns>
+        public static IList<SigningCredentials> AddCertificate(
+            this IList<SigningCredentials> signingCredentials, X509Certificate2 certificate) {
+            if (signingCredentials == null) {
+                throw new ArgumentNullException("signingCredentials");
+            }
+
+            if (certificate == null) {
+                throw new ArgumentNullException("certificate");
+            }
+
+            if (certificate.PrivateKey == null) {
+                throw new InvalidOperationException("The certificate doesn't contain the required private key.");
+            }
+
+            return signingCredentials.AddKey(new X509SecurityKey(certificate));
         }
 
         /// <summary>
@@ -115,12 +141,45 @@ namespace Owin {
                 throw new ArgumentNullException("password");
             }
 
+            builder.Options.SigningCredentials.AddCertificate(assembly, resource, password);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a specific <see cref="X509Certificate2"/> retrieved from an
+        /// embedded resource to sign tokens issued by the OpenID Connect server.
+        /// </summary>
+        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="assembly">The assembly containing the certificate.</param>
+        /// <param name="resource">The name of the embedded resource.</param>
+        /// <param name="password">The password used to open the certificate.</param>
+        /// <returns>The options used to configure the OpenID Connect server.</returns>
+        public static IList<SigningCredentials> AddCertificate(
+            this IList<SigningCredentials> signingCredentials,
+            Assembly assembly, string resource, string password) {
+            if (signingCredentials == null) {
+                throw new ArgumentNullException("signingCredentials");
+            }
+
+            if (assembly == null) {
+                throw new ArgumentNullException("assembly");
+            }
+
+            if (string.IsNullOrEmpty(resource)) {
+                throw new ArgumentNullException("resource");
+            }
+
+            if (string.IsNullOrEmpty(password)) {
+                throw new ArgumentNullException("password");
+            }
+
             using (var stream = assembly.GetManifestResourceStream(resource)) {
                 if (stream == null) {
                     throw new InvalidOperationException("The certificate was not found in the given assembly.");
                 }
 
-                return builder.UseCertificate(stream, password);
+                return signingCredentials.AddCertificate(stream, password);
             }
         }
 
@@ -134,7 +193,22 @@ namespace Owin {
         /// <returns>The options used to configure the OpenID Connect server.</returns>
         public static OpenIdConnectServerBuilder UseCertificate(
             this OpenIdConnectServerBuilder builder, Stream stream, string password) {
-            return builder.UseCertificate(stream, password, X509KeyStorageFlags.Exportable |
+            builder.Options.SigningCredentials.AddCertificate(stream, password);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a specific <see cref="X509Certificate2"/> contained in
+        /// a stream to sign tokens issued by the OpenID Connect server.
+        /// </summary>
+        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="stream">The stream containing the certificate.</param>
+        /// <param name="password">The password used to open the certificate.</param>
+        /// <returns>The options used to configure the OpenID Connect server.</returns>
+        public static IList<SigningCredentials> AddCertificate(
+            this IList<SigningCredentials> signingCredentials, Stream stream, string password) {
+            return signingCredentials.AddCertificate(stream, password, X509KeyStorageFlags.Exportable |
                                                                   X509KeyStorageFlags.MachineKeySet);
         }
 
@@ -161,11 +235,40 @@ namespace Owin {
             if (string.IsNullOrEmpty(password)) {
                 throw new ArgumentNullException("password");
             }
+
+            builder.Options.SigningCredentials.AddCertificate(stream, password, flags);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a specific <see cref="X509Certificate2"/> contained in
+        /// a stream to sign tokens issued by the OpenID Connect server.
+        /// </summary>
+        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="stream">The stream containing the certificate.</param>
+        /// <param name="password">The password used to open the certificate.</param>
+        /// <param name="flags">An enumeration of flags indicating how and where to store the private key of the certificate.</param>
+        /// <returns>The options used to configure the OpenID Connect server.</returns>
+        public static IList<SigningCredentials> AddCertificate(
+            this IList<SigningCredentials> signingCredentials, Stream stream,
+            string password, X509KeyStorageFlags flags) {
+            if (signingCredentials == null) {
+                throw new ArgumentNullException("builder");
+            }
+
+            if (stream == null) {
+                throw new ArgumentNullException("stream");
+            }
+
+            if (string.IsNullOrEmpty(password)) {
+                throw new ArgumentNullException("password");
+            }
             
             using (var buffer = new MemoryStream()) {
                 stream.CopyTo(buffer);
 
-                return builder.UseCertificate(new X509Certificate2(buffer.ToArray(), password, flags));
+                return signingCredentials.AddCertificate(new X509Certificate2(buffer.ToArray(), password, flags));
             }
         }
 
@@ -179,6 +282,18 @@ namespace Owin {
         public static OpenIdConnectServerBuilder UseCertificate(
             this OpenIdConnectServerBuilder builder, string thumbprint) {
             return builder.UseCertificate(thumbprint, StoreName.My, StoreLocation.LocalMachine);
+        }
+
+        /// <summary>
+        /// Adds a specific <see cref="X509Certificate2"/> retrieved from the
+        /// X509 machine store to sign tokens issued by the OpenID Connect server.
+        /// </summary>
+        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="thumbprint">The thumbprint of the certificate used to identify it in the X509 store.</param>
+        /// <returns>The options used to configure the OpenID Connect server.</returns>
+        public static IList<SigningCredentials> AddCertificate(
+            this IList<SigningCredentials> signingCredentials, string thumbprint) {
+            return signingCredentials.AddCertificate(thumbprint, StoreName.My, StoreLocation.LocalMachine);
         }
 
         /// <summary>
@@ -201,6 +316,31 @@ namespace Owin {
                 throw new ArgumentNullException("thumbprint");
             }
 
+            builder.Options.SigningCredentials.AddCertificate(thumbprint, name, location);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a specific <see cref="X509Certificate2"/> retrieved from the
+        /// given X509 store to sign tokens issued by the OpenID Connect server.
+        /// </summary>
+        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="thumbprint">The thumbprint of the certificate used to identify it in the X509 store.</param>
+        /// <param name="name">The name of the X509 store.</param>
+        /// <param name="location">The location of the X509 store.</param>
+        /// <returns>The options used to configure the OpenID Connect server.</returns>
+        public static IList<SigningCredentials> AddCertificate(
+            this IList<SigningCredentials> signingCredentials,
+            string thumbprint, StoreName name, StoreLocation location) {
+            if (signingCredentials == null) {
+                throw new ArgumentNullException("signingCredentials");
+            }
+
+            if (string.IsNullOrEmpty(thumbprint)) {
+                throw new ArgumentNullException("thumbprint");
+            }
+
             var store = new X509Store(name, location);
 
             try {
@@ -213,7 +353,7 @@ namespace Owin {
                     throw new InvalidOperationException("The certificate corresponding to the given thumbprint was not found.");
                 }
 
-                return builder.UseCertificate(certificate);
+                return signingCredentials.AddCertificate(certificate);
             }
 
             finally {
@@ -236,11 +376,31 @@ namespace Owin {
                 throw new ArgumentNullException("key");
             }
 
-            builder.Options.SigningCredentials.Add(new SigningCredentials(key,
+            builder.Options.SigningCredentials.AddKey(key);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a specific <see cref="SecurityKey"/> to sign tokens issued by the OpenID Connect server.
+        /// </summary>
+        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="key">The key used to sign security tokens issued by the server.</param>
+        /// <returns>The options used to configure the OpenID Connect server.</returns>
+        public static IList<SigningCredentials> AddKey(this IList<SigningCredentials> signingCredentials, SecurityKey key) {
+            if (signingCredentials == null) {
+                throw new ArgumentNullException("signingCredentials");
+            }
+
+            if (key == null) {
+                throw new ArgumentNullException("key");
+            }
+
+            signingCredentials.Add(new SigningCredentials(key,
                 SecurityAlgorithms.RsaSha256Signature,
                 SecurityAlgorithms.Sha256Digest));
 
-            return builder;
+            return signingCredentials;
         }
 
         /// <summary>
@@ -285,6 +445,35 @@ namespace Owin {
                 throw new ArgumentNullException("protector");
             }
 
+            builder.Options.SigningCredentials.AddKeys(directory, protector);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds the <see cref="RsaSecurityKey"/>s stored in the given directory.
+        /// Note: this extension will automatically ignore incompatible keys and
+        /// create a new RSA key if none has been previously added.
+        /// </summary>
+        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="directory">The directory containing the encrypted keys.</param>
+        /// <param name="protector">The data protector used to decrypt the key.</param>
+        /// <returns>The options used to configure the OpenID Connect server.</returns>
+        public static IList<SigningCredentials> AddKeys(
+            this IList<SigningCredentials> signingCredentials,
+            DirectoryInfo directory, IDataProtector protector) {
+            if (signingCredentials == null) {
+                throw new ArgumentNullException("signingCredentials");
+            }
+
+            if (directory == null) {
+                throw new ArgumentNullException("directory");
+            }
+
+            if (protector == null) {
+                throw new ArgumentNullException("protector");
+            }
+
             if (!directory.Exists) {
                 throw new InvalidOperationException("The directory does not exist");
             }
@@ -305,12 +494,12 @@ namespace Owin {
                     var provider = new RSACryptoServiceProvider();
                     provider.ImportParameters(parameters.Value);
 
-                    builder.UseKey(new RsaSecurityKey(provider));
+                    signingCredentials.AddKey(new RsaSecurityKey(provider));
                 }
             }
 
             // If no signing key has been found, generate and persist a new RSA key.
-            if (builder.Options.SigningCredentials.Count == 0) {
+            if (signingCredentials.Count == 0) {
                 // Generate a new 2048 bit RSA key and export its public/private parameters.
                 var provider = new RSACryptoServiceProvider(2048);
                 var parameters = provider.ExportParameters(includePrivateParameters: true);
@@ -326,10 +515,10 @@ namespace Owin {
                     stream.Write(bytes, 0, bytes.Length);
                 }
 
-                builder.UseKey(new RsaSecurityKey(provider));
+                signingCredentials.AddKey(new RsaSecurityKey(provider));
             }
 
-            return builder;
+            return signingCredentials;
         }
 
         /// <summary>

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
@@ -93,24 +93,24 @@ namespace Owin {
         /// <summary>
         /// Adds a specific <see cref="X509Certificate2"/> to sign tokens issued by the OpenID Connect server.
         /// </summary>
-        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="credentials">The options used to configure the OpenID Connect server.</param>
         /// <param name="certificate">The certificate used to sign security tokens issued by the server.</param>
         /// <returns>The options used to configure the OpenID Connect server.</returns>
         public static IList<SigningCredentials> AddCertificate(
-            this IList<SigningCredentials> signingCredentials, X509Certificate2 certificate) {
-            if (signingCredentials == null) {
-                throw new ArgumentNullException("signingCredentials");
+            this IList<SigningCredentials> credentials, X509Certificate2 certificate) {
+            if (credentials == null) {
+                throw new ArgumentNullException(nameof(credentials));
             }
 
             if (certificate == null) {
-                throw new ArgumentNullException("certificate");
+                throw new ArgumentNullException(nameof(certificate));
             }
 
             if (certificate.PrivateKey == null) {
                 throw new InvalidOperationException("The certificate doesn't contain the required private key.");
             }
 
-            return signingCredentials.AddKey(new X509SecurityKey(certificate));
+            return credentials.AddKey(new X509SecurityKey(certificate));
         }
 
         /// <summary>
@@ -150,28 +150,28 @@ namespace Owin {
         /// Adds a specific <see cref="X509Certificate2"/> retrieved from an
         /// embedded resource to sign tokens issued by the OpenID Connect server.
         /// </summary>
-        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="credentials">The options used to configure the OpenID Connect server.</param>
         /// <param name="assembly">The assembly containing the certificate.</param>
         /// <param name="resource">The name of the embedded resource.</param>
         /// <param name="password">The password used to open the certificate.</param>
         /// <returns>The options used to configure the OpenID Connect server.</returns>
         public static IList<SigningCredentials> AddCertificate(
-            this IList<SigningCredentials> signingCredentials,
+            this IList<SigningCredentials> credentials,
             Assembly assembly, string resource, string password) {
-            if (signingCredentials == null) {
-                throw new ArgumentNullException("signingCredentials");
+            if (credentials == null) {
+                throw new ArgumentNullException(nameof(credentials));
             }
 
             if (assembly == null) {
-                throw new ArgumentNullException("assembly");
+                throw new ArgumentNullException(nameof(assembly));
             }
 
             if (string.IsNullOrEmpty(resource)) {
-                throw new ArgumentNullException("resource");
+                throw new ArgumentNullException(nameof(resource));
             }
 
             if (string.IsNullOrEmpty(password)) {
-                throw new ArgumentNullException("password");
+                throw new ArgumentNullException(nameof(password));
             }
 
             using (var stream = assembly.GetManifestResourceStream(resource)) {
@@ -179,7 +179,7 @@ namespace Owin {
                     throw new InvalidOperationException("The certificate was not found in the given assembly.");
                 }
 
-                return signingCredentials.AddCertificate(stream, password);
+                return credentials.AddCertificate(stream, password);
             }
         }
 
@@ -202,13 +202,13 @@ namespace Owin {
         /// Adds a specific <see cref="X509Certificate2"/> contained in
         /// a stream to sign tokens issued by the OpenID Connect server.
         /// </summary>
-        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="credentials">The options used to configure the OpenID Connect server.</param>
         /// <param name="stream">The stream containing the certificate.</param>
         /// <param name="password">The password used to open the certificate.</param>
         /// <returns>The options used to configure the OpenID Connect server.</returns>
         public static IList<SigningCredentials> AddCertificate(
-            this IList<SigningCredentials> signingCredentials, Stream stream, string password) {
-            return signingCredentials.AddCertificate(stream, password, X509KeyStorageFlags.Exportable |
+            this IList<SigningCredentials> credentials, Stream stream, string password) {
+            return credentials.AddCertificate(stream, password, X509KeyStorageFlags.Exportable |
                                                                   X509KeyStorageFlags.MachineKeySet);
         }
 
@@ -245,30 +245,30 @@ namespace Owin {
         /// Adds a specific <see cref="X509Certificate2"/> contained in
         /// a stream to sign tokens issued by the OpenID Connect server.
         /// </summary>
-        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="credentials">The options used to configure the OpenID Connect server.</param>
         /// <param name="stream">The stream containing the certificate.</param>
         /// <param name="password">The password used to open the certificate.</param>
         /// <param name="flags">An enumeration of flags indicating how and where to store the private key of the certificate.</param>
         /// <returns>The options used to configure the OpenID Connect server.</returns>
         public static IList<SigningCredentials> AddCertificate(
-            this IList<SigningCredentials> signingCredentials, Stream stream,
+            this IList<SigningCredentials> credentials, Stream stream,
             string password, X509KeyStorageFlags flags) {
-            if (signingCredentials == null) {
-                throw new ArgumentNullException("builder");
+            if (credentials == null) {
+                throw new ArgumentNullException(nameof(credentials));
             }
 
             if (stream == null) {
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
             }
 
             if (string.IsNullOrEmpty(password)) {
-                throw new ArgumentNullException("password");
+                throw new ArgumentNullException(nameof(password));
             }
             
             using (var buffer = new MemoryStream()) {
                 stream.CopyTo(buffer);
 
-                return signingCredentials.AddCertificate(new X509Certificate2(buffer.ToArray(), password, flags));
+                return credentials.AddCertificate(new X509Certificate2(buffer.ToArray(), password, flags));
             }
         }
 
@@ -288,12 +288,12 @@ namespace Owin {
         /// Adds a specific <see cref="X509Certificate2"/> retrieved from the
         /// X509 machine store to sign tokens issued by the OpenID Connect server.
         /// </summary>
-        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="credentials">The options used to configure the OpenID Connect server.</param>
         /// <param name="thumbprint">The thumbprint of the certificate used to identify it in the X509 store.</param>
         /// <returns>The options used to configure the OpenID Connect server.</returns>
         public static IList<SigningCredentials> AddCertificate(
-            this IList<SigningCredentials> signingCredentials, string thumbprint) {
-            return signingCredentials.AddCertificate(thumbprint, StoreName.My, StoreLocation.LocalMachine);
+            this IList<SigningCredentials> credentials, string thumbprint) {
+            return credentials.AddCertificate(thumbprint, StoreName.My, StoreLocation.LocalMachine);
         }
 
         /// <summary>
@@ -325,20 +325,20 @@ namespace Owin {
         /// Adds a specific <see cref="X509Certificate2"/> retrieved from the
         /// given X509 store to sign tokens issued by the OpenID Connect server.
         /// </summary>
-        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="credentials">The options used to configure the OpenID Connect server.</param>
         /// <param name="thumbprint">The thumbprint of the certificate used to identify it in the X509 store.</param>
         /// <param name="name">The name of the X509 store.</param>
         /// <param name="location">The location of the X509 store.</param>
         /// <returns>The options used to configure the OpenID Connect server.</returns>
         public static IList<SigningCredentials> AddCertificate(
-            this IList<SigningCredentials> signingCredentials,
+            this IList<SigningCredentials> credentials,
             string thumbprint, StoreName name, StoreLocation location) {
-            if (signingCredentials == null) {
-                throw new ArgumentNullException("signingCredentials");
+            if (credentials == null) {
+                throw new ArgumentNullException(nameof(credentials));
             }
 
             if (string.IsNullOrEmpty(thumbprint)) {
-                throw new ArgumentNullException("thumbprint");
+                throw new ArgumentNullException(nameof(thumbprint));
             }
 
             var store = new X509Store(name, location);
@@ -353,7 +353,7 @@ namespace Owin {
                     throw new InvalidOperationException("The certificate corresponding to the given thumbprint was not found.");
                 }
 
-                return signingCredentials.AddCertificate(certificate);
+                return credentials.AddCertificate(certificate);
             }
 
             finally {
@@ -384,23 +384,23 @@ namespace Owin {
         /// <summary>
         /// Adds a specific <see cref="SecurityKey"/> to sign tokens issued by the OpenID Connect server.
         /// </summary>
-        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="credentials">The options used to configure the OpenID Connect server.</param>
         /// <param name="key">The key used to sign security tokens issued by the server.</param>
         /// <returns>The options used to configure the OpenID Connect server.</returns>
-        public static IList<SigningCredentials> AddKey(this IList<SigningCredentials> signingCredentials, SecurityKey key) {
-            if (signingCredentials == null) {
-                throw new ArgumentNullException("signingCredentials");
+        public static IList<SigningCredentials> AddKey(this IList<SigningCredentials> credentials, SecurityKey key) {
+            if (credentials == null) {
+                throw new ArgumentNullException(nameof(credentials));
             }
 
             if (key == null) {
-                throw new ArgumentNullException("key");
+                throw new ArgumentNullException(nameof(key));
             }
 
-            signingCredentials.Add(new SigningCredentials(key,
+            credentials.Add(new SigningCredentials(key,
                 SecurityAlgorithms.RsaSha256Signature,
                 SecurityAlgorithms.Sha256Digest));
 
-            return signingCredentials;
+            return credentials;
         }
 
         /// <summary>
@@ -455,23 +455,23 @@ namespace Owin {
         /// Note: this extension will automatically ignore incompatible keys and
         /// create a new RSA key if none has been previously added.
         /// </summary>
-        /// <param name="signingCredentials">The options used to configure the OpenID Connect server.</param>
+        /// <param name="credentials">The options used to configure the OpenID Connect server.</param>
         /// <param name="directory">The directory containing the encrypted keys.</param>
         /// <param name="protector">The data protector used to decrypt the key.</param>
         /// <returns>The options used to configure the OpenID Connect server.</returns>
         public static IList<SigningCredentials> AddKeys(
-            this IList<SigningCredentials> signingCredentials,
+            this IList<SigningCredentials> credentials,
             DirectoryInfo directory, IDataProtector protector) {
-            if (signingCredentials == null) {
-                throw new ArgumentNullException("signingCredentials");
+            if (credentials == null) {
+                throw new ArgumentNullException(nameof(credentials));
             }
 
             if (directory == null) {
-                throw new ArgumentNullException("directory");
+                throw new ArgumentNullException(nameof(directory));
             }
 
             if (protector == null) {
-                throw new ArgumentNullException("protector");
+                throw new ArgumentNullException(nameof(protector));
             }
 
             if (!directory.Exists) {
@@ -494,12 +494,12 @@ namespace Owin {
                     var provider = new RSACryptoServiceProvider();
                     provider.ImportParameters(parameters.Value);
 
-                    signingCredentials.AddKey(new RsaSecurityKey(provider));
+                    credentials.AddKey(new RsaSecurityKey(provider));
                 }
             }
 
             // If no signing key has been found, generate and persist a new RSA key.
-            if (signingCredentials.Count == 0) {
+            if (credentials.Count == 0) {
                 // Generate a new 2048 bit RSA key and export its public/private parameters.
                 var provider = new RSACryptoServiceProvider(2048);
                 var parameters = provider.ExportParameters(includePrivateParameters: true);
@@ -515,10 +515,10 @@ namespace Owin {
                     stream.Write(bytes, 0, bytes.Length);
                 }
 
-                signingCredentials.AddKey(new RsaSecurityKey(provider));
+                credentials.AddKey(new RsaSecurityKey(provider));
             }
 
-            return signingCredentials;
+            return credentials;
         }
 
         /// <summary>


### PR DESCRIPTION
- introduce `AddCertificate`, `AddKey` and `AddKeys` extensions over `IList<SigningCredentials>`;
- refactor `UseCertificate`, `UseKey` and `UseKeys` extensions to use implementation from `Add*`.

It opens a way to configure signing keys decoupled from "builder" object and `IAppBuilder` context.