### PR TITLE
Introspection support for multiple intended audiences and presenters per client

### DIFF
--- a/samples/Mvc/Mvc.Server/Models/Application.cs
+++ b/samples/Mvc/Mvc.Server/Models/Application.cs
@@ -1,9 +1,12 @@
-﻿namespace Mvc.Server.Models {
+﻿using System.Collections.Generic;
+
+namespace Mvc.Server.Models {
     public class Application {
         public string ApplicationID { get; set; }
         public string DisplayName { get; set; }
         public string RedirectUri { get; set; }
         public string LogoutRedirectUri { get; set; }
         public string Secret { get; set; }
+        public IList<string> IntendedAudiences { get; set; }
     }
 }

--- a/samples/Mvc/Mvc.Server/Startup.cs
+++ b/samples/Mvc/Mvc.Server/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNet.Authentication;
 using Microsoft.AspNet.Authentication.Cookies;
 using Microsoft.AspNet.Builder;
@@ -57,7 +58,7 @@ namespace Mvc.Server {
                 // Alternatively, you can also use the introspection middleware.
                 // Using it is recommended if your resource server is in a
                 // different application/separated from the authorization server.
-                // 
+                //
                 // branch.UseOAuthIntrospection(options => {
                 //     options.AutomaticAuthenticate = true;
                 //     options.AutomaticChallenge = true;
@@ -125,7 +126,7 @@ namespace Mvc.Server {
 
                 // Note: by default, tokens are signed using dynamically-generated
                 // RSA keys but you can also use your own certificate:
-                // 
+                //
                 // options.SigningCredentials.AddCertificate(certificate);
             });
 
@@ -138,7 +139,7 @@ namespace Mvc.Server {
             using (var database = app.ApplicationServices.GetService<ApplicationContext>()) {
                 // Note: when using the introspection middleware, your resource server
                 // MUST be registered as an OAuth2 client and have valid credentials.
-                // 
+                //
                 // database.Applications.Add(new Application {
                 //     ApplicationID = "resource_server",
                 //     DisplayName = "Main resource server",
@@ -150,7 +151,8 @@ namespace Mvc.Server {
                     DisplayName = "My client application",
                     RedirectUri = "http://localhost:53507/signin-oidc",
                     LogoutRedirectUri = "http://localhost:53507/",
-                    Secret = "secret_secret_secret"
+                    Secret = "secret_secret_secret",
+                    IntendedAudiences = new string[0]
                 });
 
                 database.SaveChanges();

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateClientAudiencesContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateClientAudiencesContext.cs
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Collections.Generic;
+using AspNet.Security.OpenIdConnect.Extensions;
+using Microsoft.AspNet.Authentication;
+using Microsoft.AspNet.Http;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace AspNet.Security.OpenIdConnect.Server {
+    /// <summary>
+    /// Contains information about the client audiences.
+    /// </summary>
+    public sealed class ValidateClientAudiencesContext : BaseValidatingClientContext {
+
+        private readonly AuthenticationTicket _ticket;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidateClientAudiencesContext"/> class
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="options"></param>
+        /// <param name="request"></param>
+        /// <param name="ticket"></param>
+        internal ValidateClientAudiencesContext(
+            HttpContext context,
+            OpenIdConnectServerOptions options,
+            OpenIdConnectMessage request,
+            AuthenticationTicket ticket)
+            : base(context, options, request) {
+            _ticket = ticket;
+            Skip();
+        }
+
+        /// <summary>
+        /// Gets the intended audiences of the authentication ticket.
+        /// </summary>
+        public IEnumerable<string> Audiences => _ticket.GetAudiences();
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateClientPresentersContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateClientPresentersContext.cs
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Collections.Generic;
+using AspNet.Security.OpenIdConnect.Extensions;
+using Microsoft.AspNet.Authentication;
+using Microsoft.AspNet.Http;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace AspNet.Security.OpenIdConnect.Server {
+    /// <summary>
+    /// Contains information about the client's associated presenters.
+    /// </summary>
+    public sealed class ValidateClientPresentersContext : BaseValidatingClientContext {
+
+        private readonly AuthenticationTicket _ticket;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidateClientAudiencesContext"/> class
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="options"></param>
+        /// <param name="request"></param>
+        /// <param name="ticket"></param>
+        internal ValidateClientPresentersContext(
+            HttpContext context,
+            OpenIdConnectServerOptions options,
+            OpenIdConnectMessage request,
+            AuthenticationTicket ticket)
+            : base(context, options, request) {
+            _ticket = ticket;
+            Skip();
+        }
+
+        /// <summary>
+        /// Gets the intended presenters of the authentication ticket.
+        /// </summary>
+        public IEnumerable<string> Presenters => _ticket.GetPresenters();
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Server/IOpenIdConnectServerProvider.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/IOpenIdConnectServerProvider.cs
@@ -25,11 +25,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
         Task MatchEndpoint(MatchEndpointContext context);
 
         /// <summary>
-        /// Called to validate that the context.ClientId is a registered "client_id", and that the context.RedirectUri a "redirect_uri" 
+        /// Called to validate that the context.ClientId is a registered "client_id", and that the context.RedirectUri a "redirect_uri"
         /// registered for that client. This only occurs when processing the authorization endpoint. The application MUST implement this
         /// call, and it MUST validate both of those factors before calling context.Validated. If the context.Validated method is called
-        /// with a given redirectUri parameter, then IsValidated will only become true if the incoming redirect URI matches the given redirect URI. 
-        /// If context.Validated is not called the request will not proceed further. 
+        /// with a given redirectUri parameter, then IsValidated will only become true if the incoming redirect URI matches the given redirect URI.
+        /// If context.Validated is not called the request will not proceed further.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
@@ -39,8 +39,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// Called to validate that context.PostLogoutRedirectUri a valid and registered URL.
         /// This only occurs when processing the logout endpoint. The application MUST implement this call, and it MUST validate
         /// both of those factors before calling context.Validated. If the context.Validated method is called with a given redirectUri parameter,
-        /// then IsValidated will only become true if the incoming redirect URI matches the given redirect URI. 
-        /// If context.Validated is not called the request will not proceed further. 
+        /// then IsValidated will only become true if the incoming redirect URI matches the given redirect URI.
+        /// If context.Validated is not called the request will not proceed further.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
@@ -48,19 +48,35 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called to validate that the origin of the request is a registered "client_id", and that the correct credentials for that client are
-        /// present on the request. If the web application accepts Basic authentication credentials, 
-        /// context.TryGetBasicCredentials(out clientId, out clientSecret) may be called to acquire those values if present in the request header. If the web 
-        /// application accepts "client_id" and "client_secret" as form encoded POST parameters, 
+        /// present on the request. If the web application accepts Basic authentication credentials,
+        /// context.TryGetBasicCredentials(out clientId, out clientSecret) may be called to acquire those values if present in the request header. If the web
+        /// application accepts "client_id" and "client_secret" as form encoded POST parameters,
         /// context.TryGetFormCredentials(out clientId, out clientSecret) may be called to acquire those values if present in the request body.
-        /// If context.Validated is not called the request will not proceed further. 
+        /// If context.Validated is not called the request will not proceed further.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
         Task ValidateClientAuthentication(ValidateClientAuthenticationContext context);
 
         /// <summary>
-        /// Called for each request to the authorization endpoint to determine if the request is valid and should continue. 
-        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with 
+        /// Called to validate that the authenticating client matches the intended audiences of the authentication ticket.
+        /// If context.Validated is not called the request will not proceed further.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        Task ValidateClientAudiences(ValidateClientAudiencesContext context);
+
+        /// <summary>
+        /// Called to validate that the authenticating client matches the intended presenters of the authentication ticket.
+        /// If context.Validated is not called the request will not proceed further.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        Task ValidateClientPresenters(ValidateClientPresentersContext context);
+
+        /// <summary>
+        /// Called for each request to the authorization endpoint to determine if the request is valid and should continue.
+        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with
         /// validated client redirect URI, should continue processing. An application may add any additional constraints.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -68,8 +84,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
         Task ValidateAuthorizationRequest(ValidateAuthorizationRequestContext context);
 
         /// <summary>
-        /// Called for each request to the Token endpoint to determine if the request is valid and should continue. 
-        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with 
+        /// Called for each request to the Token endpoint to determine if the request is valid and should continue.
+        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with
         /// validated client credentials, should continue processing. An application may add any additional constraints.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -90,7 +106,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         Task GrantAuthorizationCode(GrantAuthorizationCodeContext context);
 
         /// <summary>
-        /// Called when a request to the Token endpoint arrives with a "grant_type" of "refresh_token". This occurs if your application has issued a "refresh_token" 
+        /// Called when a request to the Token endpoint arrives with a "grant_type" of "refresh_token". This occurs if your application has issued a "refresh_token"
         /// along with the "access_token", and the client is attempting to use the "refresh_token" to acquire a new "access_token", and possibly a new "refresh_token".
         /// The claims and properties associated with the refresh token are present in the context.Ticket. The token request is automatically handled,
         /// but the application can call context.Rejected to instruct the Authorization Server middleware to reject the token.
@@ -105,11 +121,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called when a request to the Token endpoint arrives with a "grant_type" of "password". This occurs when the user has provided name and password
-        /// credentials directly into the client application's user interface, and the client application is using those to acquire an "access_token" and 
+        /// credentials directly into the client application's user interface, and the client application is using those to acquire an "access_token" and
         /// optional "refresh_token". If the web application supports the
         /// resource owner credentials grant type it must validate the context.Username and context.Password as appropriate. To issue an
         /// access token the context.Validated must be called with a new ticket containing the claims about the resource owner which should be associated
-        /// with the access token. The application should take appropriate measures to ensure that the endpoint isn't abused by malicious callers.  . 
+        /// with the access token. The application should take appropriate measures to ensure that the endpoint isn't abused by malicious callers.  .
         /// The default behavior is to reject this grant type.
         /// See also http://tools.ietf.org/html/rfc6749#section-4.3.2
         /// </summary>
@@ -119,7 +135,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called when a request to the Token endpoint arrives with a "grant_type" of "client_credentials". This occurs when a registered client
-        /// application wishes to acquire an "access_token" to interact with protected resources on it's own behalf, rather than on behalf of an authenticated user. 
+        /// application wishes to acquire an "access_token" to interact with protected resources on it's own behalf, rather than on behalf of an authenticated user.
         /// If the web application supports the client credentials it may assume the context.ClientId has been validated by the ValidateClientAuthentication call.
         /// To issue an access token the context.Validated must be called with a new ticket containing the claims about the client application which should be associated
         /// with the access token. The application should take appropriate measures to ensure that the endpoint isn't abused by malicious callers.
@@ -142,10 +158,10 @@ namespace AspNet.Security.OpenIdConnect.Server {
         Task GrantCustomExtension(GrantCustomExtensionContext context);
 
         /// <summary>
-        /// Called at the final stage of an incoming authorization endpoint request before the execution continues on to the web application component 
+        /// Called at the final stage of an incoming authorization endpoint request before the execution continues on to the web application component
         /// responsible for producing the html response. Anything present in the OWIN pipeline following the Authorization Server may produce the
-        /// response for the authorization page. If running on IIS any ASP.NET technology running on the server may produce the response for the 
-        /// authorization page. If the web application wishes to produce the response directly in the AuthorizationEndpoint call it may write to the 
+        /// response for the authorization page. If running on IIS any ASP.NET technology running on the server may produce the response for the
+        /// authorization page. If the web application wishes to produce the response directly in the AuthorizationEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing. If the web application wishes
         /// to grant the authorization directly in the AuthorizationEndpoint call it cay call context.OwinContext.Authentication.SignIn with the
         /// appropriate ClaimsIdentity and should call context.RequestCompleted to stop other handlers from executing.
@@ -158,7 +174,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// Called before the AuthorizationEndpoint redirects its response to the caller.
         /// The response could contain an access token when using implicit flow or
         /// an authorization code when using the authorization code flow.
-        /// If the web application wishes to produce the authorization response directly in the AuthorizationEndpoint call it may write to the 
+        /// If the web application wishes to produce the authorization response directly in the AuthorizationEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
@@ -167,10 +183,10 @@ namespace AspNet.Security.OpenIdConnect.Server {
         Task AuthorizationEndpointResponse(AuthorizationEndpointResponseContext context);
 
         /// <summary>
-        /// Called at the final stage of an incoming logout endpoint request before the execution continues on to the web application component 
+        /// Called at the final stage of an incoming logout endpoint request before the execution continues on to the web application component
         /// responsible for producing the html response. Anything present in the OWIN pipeline following the Authorization Server may produce the
-        /// response for the logout page. If running on IIS any ASP.NET technology running on the server may produce the response for the 
-        /// authorization page. If the web application wishes to produce the response directly in the LogoutEndpoint call it may write to the 
+        /// response for the logout page. If running on IIS any ASP.NET technology running on the server may produce the response for the
+        /// authorization page. If the web application wishes to produce the response directly in the LogoutEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -179,7 +195,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the LogoutEndpoint endpoint redirects its response to the caller.
-        /// If the web application wishes to produce the authorization response directly in the LogoutEndpoint call it may write to the 
+        /// If the web application wishes to produce the authorization response directly in the LogoutEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
@@ -188,7 +204,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         Task LogoutEndpointResponse(LogoutEndpointResponseContext context);
 
         /// <summary>
-        /// Called at the final stage of an incoming userinfo endpoint request before the execution continues on to the web application component 
+        /// Called at the final stage of an incoming userinfo endpoint request before the execution continues on to the web application component
         /// responsible for producing the JSON response. Anything present in the OWIN pipeline following the Authorization Server may produce the
         /// response for the userinfo response. If the web application wishes to produce the response directly in the ProfileEndpoint call it
         /// may write to the context.Response directly and should call context.HandleResponse to stop other handlers from executing.
@@ -199,7 +215,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the ProfileEndpoint endpoint starts writing to the response stream.
-        /// If the web application wishes to produce the userinfo response directly in the ProfileEndpoint call it may write to the 
+        /// If the web application wishes to produce the userinfo response directly in the ProfileEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
@@ -217,7 +233,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the authorization server starts emitting the OpenID Connect configuration associated with this instance.
-        /// If the web application wishes to produce the configuration metadata directly in this call, it may write to the 
+        /// If the web application wishes to produce the configuration metadata directly in this call, it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -234,7 +250,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the authorization server starts emitting the OpenID Connect JSON Web Key set associated with this instance.
-        /// If the web application wishes to produce the JSON Web Key set directly in this call, it may write to the 
+        /// If the web application wishes to produce the JSON Web Key set directly in this call, it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -243,8 +259,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called at the final stage of a successful Token endpoint request.
-        /// An application may implement this call in order to do any final 
-        /// modification of the claims being used to issue access or refresh tokens. 
+        /// An application may implement this call in order to do any final
+        /// modification of the claims being used to issue access or refresh tokens.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
@@ -252,7 +268,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the TokenEndpoint redirects its response to the caller.
-        /// This call may also be used in order to add additional 
+        /// This call may also be used in order to add additional
         /// response parameters to the JSON response payload.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -271,7 +287,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <summary>
         /// Called before the authorization server starts emitting the status and metadata associated with the token received.
         /// Validation conforms to the OAuth 2.0 Token Introspection specification with some additions. See documentation for details.
-        /// If the web application wishes to produce the token status and metadata directly in this call, it may write to the 
+        /// If the web application wishes to produce the token status and metadata directly in this call, it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
@@ -6,13 +6,12 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Authentication;
 
 namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Default implementation of <see cref="IOpenIdConnectServerProvider"/> used by the authorization
     /// server to communicate with the web application while processing requests.
-    /// <see cref="OpenIdConnectServerProvider"/> provides some default behavior, 
+    /// <see cref="OpenIdConnectServerProvider"/> provides some default behavior,
     /// may be used as a virtual base class, and offers delegate properties
     /// which may be used to handle individual calls without declaring a new class type.
     /// </summary>
@@ -26,36 +25,48 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public Func<MatchEndpointContext, Task> OnMatchEndpoint { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
-        /// Called to validate that the context.ClientId is a registered "client_id", and that the context.RedirectUri a "redirect_uri" 
+        /// Called to validate that the context.ClientId is a registered "client_id", and that the context.RedirectUri a "redirect_uri"
         /// registered for that client. This only occurs when processing the authorization endpoint. The application MUST implement this
         /// call, and it MUST validate both of those factors before calling context.Validated. If the context.Validated method is called
-        /// with a given redirectUri parameter, then IsValidated will only become true if the incoming redirect URI matches the given redirect URI. 
-        /// If context.Validated is not called the request will not proceed further. 
+        /// with a given redirectUri parameter, then IsValidated will only become true if the incoming redirect URI matches the given redirect URI.
+        /// If context.Validated is not called the request will not proceed further.
         /// </summary>
         public Func<ValidateClientRedirectUriContext, Task> OnValidateClientRedirectUri { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
         /// Called to validate that the origin of the request is a registered "client_id", and that the correct credentials for that client are
-        /// present on the request. If the web application accepts Basic authentication credentials, 
-        /// context.TryGetBasicCredentials(out clientId, out clientSecret) may be called to acquire those values if present in the request header. If the web 
-        /// application accepts "client_id" and "client_secret" as form encoded POST parameters, 
+        /// present on the request. If the web application accepts Basic authentication credentials,
+        /// context.TryGetBasicCredentials(out clientId, out clientSecret) may be called to acquire those values if present in the request header. If the web
+        /// application accepts "client_id" and "client_secret" as form encoded POST parameters,
         /// context.TryGetFormCredentials(out clientId, out clientSecret) may be called to acquire those values if present in the request body.
-        /// If context.Validated is not called the request will not proceed further. 
+        /// If context.Validated is not called the request will not proceed further.
         /// </summary>
         public Func<ValidateClientAuthenticationContext, Task> OnValidateClientAuthentication { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
-        /// Called for each request to the authorization endpoint to determine if the request is valid and should continue. 
-        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with 
+        /// Called to validate that the authenticating client matches the intended audiences of the authentication ticket.
+        /// If context.Validated is not called the request will not proceed further.
+        /// </summary>
+        public Func<ValidateClientAudiencesContext, Task> OnValidateClientAudiences { get; set; } = context => Task.FromResult<object>(null);
+
+        /// <summary>
+        /// Called to validate that the authenticating client matches the intended presenters of the authentication ticket.
+        /// If context.Validated is not called the request will not proceed further.
+        /// </summary>
+        public Func<ValidateClientPresentersContext, Task> OnValidateClientPresenters { get; set; } = context => Task.FromResult<object>(null);
+
+        /// <summary>
+        /// Called for each request to the authorization endpoint to determine if the request is valid and should continue.
+        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with
         /// validated client redirect URI, should continue processing. An application may add any additional constraints.
         /// </summary>
         public Func<ValidateAuthorizationRequestContext, Task> OnValidateAuthorizationRequest { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
-        /// Called for each request to the Token endpoint to determine if the request is valid and should continue. 
-        /// If the application supports custom grant types it is entirely responsible for determining if the request 
-        /// should result in an access_token. 
-        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with 
+        /// Called for each request to the Token endpoint to determine if the request is valid and should continue.
+        /// If the application supports custom grant types it is entirely responsible for determining if the request
+        /// should result in an access_token.
+        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with
         /// validated client credentials, should continue processing. An application may add any additional constraints.
         /// </summary>
         public Func<ValidateTokenRequestContext, Task> OnValidateTokenRequest { get; set; } = context => Task.FromResult<object>(null);
@@ -64,8 +75,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// Called to validate that context.PostLogoutRedirectUri a valid and registered URL.
         /// This only occurs when processing the logout endpoint. The application MUST implement this call, and it MUST validate
         /// both of those factors before calling context.Validated. If the context.Validated method is called with a given redirectUri parameter,
-        /// then IsValidated will only become true if the incoming redirect URI matches the given redirect URI. 
-        /// If context.Validated is not called the request will not proceed further. 
+        /// then IsValidated will only become true if the incoming redirect URI matches the given redirect URI.
+        /// If context.Validated is not called the request will not proceed further.
         /// </summary>
         public Func<ValidateClientLogoutRedirectUriContext, Task> OnValidateClientLogoutRedirectUri { get; set; } = context => Task.FromResult<object>(null);
 
@@ -82,7 +93,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called when a request to the Token endpoint arrives with a "grant_type" of "password". This occurs when the user has provided name and password
-        /// credentials directly into the client application's user interface, and the client application is using those to acquire an "access_token" and 
+        /// credentials directly into the client application's user interface, and the client application is using those to acquire an "access_token" and
         /// optional "refresh_token". If the web application supports the
         /// resource owner credentials grant type it must validate the context.Username and context.Password as appropriate. To issue an
         /// access token the context.Validated must be called with a new ticket containing the claims about the resource owner which should be associated
@@ -94,7 +105,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called when a request to the Token endpoint arrives with a "grant_type" of "client_credentials". This occurs when a registered client
-        /// application wishes to acquire an "access_token" to interact with protected resources on it's own behalf, rather than on behalf of an authenticated user. 
+        /// application wishes to acquire an "access_token" to interact with protected resources on it's own behalf, rather than on behalf of an authenticated user.
         /// If the web application supports the client credentials it may assume the context.ClientId has been validated by the ValidateClientAuthentication call.
         /// To issue an access token the context.Validated must be called with a new ticket containing the claims about the client application which should be associated
         /// with the access token. The application should take appropriate measures to ensure that the endpoint isn�t abused by malicious callers.
@@ -104,7 +115,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public Func<GrantClientCredentialsContext, Task> OnGrantClientCredentials { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
-        /// Called when a request to the Token endpoint arrives with a "grant_type" of "refresh_token". This occurs if your application has issued a "refresh_token" 
+        /// Called when a request to the Token endpoint arrives with a "grant_type" of "refresh_token". This occurs if your application has issued a "refresh_token"
         /// along with the "access_token", and the client is attempting to use the "refresh_token" to acquire a new "access_token", and possibly a new "refresh_token".
         /// The claims and properties associated with the refresh token are present in the context.Ticket. The token request is automatically handled,
         /// but the application can call context.Rejected to instruct the Authorization Server middleware to reject the token.
@@ -125,10 +136,10 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public Func<GrantCustomExtensionContext, Task> OnGrantCustomExtension { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
-        /// Called at the final stage of an incoming authorization endpoint request before the execution continues on to the web application component 
+        /// Called at the final stage of an incoming authorization endpoint request before the execution continues on to the web application component
         /// responsible for producing the html response. Anything present in the OWIN pipeline following the Authorization Server may produce the
-        /// response for the authorization page. If running on IIS any ASP.NET technology running on the server may produce the response for the 
-        /// authorization page. If the web application wishes to produce the response directly in the AuthorizationEndpoint call it may write to the 
+        /// response for the authorization page. If running on IIS any ASP.NET technology running on the server may produce the response for the
+        /// authorization page. If the web application wishes to produce the response directly in the AuthorizationEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing. If the web application wishes
         /// to grant the authorization directly in the AuthorizationEndpoint call it cay call context.OwinContext.Authentication.SignIn with the
         /// appropriate ClaimsIdentity and should call context.RequestCompleted to stop other handlers from executing.
@@ -139,31 +150,31 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// Called before the AuthorizationEndpoint redirects its response to the caller.
         /// The response could contain an access token when using implicit flow or
         /// an authorization code when using the authorization code flow.
-        /// If the web application wishes to produce the authorization response directly in the AuthorizationEndpoint call it may write to the 
+        /// If the web application wishes to produce the authorization response directly in the AuthorizationEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
         public Func<AuthorizationEndpointResponseContext, Task> OnAuthorizationEndpointResponse { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
-        /// Called at the final stage of an incoming logout endpoint request before the execution continues on to the web application component 
+        /// Called at the final stage of an incoming logout endpoint request before the execution continues on to the web application component
         /// responsible for producing the html response. Anything present in the OWIN pipeline following the Authorization Server may produce the
-        /// response for the logout page. If running on IIS any ASP.NET technology running on the server may produce the response for the 
-        /// authorization page. If the web application wishes to produce the response directly in the LogoutEndpoint call it may write to the 
+        /// response for the logout page. If running on IIS any ASP.NET technology running on the server may produce the response for the
+        /// authorization page. If the web application wishes to produce the response directly in the LogoutEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// </summary>
         public Func<LogoutEndpointContext, Task> OnLogoutEndpoint { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
         /// Called before the LogoutEndpoint endpoint redirects its response to the caller.
-        /// If the web application wishes to produce the authorization response directly in the LogoutEndpoint call it may write to the 
+        /// If the web application wishes to produce the authorization response directly in the LogoutEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
         public Func<LogoutEndpointResponseContext, Task> OnLogoutEndpointResponse { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
-        /// Called at the final stage of an incoming userinfo endpoint request before the execution continues on to the web application component 
+        /// Called at the final stage of an incoming userinfo endpoint request before the execution continues on to the web application component
         /// responsible for producing the JSON response. Anything present in the OWIN pipeline following the Authorization Server may produce the
         /// response for the userinfo response. If the web application wishes to produce the response directly in the ProfileEndpoint call it
         /// may write to the context.Response directly and should call context.HandleResponse to stop other handlers from executing.
@@ -172,7 +183,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the ProfileEndpoint endpoint starts writing to the response stream.
-        /// If the web application wishes to produce the userinfo response directly in the ProfileEndpoint call it may write to the 
+        /// If the web application wishes to produce the userinfo response directly in the ProfileEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
@@ -186,7 +197,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the authorization server starts emitting the OpenID Connect configuration associated with this instance.
-        /// If the web application wishes to produce the configuration metadata directly in this call, it may write to the 
+        /// If the web application wishes to produce the configuration metadata directly in this call, it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
         /// </summary>
         public Func<ConfigurationEndpointResponseContext, Task> OnConfigurationEndpointResponse { get; set; } = context => Task.FromResult<object>(null);
@@ -199,21 +210,21 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the authorization server starts emitting the OpenID Connect JSON Web Key set associated with this instance.
-        /// If the web application wishes to produce the JSON Web Key set directly in this call, it may write to the 
+        /// If the web application wishes to produce the JSON Web Key set directly in this call, it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
         /// </summary>
         public Func<CryptographyEndpointResponseContext, Task> OnCryptographyEndpointResponse { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
         /// Called at the final stage of a successful Token endpoint request.
-        /// An application may implement this call in order to do any final 
-        /// modification of the claims being used to issue access or refresh tokens. 
+        /// An application may implement this call in order to do any final
+        /// modification of the claims being used to issue access or refresh tokens.
         /// </summary>
         public Func<TokenEndpointContext, Task> OnTokenEndpoint { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
         /// Called before the TokenEndpoint redirects its response to the caller.
-        /// This call may also be used in order to add additional 
+        /// This call may also be used in order to add additional
         /// response parameters to the JSON response payload.
         /// </summary>
         public Func<TokenEndpointResponseContext, Task> OnTokenEndpointResponse { get; set; } = context => Task.FromResult<object>(null);
@@ -228,7 +239,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <summary>
         /// Called before the authorization server starts emitting the status and metadata associated with the token received.
         /// Validation conforms to the OAuth 2.0 Token Introspection specification with some additions. See documentation for details.
-        /// If the web application wishes to produce the token status and metadata directly in this call, it may write to the 
+        /// If the web application wishes to produce the token status and metadata directly in this call, it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
         /// </summary>
         public Func<ValidationEndpointResponseContext, Task> OnValidationEndpointResponse { get; set; } = context => Task.FromResult<object>(null);
@@ -300,11 +311,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public virtual Task MatchEndpoint(MatchEndpointContext context) => OnMatchEndpoint(context);
 
         /// <summary>
-        /// Called to validate that the context.ClientId is a registered "client_id", and that the context.RedirectUri a "redirect_uri" 
+        /// Called to validate that the context.ClientId is a registered "client_id", and that the context.RedirectUri a "redirect_uri"
         /// registered for that client. This only occurs when processing the authorization endpoint. The application MUST implement this
         /// call, and it MUST validate both of those factors before calling context.Validated. If the context.Validated method is called
-        /// with a given redirectUri parameter, then IsValidated will only become true if the incoming redirect URI matches the given redirect URI. 
-        /// If context.Validated is not called the request will not proceed further. 
+        /// with a given redirectUri parameter, then IsValidated will only become true if the incoming redirect URI matches the given redirect URI.
+        /// If context.Validated is not called the request will not proceed further.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
@@ -314,8 +325,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// Called to validate that context.PostLogoutRedirectUri a valid and registered URL.
         /// This only occurs when processing the logout endpoint. The application MUST implement this call, and it MUST validate
         /// both of those factors before calling context.Validated. If the context.Validated method is called with a given redirectUri parameter,
-        /// then IsValidated will only become true if the incoming redirect URI matches the given redirect URI. 
-        /// If context.Validated is not called the request will not proceed further. 
+        /// then IsValidated will only become true if the incoming redirect URI matches the given redirect URI.
+        /// If context.Validated is not called the request will not proceed further.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
@@ -323,19 +334,36 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called to validate that the origin of the request is a registered "client_id", and that the correct credentials for that client are
-        /// present on the request. If the web application accepts Basic authentication credentials, 
-        /// context.TryGetBasicCredentials(out clientId, out clientSecret) may be called to acquire those values if present in the request header. If the web 
-        /// application accepts "client_id" and "client_secret" as form encoded POST parameters, 
+        /// present on the request. If the web application accepts Basic authentication credentials,
+        /// context.TryGetBasicCredentials(out clientId, out clientSecret) may be called to acquire those values if present in the request header. If the web
+        /// application accepts "client_id" and "client_secret" as form encoded POST parameters,
         /// context.TryGetFormCredentials(out clientId, out clientSecret) may be called to acquire those values if present in the request body.
-        /// If context.Validated is not called the request will not proceed further. 
+        /// If context.Validated is not called the request will not proceed further.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
         public virtual Task ValidateClientAuthentication(ValidateClientAuthenticationContext context) => OnValidateClientAuthentication(context);
 
         /// <summary>
-        /// Called for each request to the authorization endpoint to determine if the request is valid and should continue. 
-        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with 
+        /// Called to validate that the authenticating client matches the intended audiences of the authentication ticket.
+        /// If context.Validated is not called the request will not proceed further.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task ValidateClientAudiences(ValidateClientAudiencesContext context) => OnValidateClientAudiences(context);
+
+        /// <summary>
+        /// Called to validate that the authenticating client matches the intended presenters of the authentication ticket.
+        /// If context.Validated is not called the request will not proceed further.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task ValidateClientPresenters(ValidateClientPresentersContext context) => OnValidateClientPresenters(context);
+
+
+        /// <summary>
+        /// Called for each request to the authorization endpoint to determine if the request is valid and should continue.
+        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with
         /// validated client redirect URI, should continue processing. An application may add any additional constraints.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -343,8 +371,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public virtual Task ValidateAuthorizationRequest(ValidateAuthorizationRequestContext context) => OnValidateAuthorizationRequest(context);
 
         /// <summary>
-        /// Called for each request to the Token endpoint to determine if the request is valid and should continue. 
-        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with 
+        /// Called for each request to the Token endpoint to determine if the request is valid and should continue.
+        /// The default behavior when using the OpenIdConnectServerProvider is to assume well-formed requests, with
         /// validated client credentials, should continue processing. An application may add any additional constraints.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -365,7 +393,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public virtual Task GrantAuthorizationCode(GrantAuthorizationCodeContext context) => OnGrantAuthorizationCode(context);
 
         /// <summary>
-        /// Called when a request to the Token endpoint arrives with a "grant_type" of "refresh_token". This occurs if your application has issued a "refresh_token" 
+        /// Called when a request to the Token endpoint arrives with a "grant_type" of "refresh_token". This occurs if your application has issued a "refresh_token"
         /// along with the "access_token", and the client is attempting to use the "refresh_token" to acquire a new "access_token", and possibly a new "refresh_token".
         /// The claims and properties associated with the refresh token are present in the context.Ticket. The token request is automatically handled,
         /// but the application can call context.Rejected to instruct the Authorization Server middleware to reject the token.
@@ -380,7 +408,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called when a request to the Token endpoint arrives with a "grant_type" of "password". This occurs when the user has provided name and password
-        /// credentials directly into the client application's user interface, and the client application is using those to acquire an "access_token" and 
+        /// credentials directly into the client application's user interface, and the client application is using those to acquire an "access_token" and
         /// optional "refresh_token". If the web application supports the
         /// resource owner credentials grant type it must validate the context.Username and context.Password as appropriate. To issue an
         /// access token the context.Validated must be called with a new ticket containing the claims about the resource owner which should be associated
@@ -394,7 +422,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called when a request to the Token endpoint arrives with a "grant_type" of "client_credentials". This occurs when a registered client
-        /// application wishes to acquire an "access_token" to interact with protected resources on it's own behalf, rather than on behalf of an authenticated user. 
+        /// application wishes to acquire an "access_token" to interact with protected resources on it's own behalf, rather than on behalf of an authenticated user.
         /// If the web application supports the client credentials it may assume the context.ClientId has been validated by the ValidateClientAuthentication call.
         /// To issue an access token the context.Validated must be called with a new ticket containing the claims about the client application which should be associated
         /// with the access token. The application should take appropriate measures to ensure that the endpoint isn't abused by malicious callers.
@@ -417,10 +445,10 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public virtual Task GrantCustomExtension(GrantCustomExtensionContext context) => OnGrantCustomExtension(context);
 
         /// <summary>
-        /// Called at the final stage of an incoming authorization endpoint request before the execution continues on to the web application component 
+        /// Called at the final stage of an incoming authorization endpoint request before the execution continues on to the web application component
         /// responsible for producing the html response. Anything present in the OWIN pipeline following the Authorization Server may produce the
-        /// response for the authorization page. If running on IIS any ASP.NET technology running on the server may produce the response for the 
-        /// authorization page. If the web application wishes to produce the response directly in the AuthorizationEndpoint call it may write to the 
+        /// response for the authorization page. If running on IIS any ASP.NET technology running on the server may produce the response for the
+        /// authorization page. If the web application wishes to produce the response directly in the AuthorizationEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing. If the web application wishes
         /// to grant the authorization directly in the AuthorizationEndpoint call it cay call context.OwinContext.Authentication.SignIn with the
         /// appropriate ClaimsIdentity and should call context.RequestCompleted to stop other handlers from executing.
@@ -433,7 +461,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// Called before the AuthorizationEndpoint redirects its response to the caller.
         /// The response could contain an access token when using implicit flow or
         /// an authorization code when using the authorization code flow.
-        /// If the web application wishes to produce the authorization response directly in the AuthorizationEndpoint call it may write to the 
+        /// If the web application wishes to produce the authorization response directly in the AuthorizationEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
@@ -442,10 +470,10 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public virtual Task AuthorizationEndpointResponse(AuthorizationEndpointResponseContext context) => OnAuthorizationEndpointResponse(context);
 
         /// <summary>
-        /// Called at the final stage of an incoming logout endpoint request before the execution continues on to the web application component 
+        /// Called at the final stage of an incoming logout endpoint request before the execution continues on to the web application component
         /// responsible for producing the html response. Anything present in the OWIN pipeline following the Authorization Server may produce the
-        /// response for the logout page. If running on IIS any ASP.NET technology running on the server may produce the response for the 
-        /// authorization page. If the web application wishes to produce the response directly in the LogoutEndpoint call it may write to the 
+        /// response for the logout page. If running on IIS any ASP.NET technology running on the server may produce the response for the
+        /// authorization page. If the web application wishes to produce the response directly in the LogoutEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -454,7 +482,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the LogoutEndpoint endpoint redirects its response to the caller.
-        /// If the web application wishes to produce the authorization response directly in the LogoutEndpoint call it may write to the 
+        /// If the web application wishes to produce the authorization response directly in the LogoutEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
@@ -463,7 +491,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public virtual Task LogoutEndpointResponse(LogoutEndpointResponseContext context) => OnLogoutEndpointResponse(context);
 
         /// <summary>
-        /// Called at the final stage of an incoming userinfo endpoint request before the execution continues on to the web application component 
+        /// Called at the final stage of an incoming userinfo endpoint request before the execution continues on to the web application component
         /// responsible for producing the JSON response. Anything present in the OWIN pipeline following the Authorization Server may produce the
         /// response for the userinfo response. If the web application wishes to produce the response directly in the ProfileEndpoint call it
         /// may write to the context.Response directly and should call context.HandleResponse to stop other handlers from executing.
@@ -474,7 +502,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the ProfileEndpoint endpoint starts writing to the response stream.
-        /// If the web application wishes to produce the userinfo response directly in the ProfileEndpoint call it may write to the 
+        /// If the web application wishes to produce the userinfo response directly in the ProfileEndpoint call it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
@@ -492,7 +520,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the authorization server starts emitting the OpenID Connect configuration associated with this instance.
-        /// If the web application wishes to produce the configuration metadata directly in this call, it may write to the 
+        /// If the web application wishes to produce the configuration metadata directly in this call, it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -509,7 +537,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the authorization server starts emitting the OpenID Connect JSON Web Key set associated with this instance.
-        /// If the web application wishes to produce the JSON Web Key set directly in this call, it may write to the 
+        /// If the web application wishes to produce the JSON Web Key set directly in this call, it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -518,8 +546,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called at the final stage of a successful Token endpoint request.
-        /// An application may implement this call in order to do any final 
-        /// modification of the claims being used to issue access or refresh tokens. 
+        /// An application may implement this call in order to do any final
+        /// modification of the claims being used to issue access or refresh tokens.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
@@ -527,7 +555,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Called before the TokenEndpoint redirects its response to the caller.
-        /// This call may also be used in order to add additional 
+        /// This call may also be used in order to add additional
         /// response parameters to the JSON response payload.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -546,7 +574,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <summary>
         /// Called before the authorization server starts emitting the status and metadata associated with the token received.
         /// Validation conforms to the OAuth 2.0 Token Introspection specification with some additions. See documentation for details.
-        /// If the web application wishes to produce the status and metadata directly in this call, it may write to the 
+        /// If the web application wishes to produce the status and metadata directly in this call, it may write to the
         /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>


### PR DESCRIPTION
As discussed on gitter, this is a draft for giving the user control over the decision if an introspecting client is indeed the indended audience or presenter of a token.

While the default behavior is to check if the ticket contains any audience or presenter that matches the `client_id`, overriding `ValidateClientAudiences` and `ValidateClientPresenters` allows for a finer-grained control. Here the user may look up a list of valid audiences or presenters for the client, which then can be used to control the further flow.