### PR TITLE
Reject invalid introspection requests

### DIFF
--- a/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -751,6 +751,16 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             return ticket.Properties.GetUsage();
         }
 
+        public static bool IsClientAuthenticated(this AuthenticationTicket ticket)
+        {
+            if (ticket == null)
+            {
+                throw new ArgumentNullException(nameof(ticket));
+            }
+
+            return ticket.ContainsProperty(OpenIdConnectConstants.Extra.ClientAuthenticated);
+        }
+
         /// <summary>
         /// Sets the audiences list in the authentication properties.
         /// Note: this method automatically excludes duplicate audiences.

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Endpoints.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Endpoints.cs
@@ -1668,7 +1668,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             await Options.Provider.ValidateClientAuthentication(clientNotification);
 
             // Reject the request if client authentication was rejected.
-            if (!clientNotification.IsValidated) {
+            if (clientNotification.IsRejected) {
                 Options.Logger.WriteError("invalid client authentication.");
 
                 await SendErrorPayloadAsync(new OpenIdConnectMessage {
@@ -1729,6 +1729,91 @@ namespace Owin.Security.OpenIdConnect.Server {
                 return;
             }
 
+            var usage = ticket.GetUsage();
+            var identifier = ticket.GetProperty(OpenIdConnectConstants.Extra.ClientId);
+            var audiences = ticket.GetAudiences();
+            if (string.Equals(usage, OpenIdConnectConstants.Usages.RefreshToken, StringComparison.Ordinal)) {
+                // For Refresh tokens
+                if (clientNotification.IsSkipped && ticket.IsClientAuthenticated()) {
+                    // If the caller was not authenticated
+                    //  AND the token was issued to an authenticated client
+                    Options.Logger.WriteVerbose("refresh token issued to authenticated client but caller was not authenticated");
+
+                    await SendPayloadAsync(new JObject
+                    {
+                        [OpenIdConnectConstants.Claims.Active] = false
+                    });
+
+                    return;
+                }
+
+
+                if (clientNotification.IsValidated &&
+                     (!ticket.IsClientAuthenticated() || !string.Equals(identifier, clientNotification.ClientId))) {
+                    // OR if the caller was authenticated 
+                    //  AND either the token was not issued to an authenticated client OR the token was issued to a different authenticated client
+                    // Then the token belongs to a different client, reject the request.
+                    Options.Logger.WriteVerbose("refresh token issued to different client");
+
+                    await SendPayloadAsync(new JObject {
+                        [OpenIdConnectConstants.Claims.Active] = false
+                    });
+
+                    return;
+                }
+            }
+
+            else if (string.Equals(usage, OpenIdConnectConstants.Usages.IdToken, StringComparison.Ordinal)) {
+                //For Identity tokens
+                if (clientNotification.IsSkipped ||
+                    (!string.IsNullOrWhiteSpace(clientNotification.ClientId) &&
+                     !audiences.Contains(clientNotification.ClientId))) {
+                    // If the caller is not authenticated OR is not one of the specified audiences,
+                    if (ticket.IsClientAuthenticated()) {
+                        // And if the token was issued to an authenticated client, it was issued to a different client
+                        Options.Logger.WriteVerbose("identity token issued to different client");
+
+                        await SendPayloadAsync(new JObject {
+                            [OpenIdConnectConstants.Claims.Active] = false
+                        });
+
+                        return;
+                    }
+                }
+            }
+
+            else if (string.Equals(usage, OpenIdConnectConstants.Usages.AccessToken, StringComparison.Ordinal)) {
+                // For access tokens
+                if (clientNotification.IsValidated && !string.IsNullOrWhiteSpace(clientNotification.ClientId)) {
+                    if (!audiences.Contains(clientNotification.ClientId)) {
+                        //If the client is authenticated but not in the audiences, they're not allowed to validate the token.
+                        Options.Logger.WriteVerbose("invalid audience for access token");
+
+                        await SendPayloadAsync(new JObject {
+                            [OpenIdConnectConstants.Claims.Active] = false
+                        });
+
+                        return;
+                    }
+                }
+
+                else
+                {
+                    //If the caller is not authenticated
+                    if (!ticket.IsClientAuthenticated() &&
+                        !ticket.Identity.HasClaim(JwtRegisteredClaimNames.Azp, clientNotification.ClientId)) {
+                        //If the token was issued to an authenticated client and the caller isn't an authorized party
+                        Options.Logger.WriteVerbose("unauthorized party for access token");
+
+                        await SendPayloadAsync(new JObject {
+                            [OpenIdConnectConstants.Claims.Active] = false
+                        });
+
+                        return;
+                    }
+                }
+            }
+
             // Insert the validation request in the ASP.NET context.
             Context.SetOpenIdConnectRequest(request);
 
@@ -1753,7 +1838,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             // Note: only add "token_type" when the received token is an access token.
             // See https://tools.ietf.org/html/rfc7662#section-2.2
             // and https://tools.ietf.org/html/rfc6749#section-5.1
-            if (string.Equals(ticket.GetUsage(), OpenIdConnectConstants.Usages.AccessToken, StringComparison.Ordinal)) {
+            if (string.Equals(usage, OpenIdConnectConstants.Usages.AccessToken, StringComparison.Ordinal)) {
                 notification.TokenType = OpenIdConnectConstants.TokenTypes.Bearer;
             }
 
@@ -1770,7 +1855,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             if (notification.HandledResponse) {
                 return;
             }
-
+            
             var payload = new JObject();
 
             payload.Add(OpenIdConnectConstants.Claims.Active, notification.Active);
@@ -1816,13 +1901,20 @@ namespace Owin.Security.OpenIdConnect.Server {
                     break;
             }
 
-            foreach (var claim in notification.Claims) {
-                // Ignore claims whose value is null.
-                if (claim.Value == null) {
-                    continue;
-                }
+            // Note: only return non-standard claims if the caller is authenticated AND the caller is in the
+            // specified audiences AND if the introspection request is for an identity or access token.
+            if (clientNotification.IsValidated && !string.IsNullOrWhiteSpace(clientNotification.ClientId) &&
+                notification.Audiences.Contains(clientNotification.ClientId) &&
+                (string.Equals(ticket.GetUsage(), OpenIdConnectConstants.Usages.AccessToken, StringComparison.Ordinal) ||
+                 string.Equals(ticket.GetUsage(), OpenIdConnectConstants.Usages.IdToken, StringComparison.Ordinal))) {
+                foreach (var claim in notification.Claims) {
+                    // Ignore claims whose value is null.
+                    if (claim.Value == null) {
+                        continue;
+                    }
 
-                payload.Add(claim.Key, claim.Value);
+                    payload.Add(claim.Key, claim.Value);
+                }
             }
 
             var context = new ValidationEndpointResponseContext(Context, Options, payload);


### PR DESCRIPTION
Finished logic to reject unauthenticated and invalid introspection requests based on audiences and authorized parties.