### PR TITLE
Remove automatic resource/scope handling

### DIFF
--- a/samples/Mvc/Mvc.Server/Controllers/AuthorizationController.cs
+++ b/samples/Mvc/Mvc.Server/Controllers/AuthorizationController.cs
@@ -130,11 +130,14 @@ namespace Mvc.Server.Controllers {
             var properties = new AuthenticationProperties();
 
             // Set the list of scopes granted to the client application.
+            // Note: this sample always grants the "openid", "email" and "profile" scopes
+            // when they are requested by the client application: a real world application
+            // would probably display a form allowing to select the scopes to grant.
             properties.SetScopes(new[] {
                 /* openid: */ OpenIdConnectConstants.Scopes.OpenId,
                 /* email: */ OpenIdConnectConstants.Scopes.Email,
                 /* profile: */ OpenIdConnectConstants.Scopes.Profile
-            });
+            }.Intersect(request.GetScopes()));
 
             // Set the resources servers the access token should be issued for.
             properties.SetResources(new[] { "resource_server" });

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -307,22 +307,13 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 context.Properties[OpenIdConnectConstants.Properties.RedirectUri] = request.RedirectUri;
             }
 
-            // Note: the application is allowed to specify a different "resource"
-            // parameter when calling AuthenticationManager.SignInAsync: in this case,
-            // don't replace the "resource" property stored in the authentication ticket.
-            if (!string.IsNullOrEmpty(request.Resource) &&
-                !context.Properties.ContainsKey(OpenIdConnectConstants.Properties.Resources)) {
-                // Keep the original resource parameter for later comparison.
-                context.Properties[OpenIdConnectConstants.Properties.Resources] = request.Resource;
-            }
-
             // Note: the application is allowed to specify a different "scope"
             // parameter when calling AuthenticationManager.SignInAsync: in this case,
             // don't replace the "scope" property stored in the authentication ticket.
-            if (!string.IsNullOrEmpty(request.Scope) &&
-                !context.Properties.ContainsKey(OpenIdConnectConstants.Properties.Scopes)) {
-                // Keep the original scope parameter for later comparison.
-                context.Properties[OpenIdConnectConstants.Properties.Scopes] = request.Scope;
+            if (!context.Properties.ContainsKey(OpenIdConnectConstants.Properties.Scopes) &&
+                 request.ContainsScope(OpenIdConnectConstants.Scopes.OpenId)) {
+                // Always include the "openid" scope when the developer didn't explicitly call SetScopes.
+                context.Properties[OpenIdConnectConstants.Properties.Scopes] = OpenIdConnectConstants.Scopes.OpenId;
             }
 
             // Determine whether an authorization code should be returned
@@ -368,14 +359,16 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
                 // Note: when the "resource" parameter added to the OpenID Connect response
                 // is identical to the request parameter, setting it is not necessary.
-                if (!string.Equals(request.Resource, resources, StringComparison.Ordinal)) {
+                if (!string.IsNullOrEmpty(request.Resource) &&
+                    !string.Equals(request.Resource, resources, StringComparison.Ordinal)) {
                     response.Resource = resources;
                 }
 
                 // Note: when the "scope" parameter added to the OpenID Connect response
                 // is identical to the request parameter, setting it is not necessary.
                 var scopes = properties.GetProperty(OpenIdConnectConstants.Properties.Scopes);
-                if (!string.Equals(request.Scope, scopes, StringComparison.Ordinal)) {
+                if (!string.IsNullOrEmpty(request.Scope) &&
+                    !string.Equals(request.Scope, scopes, StringComparison.Ordinal)) {
                     response.Scope = scopes;
                 }
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
@@ -387,13 +387,5 @@ namespace AspNet.Security.OpenIdConnect.Server {
                     throw new InvalidOperationException($"The '{algorithm}' has no corresponding JWA identifier.");
             }
         }
-
-        internal static bool ContainsSet(this IEnumerable<string> source, IEnumerable<string> set) {
-            if (source == null || set == null) {
-                return false;
-            }
-
-            return new HashSet<string>(source).IsSupersetOf(set);
-        }
     }
 }


### PR DESCRIPTION
Note: I removed the automatic resource/scope handling but I kept the extra checks that ensure a client application doesn't ask for more scopes/resources than originally granted by the authorization server.

Also, per @sunsided's suggestion, the "openid" scope is automatically included if the developer doesn't call `SetScopes` (except when the request is not an OIDC request).

/cc @damccull @sunsided @DovydasNavickas