### PR TITLE
Mark the event classes as public and non-sealed

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/Events/AuthorizationEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/AuthorizationEndpointContext.cs
@@ -13,11 +13,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised after the Authorization Server has processed the request, but before it is passed on to the web application.
     /// Calling RequestCompleted will prevent the request from passing on to the web application.
     /// </summary>
-    public sealed class AuthorizationEndpointContext : BaseControlContext {
+    public class AuthorizationEndpointContext : BaseControlContext {
         /// <summary>
         /// Creates an instance of this context
         /// </summary>
-        internal AuthorizationEndpointContext(
+        public AuthorizationEndpointContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/AuthorizationEndpointResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/AuthorizationEndpointResponseContext.cs
@@ -12,7 +12,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information when processing an Authorization Response
     /// </summary>
-    public sealed class AuthorizationEndpointResponseContext : BaseControlContext {
+    public class AuthorizationEndpointResponseContext : BaseControlContext {
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthorizationEndpointResponseContext"/> class
@@ -22,7 +22,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="ticket"></param>
         /// <param name="request"></param>
         /// <param name="response"></param>
-        internal AuthorizationEndpointResponseContext(
+        public AuthorizationEndpointResponseContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             AuthenticationTicket ticket,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ConfigurationEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ConfigurationEndpointContext.cs
@@ -13,11 +13,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server handles
     /// the request made to the configuration metadata endpoint.
     /// </summary>
-    public sealed class ConfigurationEndpointContext : BaseControlContext {
+    public class ConfigurationEndpointContext : BaseControlContext {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>
-        internal ConfigurationEndpointContext(
+        public ConfigurationEndpointContext(
             HttpContext context,
             OpenIdConnectServerOptions options)
             : base(context) {

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ConfigurationEndpointResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ConfigurationEndpointResponseContext.cs
@@ -15,11 +15,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server starts
     /// writing the configuration metadata to the response stream.
     /// </summary>
-    public sealed class ConfigurationEndpointResponseContext : BaseControlContext {
+    public class ConfigurationEndpointResponseContext : BaseControlContext {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>
-        internal ConfigurationEndpointResponseContext(
+        public ConfigurationEndpointResponseContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             JObject payload)

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/CryptographyEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/CryptographyEndpointContext.cs
@@ -14,11 +14,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server handles
     /// the request made to the JWKS metadata endpoint.
     /// </summary>
-    public sealed class CryptographyEndpointContext : BaseControlContext {
+    public class CryptographyEndpointContext : BaseControlContext {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>
-        internal CryptographyEndpointContext(
+        public CryptographyEndpointContext(
             HttpContext context,
             OpenIdConnectServerOptions options)
             : base(context) {

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/CryptographyEndpointResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/CryptographyEndpointResponseContext.cs
@@ -14,11 +14,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server starts
     /// writing the JWKS metadata to the response stream.
     /// </summary>
-    public sealed class CryptographyEndpointResponseContext : BaseControlContext {
+    public class CryptographyEndpointResponseContext : BaseControlContext {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>
-        internal CryptographyEndpointResponseContext(
+        public CryptographyEndpointResponseContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             JObject payload)

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/DeserializeAccessTokenContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/DeserializeAccessTokenContext.cs
@@ -13,7 +13,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when receiving an access token.
     /// </summary>
-    public sealed class DeserializeAccessTokenContext : BaseContext {
+    public class DeserializeAccessTokenContext : BaseContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeserializeAccessTokenContext"/> class
         /// </summary>
@@ -21,7 +21,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="options"></param>
         /// <param name="request"></param>
         /// <param name="token"></param>
-        internal DeserializeAccessTokenContext(
+        public DeserializeAccessTokenContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/DeserializeAuthorizationCodeContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/DeserializeAuthorizationCodeContext.cs
@@ -12,7 +12,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when receiving an authorization code.
     /// </summary>
-    public sealed class DeserializeAuthorizationCodeContext : BaseContext {
+    public class DeserializeAuthorizationCodeContext : BaseContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeserializeAuthorizationCodeContext"/> class
         /// </summary>
@@ -20,7 +20,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="options"></param>
         /// <param name="request"></param>
         /// <param name="code"></param>
-        internal DeserializeAuthorizationCodeContext(
+        public DeserializeAuthorizationCodeContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/DeserializeIdentityTokenContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/DeserializeIdentityTokenContext.cs
@@ -14,7 +14,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when receiving an identity token.
     /// </summary>
-    public sealed class DeserializeIdentityTokenContext : BaseContext {
+    public class DeserializeIdentityTokenContext : BaseContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeserializeIdentityTokenContext"/> class
         /// </summary>
@@ -22,7 +22,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="options"></param>
         /// <param name="request"></param>
         /// <param name="token"></param>
-        internal DeserializeIdentityTokenContext(
+        public DeserializeIdentityTokenContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/DeserializeRefreshTokenContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/DeserializeRefreshTokenContext.cs
@@ -12,7 +12,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when receiving a refresh token.
     /// </summary>
-    public sealed class DeserializeRefreshTokenContext : BaseContext {
+    public class DeserializeRefreshTokenContext : BaseContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeserializeRefreshTokenContext"/> class
         /// </summary>
@@ -20,7 +20,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="options"></param>
         /// <param name="request"></param>
         /// <param name="token"></param>
-        internal DeserializeRefreshTokenContext(
+        public DeserializeRefreshTokenContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/GrantAuthorizationCodeContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/GrantAuthorizationCodeContext.cs
@@ -12,7 +12,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information when handling an OpenIdConnect authorization code grant.
     /// </summary>
-    public sealed class GrantAuthorizationCodeContext : BaseValidatingTicketContext {
+    public class GrantAuthorizationCodeContext : BaseValidatingTicketContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrantAuthorizationCodeContext"/> class
         /// </summary>
@@ -20,7 +20,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="options"></param>
         /// <param name="request"></param>
         /// <param name="ticket"></param>
-        internal GrantAuthorizationCodeContext(
+        public GrantAuthorizationCodeContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/GrantClientCredentialsContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/GrantClientCredentialsContext.cs
@@ -13,14 +13,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used in handling an OpenIdConnect client credentials grant.
     /// </summary>
-    public sealed class GrantClientCredentialsContext : BaseValidatingTicketContext {
+    public class GrantClientCredentialsContext : BaseValidatingTicketContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrantClientCredentialsContext"/> class
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
         /// <param name="request"></param>
-        internal GrantClientCredentialsContext(
+        public GrantClientCredentialsContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/GrantCustomExtensionContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/GrantCustomExtensionContext.cs
@@ -11,14 +11,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when handling OpenIdConnect extension grant types.
     /// </summary>
-    public sealed class GrantCustomExtensionContext : BaseValidatingTicketContext {
+    public class GrantCustomExtensionContext : BaseValidatingTicketContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrantCustomExtensionContext"/> class
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
         /// <param name="request"></param>
-        internal GrantCustomExtensionContext(
+        public GrantCustomExtensionContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/GrantRefreshTokenContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/GrantRefreshTokenContext.cs
@@ -12,7 +12,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when granting an OpenIdConnect refresh token.
     /// </summary>
-    public sealed class GrantRefreshTokenContext : BaseValidatingTicketContext {
+    public class GrantRefreshTokenContext : BaseValidatingTicketContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrantRefreshTokenContext"/> class
         /// </summary>
@@ -20,7 +20,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="options"></param>
         /// <param name="request"></param>
         /// <param name="ticket"></param>
-        internal GrantRefreshTokenContext(
+        public GrantRefreshTokenContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/GrantResourceOwnerCredentialsContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/GrantResourceOwnerCredentialsContext.cs
@@ -13,14 +13,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used in handling an OpenIdConnect resource owner grant.
     /// </summary>
-    public sealed class GrantResourceOwnerCredentialsContext : BaseValidatingTicketContext {
+    public class GrantResourceOwnerCredentialsContext : BaseValidatingTicketContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrantResourceOwnerCredentialsContext"/> class
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
         /// <param name="request"></param>
-        internal GrantResourceOwnerCredentialsContext(
+        public GrantResourceOwnerCredentialsContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/IntrospectionEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/IntrospectionEndpointContext.cs
@@ -17,11 +17,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server handles
     /// the request made to the token introspection endpoint.
     /// </summary>
-    public sealed class IntrospectionEndpointContext : BaseControlContext {
+    public class IntrospectionEndpointContext : BaseControlContext {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>
-        internal IntrospectionEndpointContext(
+        public IntrospectionEndpointContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/IntrospectionEndpointResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/IntrospectionEndpointResponseContext.cs
@@ -13,11 +13,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised before the authorization server starts
     /// writing the token status/metadata to the response stream.
     /// </summary>
-    public sealed class IntrospectionEndpointResponseContext : BaseControlContext {
+    public class IntrospectionEndpointResponseContext : BaseControlContext {
         /// <summary>
         /// Creates an instance of this context.
         /// </summary>
-        internal IntrospectionEndpointResponseContext(
+        public IntrospectionEndpointResponseContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             JObject payload)

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/LogoutEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/LogoutEndpointContext.cs
@@ -13,11 +13,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised after the Authorization Server has processed the logout request, but before it is passed on to the web application.
     /// Calling RequestCompleted will prevent the request from passing on to the web application.
     /// </summary>
-    public sealed class LogoutEndpointContext : BaseControlContext {
+    public class LogoutEndpointContext : BaseControlContext {
         /// <summary>
         /// Creates an instance of this context
         /// </summary>
-        internal LogoutEndpointContext(
+        public LogoutEndpointContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/LogoutEndpointResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/LogoutEndpointResponseContext.cs
@@ -12,7 +12,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information when processing a logout response.
     /// </summary>
-    public sealed class LogoutEndpointResponseContext : BaseControlContext {
+    public class LogoutEndpointResponseContext : BaseControlContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="LogoutEndpointResponseContext"/> class
         /// </summary>
@@ -20,7 +20,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="options"></param>
         /// <param name="request"></param>
         /// <param name="response"></param>
-        internal LogoutEndpointResponseContext(
+        public LogoutEndpointResponseContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/MatchEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/MatchEndpointContext.cs
@@ -11,13 +11,13 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when determining the OpenIdConnect flow type based on the request.
     /// </summary>
-    public sealed class MatchEndpointContext : BaseControlContext {
+    public class MatchEndpointContext : BaseControlContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="MatchEndpointContext"/> class
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
-        internal MatchEndpointContext(
+        public MatchEndpointContext(
             HttpContext context,
             OpenIdConnectServerOptions options)
             : base(context) {

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ProfileEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ProfileEndpointContext.cs
@@ -15,11 +15,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// An event raised after the Authorization Server has processed the request, but before it is passed on to the web application.
     /// Calling RequestCompleted will prevent the request from passing on to the web application.
     /// </summary>
-    public sealed class ProfileEndpointContext : BaseControlContext {
+    public class ProfileEndpointContext : BaseControlContext {
         /// <summary>
         /// Creates an instance of this context
         /// </summary>
-        internal ProfileEndpointContext(
+        public ProfileEndpointContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ProfileEndpointResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ProfileEndpointResponseContext.cs
@@ -13,7 +13,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used at the end of a userinfo request.
     /// </summary>
-    public sealed class ProfileEndpointResponseContext : BaseControlContext {
+    public class ProfileEndpointResponseContext : BaseControlContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="ProfileEndpointResponseContext"/> class
         /// </summary>
@@ -21,7 +21,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="options"></param>
         /// <param name="request"></param>
         /// <param name="payload"></param>
-        internal ProfileEndpointResponseContext(
+        public ProfileEndpointResponseContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/SerializeAccessTokenContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/SerializeAccessTokenContext.cs
@@ -15,7 +15,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when issuing an access token.
     /// </summary>
-    public sealed class SerializeAccessTokenContext : BaseContext {
+    public class SerializeAccessTokenContext : BaseContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="SerializeAccessTokenContext"/> class
         /// </summary>
@@ -24,7 +24,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="request"></param>
         /// <param name="response"></param>
         /// <param name="ticket"></param>
-        internal SerializeAccessTokenContext(
+        public SerializeAccessTokenContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/SerializeAuthorizationCodeContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/SerializeAuthorizationCodeContext.cs
@@ -14,7 +14,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when issuing an authorization code.
     /// </summary>
-    public sealed class SerializeAuthorizationCodeContext : BaseContext {
+    public class SerializeAuthorizationCodeContext : BaseContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="SerializeAuthorizationCodeContext"/> class
         /// </summary>
@@ -23,7 +23,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="request"></param>
         /// <param name="response"></param>
         /// <param name="ticket"></param>
-        internal SerializeAuthorizationCodeContext(
+        public SerializeAuthorizationCodeContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/SerializeIdentityTokenContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/SerializeIdentityTokenContext.cs
@@ -16,7 +16,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when issuing an identity token.
     /// </summary>
-    public sealed class SerializeIdentityTokenContext : BaseContext {
+    public class SerializeIdentityTokenContext : BaseContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="SerializeIdentityTokenContext"/> class
         /// </summary>
@@ -25,7 +25,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="request"></param>
         /// <param name="response"></param>
         /// <param name="ticket"></param>
-        internal SerializeIdentityTokenContext(
+        public SerializeIdentityTokenContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/SerializeRefreshTokenContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/SerializeRefreshTokenContext.cs
@@ -14,7 +14,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when issuing a refresh token.
     /// </summary>
-    public sealed class SerializeRefreshTokenContext : BaseContext {
+    public class SerializeRefreshTokenContext : BaseContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="SerializeRefreshTokenContext"/> class
         /// </summary>
@@ -23,7 +23,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="request"></param>
         /// <param name="response"></param>
         /// <param name="ticket"></param>
-        internal SerializeRefreshTokenContext(
+        public SerializeRefreshTokenContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/TokenEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/TokenEndpointContext.cs
@@ -12,7 +12,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when processing an OpenIdConnect token request.
     /// </summary>
-    public sealed class TokenEndpointContext : BaseControlContext {
+    public class TokenEndpointContext : BaseControlContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenEndpointContext"/> class
         /// </summary>
@@ -20,7 +20,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="options"></param>
         /// <param name="request"></param>
         /// <param name="ticket"></param>
-        internal TokenEndpointContext(
+        public TokenEndpointContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/TokenEndpointResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/TokenEndpointResponseContext.cs
@@ -13,7 +13,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used at the end of a token-endpoint-request.
     /// </summary>
-    public sealed class TokenEndpointResponseContext : BaseControlContext {
+    public class TokenEndpointResponseContext : BaseControlContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenEndpointResponseContext"/> class
         /// </summary>
@@ -22,7 +22,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="ticket"></param>
         /// <param name="request"></param>
         /// <param name="payload"></param>
-        internal TokenEndpointResponseContext(
+        public TokenEndpointResponseContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             AuthenticationTicket ticket,

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateAuthorizationRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateAuthorizationRequestContext.cs
@@ -12,14 +12,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when validating an authorization request.
     /// </summary>
-    public sealed class ValidateAuthorizationRequestContext : BaseValidatingContext {
+    public class ValidateAuthorizationRequestContext : BaseValidatingContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidateAuthorizationRequestContext"/> class.
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
         /// <param name="request"></param>
-        internal ValidateAuthorizationRequestContext(
+        public ValidateAuthorizationRequestContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateIntrospectionRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateIntrospectionRequestContext.cs
@@ -11,14 +11,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when validating an introspection request.
     /// </summary>
-    public sealed class ValidateIntrospectionRequestContext : BaseValidatingClientContext {
+    public class ValidateIntrospectionRequestContext : BaseValidatingClientContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidateIntrospectionRequestContext"/> class.
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
         /// <param name="request"></param>
-        internal ValidateIntrospectionRequestContext(
+        public ValidateIntrospectionRequestContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateLogoutRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateLogoutRequestContext.cs
@@ -12,14 +12,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when validating a logout request.
     /// </summary>
-    public sealed class ValidateLogoutRequestContext : BaseValidatingContext {
+    public class ValidateLogoutRequestContext : BaseValidatingContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidateLogoutRequestContext"/> class.
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
         /// <param name="request"></param>
-        internal ValidateLogoutRequestContext(
+        public ValidateLogoutRequestContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateTokenRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateTokenRequestContext.cs
@@ -11,14 +11,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
     /// Provides context information used when validating a token request.
     /// </summary>
-    public sealed class ValidateTokenRequestContext : BaseValidatingClientContext {
+    public class ValidateTokenRequestContext : BaseValidatingClientContext {
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidateTokenRequestContext"/> class.
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
         /// <param name="request"></param>
-        internal ValidateTokenRequestContext(
+        public ValidateTokenRequestContext(
             HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/197.