### PR TITLE
Rename Validated/Skipped/Rejected to Validate/Skip/Reject

### DIFF
--- a/samples/Nancy/Nancy.Server/Providers/AuthorizationProvider.cs
+++ b/samples/Nancy/Nancy.Server/Providers/AuthorizationProvider.cs
@@ -16,7 +16,7 @@ namespace Nancy.Server.Providers {
             // with JavaScript or desktop applications, where client credentials cannot be safely stored.
             // In this case, call context.Skipped() to inform the server middleware the client is not trusted.
             if (string.IsNullOrEmpty(context.ClientId) || string.IsNullOrEmpty(context.ClientSecret)) {
-                context.Rejected(
+                context.Reject(
                     error: "invalid_request",
                     description: "Missing credentials: ensure that your credentials were correctly " +
                                  "flowed in the request body or in the authorization header");
@@ -31,7 +31,7 @@ namespace Nancy.Server.Providers {
                                          select entity).SingleOrDefaultAsync(context.OwinContext.Request.CallCancelled);
 
                 if (application == null) {
-                    context.Rejected(
+                    context.Reject(
                         error: "invalid_client",
                         description: "Application not found in the database: " +
                                      "ensure that your client_id is correct");
@@ -39,7 +39,7 @@ namespace Nancy.Server.Providers {
                 }
 
                 if (!string.Equals(context.ClientSecret, application.Secret, StringComparison.Ordinal)) {
-                    context.Rejected(
+                    context.Reject(
                         error: "invalid_client",
                         description: "Invalid credentials: ensure that you " +
                                      "specified a correct client_secret");
@@ -47,7 +47,7 @@ namespace Nancy.Server.Providers {
                     return;
                 }
 
-                context.Validated();
+                context.Validate();
             }
         }
 
@@ -59,7 +59,7 @@ namespace Nancy.Server.Providers {
                                          select entity).SingleOrDefaultAsync(context.OwinContext.Request.CallCancelled);
 
                 if (application == null) {
-                    context.Rejected(
+                    context.Reject(
                         error: "invalid_client",
                         description: "Application not found in the database: " +
                                      "ensure that your client_id is correct");
@@ -68,7 +68,7 @@ namespace Nancy.Server.Providers {
 
                 if (!string.IsNullOrEmpty(context.RedirectUri)) {
                     if (!string.Equals(context.RedirectUri, application.RedirectUri, StringComparison.Ordinal)) {
-                        context.Rejected(error: "invalid_client", description: "Invalid redirect_uri");
+                        context.Reject(error: "invalid_client", description: "Invalid redirect_uri");
 
                         return;
                     }
@@ -83,12 +83,12 @@ namespace Nancy.Server.Providers {
                 // Note: ValidateClientLogoutRedirectUri is not invoked when post_logout_redirect_uri is null.
                 // When provided, post_logout_redirect_uri must exactly match the address registered by the client application.
                 if (!await database.Applications.AnyAsync(application => application.LogoutRedirectUri == context.PostLogoutRedirectUri)) {
-                    context.Rejected(error: "invalid_client", description: "Invalid post_logout_redirect_uri");
+                    context.Reject(error: "invalid_client", description: "Invalid post_logout_redirect_uri");
 
                     return;
                 }
 
-                context.Validated();
+                context.Validate();
             }
         }
 
@@ -119,7 +119,7 @@ namespace Nancy.Server.Providers {
             // and resource owner password credentials grant types but this authorization server uses a safer policy
             // rejecting the last two ones. You may consider relaxing it to support the ROPC or client credentials grant types.
             if (!context.Request.IsAuthorizationCodeGrantType() && !context.Request.IsRefreshTokenGrantType()) {
-                context.Rejected(
+                context.Reject(
                     error: "unsupported_grant_type",
                     description: "Only authorization code and refresh token grant types " +
                                  "are accepted by this authorization server");

--- a/src/Owin.Security.OpenIdConnect.Server/Events/BaseValidatingContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/BaseValidatingContext.cs
@@ -23,19 +23,19 @@ namespace Owin.Security.OpenIdConnect.Server {
         }
 
         /// <summary>
-        /// Gets whether the <see cref="Skipped"/>
+        /// Gets whether the <see cref="Skip"/>
         /// method has been called or not.
         /// </summary>
         public bool IsSkipped { get; private set; }
 
         /// <summary>
-        /// Gets whether the <see cref="Validated"/>
+        /// Gets whether the <see cref="Validate"/>
         /// method has been called or not.
         /// </summary>
         public bool IsValidated { get; private set; }
 
         /// <summary>
-        /// Gets whether the <see cref="Rejected"/>
+        /// Gets whether the <see cref="Reject"/>
         /// method has been called or not.
         /// </summary>
         public bool IsRejected { get; private set; }
@@ -62,7 +62,7 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// Marks the context as skipped by the application.
         /// </summary>
         /// <returns></returns>
-        public virtual new bool Skipped() {
+        public virtual bool Skip() {
             IsSkipped = true;
             IsRejected = false;
             IsValidated = false;
@@ -74,7 +74,7 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// Marks this context as validated by the application.
         /// </summary>
         /// <returns>True if the validation has taken effect.</returns>
-        public virtual bool Validated() {
+        public virtual bool Validate() {
             IsSkipped = false;
             IsValidated = true;
             IsRejected = false;
@@ -85,7 +85,7 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// <summary>
         /// Marks this context as not validated by the application.
         /// </summary>
-        public virtual bool Rejected() {
+        public virtual bool Reject() {
             IsSkipped = false;
             IsRejected = true;
             IsValidated = false;
@@ -98,10 +98,10 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// and assigns various error information properties.
         /// </summary>
         /// <param name="error">Assigned to the <see cref="Error"/> property.</param>
-        public virtual bool Rejected(string error) {
+        public virtual bool Reject(string error) {
             Error = error;
 
-            return Rejected();
+            return Reject();
         }
 
         /// <summary>
@@ -110,11 +110,11 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// </summary>
         /// <param name="error">Assigned to the <see cref="Error"/> property.</param>
         /// <param name="description">Assigned to the <see cref="ErrorDescription"/> property.</param>
-        public virtual bool Rejected(string error, string description) {
+        public virtual bool Reject(string error, string description) {
             Error = error;
             ErrorDescription = description;
 
-            return Rejected();
+            return Reject();
         }
 
         /// <summary>
@@ -124,12 +124,12 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// <param name="error">Assigned to the <see cref="Error"/> property</param>
         /// <param name="description">Assigned to the <see cref="ErrorDescription"/> property</param>
         /// <param name="uri">Assigned to the <see cref="ErrorUri"/> property</param>
-        public virtual bool Rejected(string error, string description, string uri) {
+        public virtual bool Reject(string error, string description, string uri) {
             Error = error;
             ErrorDescription = description;
             ErrorUri = uri;
 
-            return Rejected();
+            return Reject();
         }
     }
 }

--- a/src/Owin.Security.OpenIdConnect.Server/Events/BaseValidatingTicketContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/BaseValidatingTicketContext.cs
@@ -37,9 +37,9 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// </summary>
         /// <param name="ticket">Assigned to the Ticket property</param>
         /// <returns>True if the validation has taken effect.</returns>
-        public bool Validated(AuthenticationTicket ticket) {
+        public bool Validate(AuthenticationTicket ticket) {
             AuthenticationTicket = ticket;
-            return Validated();
+            return Validate();
         }
 
         /// <summary>
@@ -48,12 +48,10 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// </summary>
         /// <param name="identity">Assigned to the Ticket.Identity property</param>
         /// <returns>True if the validation has taken effect.</returns>
-        public bool Validated(ClaimsIdentity identity) {
-            var properties = AuthenticationTicket != null ?
-                             AuthenticationTicket.Properties :
-                             new AuthenticationProperties();
+        public bool Validate(ClaimsIdentity identity) {
+            var properties = AuthenticationTicket?.Properties ?? new AuthenticationProperties();
 
-            return Validated(new AuthenticationTicket(identity, properties));
+            return Validate(new AuthenticationTicket(identity, properties));
         }
     }
 }

--- a/src/Owin.Security.OpenIdConnect.Server/Events/GrantAuthorizationCodeContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/GrantAuthorizationCodeContext.cs
@@ -27,7 +27,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             AuthenticationTicket ticket)
             : base(context, options, ticket) {
             Request = request;
-            Validated();
+            Validate();
         }
 
         /// <summary>

--- a/src/Owin.Security.OpenIdConnect.Server/Events/GrantRefreshTokenContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/GrantRefreshTokenContext.cs
@@ -27,7 +27,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             AuthenticationTicket ticket)
             : base(context, options, ticket) {
             Request = request;
-            Validated();
+            Validate();
         }
 
         /// <summary>

--- a/src/Owin.Security.OpenIdConnect.Server/Events/ValidateAuthorizationRequestContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/ValidateAuthorizationRequestContext.cs
@@ -24,7 +24,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request)
             : base(context, options) {
             Request = request;
-            Validated();
+            Validate();
         }
 
         /// <summary>

--- a/src/Owin.Security.OpenIdConnect.Server/Events/ValidateClientAuthenticationContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/ValidateClientAuthenticationContext.cs
@@ -34,7 +34,7 @@ namespace Owin.Security.OpenIdConnect.Server {
         public bool Validated(string clientId) {
             ClientId = clientId;
 
-            return Validated();
+            return Validate();
         }
 
         /// <summary>
@@ -48,18 +48,18 @@ namespace Owin.Security.OpenIdConnect.Server {
             ClientId = clientId;
             ClientSecret = clientSecret;
 
-            return Validated();
+            return Validate();
         }
 
         /// <summary>
         /// Resets client_id and client_secret and marks
         /// the context as rejected by the application.
         /// </summary>
-        public override bool Rejected() {
+        public override bool Reject() {
             ClientId = null;
             ClientSecret = null;
 
-            return base.Rejected();
+            return base.Reject();
         }
     }
 }

--- a/src/Owin.Security.OpenIdConnect.Server/Events/ValidateClientLogoutRedirectUriContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/ValidateClientLogoutRedirectUriContext.cs
@@ -39,13 +39,13 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// IsValidated becomes true and HasError becomes false as a result of calling.
         /// </summary>
         /// <returns></returns>
-        public override bool Validated() {
+        public override bool Validate() {
             if (string.IsNullOrEmpty(PostLogoutRedirectUri)) {
                 // Don't allow default validation when redirect_uri not provided with request
                 return false;
             }
 
-            return base.Validated();
+            return base.Validate();
         }
 
         /// <summary>
@@ -66,29 +66,29 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             PostLogoutRedirectUri = redirectUri;
 
-            return Validated();
+            return Validate();
         }
 
         /// <summary>
         /// Resets post_logout_redirect_uri and marks
         /// the context as skipped by the application.
         /// </summary>
-        public override bool Skipped() {
+        public override bool Skip() {
             // Reset post_logout_redirect_uri if validation was skipped.
             PostLogoutRedirectUri = null;
 
-            return base.Skipped();
+            return base.Skip();
         }
 
         /// <summary>
         /// Resets post_logout_redirect_uri and marks
         /// the context as rejected by the application.
         /// </summary>
-        public override bool Rejected() {
+        public override bool Reject() {
             // Reset post_logout_redirect_uri if validation failed.
             PostLogoutRedirectUri = null;
 
-            return base.Rejected();
+            return base.Reject();
         }
     }
 }

--- a/src/Owin.Security.OpenIdConnect.Server/Events/ValidateClientRedirectUriContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/ValidateClientRedirectUriContext.cs
@@ -39,13 +39,13 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// IsValidated becomes true and HasError becomes false as a result of calling.
         /// </summary>
         /// <returns></returns>
-        public override bool Validated() {
+        public override bool Validate() {
             if (string.IsNullOrEmpty(RedirectUri)) {
                 // Don't allow default validation when redirect_uri not provided with request
                 return false;
             }
 
-            return base.Validated();
+            return base.Validate();
         }
 
         /// <summary>
@@ -66,29 +66,29 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             RedirectUri = redirectUri;
 
-            return Validated();
+            return Validate();
         }
 
         /// <summary>
         /// Resets redirect_uri and marks the context
         /// as skipped by the application.
         /// </summary>
-        public override bool Skipped() {
+        public override bool Skip() {
             // Reset redirect_uri if validation was skipped.
             RedirectUri = null;
 
-            return base.Skipped();
+            return base.Skip();
         }
 
         /// <summary>
         /// Resets redirect_uri and marks the context
         /// as rejected by the application.
         /// </summary>
-        public override bool Rejected() {
+        public override bool Reject() {
             // Reset redirect_uri if validation failed.
             RedirectUri = null;
 
-            return base.Rejected();
+            return base.Reject();
         }
     }
 }

--- a/src/Owin.Security.OpenIdConnect.Server/Events/ValidateTokenRequestContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/ValidateTokenRequestContext.cs
@@ -25,7 +25,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request)
             : base(context, options) {
             Request = request;
-            Validated();
+            Validate();
         }
 
         /// <summary>

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Endpoints.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Endpoints.cs
@@ -948,12 +948,24 @@ namespace Owin.Security.OpenIdConnect.Server {
             }
 
             // Reject grant_type=client_credentials requests if client authentication was skipped.
-            if (clientNotification.IsSkipped && request.IsClientCredentialsGrantType()) {
+            else if (clientNotification.IsSkipped && request.IsClientCredentialsGrantType()) {
                 Options.Logger.WriteError("client authentication is required for client_credentials grant type.");
 
                 await SendErrorPayloadAsync(new OpenIdConnectMessage {
                     Error = OpenIdConnectConstants.Errors.InvalidGrant,
                     ErrorDescription = "client authentication is required when using client_credentials"
+                });
+
+                return;
+            }
+
+            // Ensure that the client_id has been set from the ValidateClientAuthentication event.
+            else if (clientNotification.IsValidated && string.IsNullOrEmpty(request.ClientId)) {
+                Options.Logger.WriteError("Client authentication was validated but the client_id was not set.");
+
+                await SendErrorPayloadAsync(new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.ServerError,
+                    ErrorDescription = "An internal server error occurred."
                 });
 
                 return;
@@ -1844,6 +1856,18 @@ namespace Owin.Security.OpenIdConnect.Server {
 
                 await SendPayloadAsync(new JObject {
                     [OpenIdConnectConstants.Claims.Active] = false
+                });
+
+                return;
+            }
+
+            // Ensure that the client_id has been set from the ValidateClientAuthentication event.
+            else if (clientNotification.IsValidated && string.IsNullOrEmpty(request.ClientId)) {
+                Options.Logger.WriteError("Client authentication was validated but the client_id was not set.");
+
+                await SendErrorPayloadAsync(new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.ServerError,
+                    ErrorDescription = "An internal server error occurred."
                 });
 
                 return;


### PR DESCRIPTION
Per @SetTrend's recent suggestion, `Validated`/`Skipped`/`Rejected` will be renamed to `Validate`/`Skip`/`Reject` in both the OWIN and ASP.NET versions (https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/173#issuecomment-155238696).