### PR TITLE
Automatically infer the "resources" property from "audiences" when no explicit value can be found

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -375,13 +375,20 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 context.Properties[OpenIdConnectConstants.Properties.RedirectUri] = request.RedirectUri;
             }
 
-            // Note: the application is allowed to specify a different "scope"
+            // Always include the "openid" scope when the developer doesn't explicitly call SetScopes.
+            // Note: the application is allowed to specify a different "scopes"
             // parameter when calling AuthenticationManager.SignInAsync: in this case,
-            // don't replace the "scope" property stored in the authentication ticket.
+            // don't replace the "scopes" property stored in the authentication ticket.
             if (!context.Properties.ContainsKey(OpenIdConnectConstants.Properties.Scopes) &&
                  request.HasScope(OpenIdConnectConstants.Scopes.OpenId)) {
-                // Always include the "openid" scope when the developer didn't explicitly call SetScopes.
                 context.Properties[OpenIdConnectConstants.Properties.Scopes] = OpenIdConnectConstants.Scopes.OpenId;
+            }
+
+            string audiences;
+            // When a "resources" property cannot be found in the authentication properties, infer it from the "audiences" property.
+            if (!context.Properties.ContainsKey(OpenIdConnectConstants.Properties.Resources) &&
+                 context.Properties.TryGetValue(OpenIdConnectConstants.Properties.Audiences, out audiences)) {
+                context.Properties[OpenIdConnectConstants.Properties.Resources] = audiences;
             }
 
             // Determine whether an authorization code should be returned

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
@@ -519,12 +519,19 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 ticket.Properties.Items[OpenIdConnectConstants.Properties.Confidential] = "true";
             }
 
-            // Note: the application is allowed to specify a different "scope": in this case,
-            // don't replace the "scope" property stored in the authentication ticket.
+            // Always include the "openid" scope when the developer doesn't explicitly call SetScopes.
+            // Note: the application is allowed to specify a different "scopes": in this case,
+            // don't replace the "scopes" property stored in the authentication ticket.
             if (!ticket.Properties.Items.ContainsKey(OpenIdConnectConstants.Properties.Scopes) &&
                  request.HasScope(OpenIdConnectConstants.Scopes.OpenId)) {
-                // Always include the "openid" scope when the developer didn't explicitly call SetScopes.
                 ticket.Properties.Items[OpenIdConnectConstants.Properties.Scopes] = OpenIdConnectConstants.Scopes.OpenId;
+            }
+
+            string audiences;
+            // When a "resources" property cannot be found in the authentication properties, infer it from the "audiences" property.
+            if (!ticket.Properties.Items.ContainsKey(OpenIdConnectConstants.Properties.Resources) &&
+                 ticket.Properties.Items.TryGetValue(OpenIdConnectConstants.Properties.Audiences, out audiences)) {
+                ticket.Properties.Items[OpenIdConnectConstants.Properties.Resources] = audiences;
             }
 
             var response = new OpenIdConnectMessage();


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/195.