### PR TITLE
Remove OpenIdConnectExtensions.CopyTo

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -598,33 +598,6 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
         }
 
         /// <summary>
-        /// Copies the authentication properties to another instance.
-        /// </summary>
-        /// <param name="source">The source instance.</param>
-        /// <param name="destination">The destination instance.</param>
-        public static void CopyTo(
-            [NotNull] this AuthenticationProperties source,
-            [NotNull] AuthenticationProperties destination) {
-            if (source == null) {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (destination == null) {
-                throw new ArgumentNullException(nameof(destination));
-            }
-
-            // Don't copy values if the source
-            // and destination instances are identical.
-            if (ReferenceEquals(destination, source)) {
-                return;
-            }
-
-            foreach (var property in source.Items) {
-                destination.Items[property.Key] = property.Value;
-            }
-        }
-
-        /// <summary>
         /// Gets a given property from the authentication ticket.
         /// </summary>
         /// <param name="ticket">The authentication ticket.</param>

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -57,11 +57,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 return notification.AuthorizationCode;
             }
 
-            // Allow the application to change the authentication
-            // ticket from the SerializeAuthorizationCode event.
-            ticket = notification.Ticket;
-            ticket.Properties.CopyTo(properties);
-
             if (notification.DataFormat == null) {
                 return null;
             }
@@ -136,11 +131,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
             if (!string.IsNullOrEmpty(notification.AccessToken)) {
                 return notification.AccessToken;
             }
-
-            // Allow the application to change the authentication
-            // ticket from the SerializeAccessTokenAsync event.
-            ticket = notification.Ticket;
-            ticket.Properties.CopyTo(properties);
 
             if (notification.SecurityTokenHandler == null) {
                 return notification.DataFormat?.Protect(ticket);
@@ -333,11 +323,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 return notification.IdentityToken;
             }
 
-            // Allow the application to change the authentication
-            // ticket from the SerializeIdentityTokenAsync event.
-            ticket = notification.Ticket;
-            ticket.Properties.CopyTo(properties);
-
             if (notification.SecurityTokenHandler == null) {
                 return null;
             }
@@ -518,11 +503,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
             if (!string.IsNullOrEmpty(notification.RefreshToken)) {
                 return notification.RefreshToken;
             }
-
-            // Allow the application to change the authentication
-            // ticket from the SerializeRefreshTokenAsync event.
-            ticket = notification.Ticket;
-            ticket.Properties.CopyTo(properties);
 
             return notification.DataFormat?.Protect(ticket);
         }

--- a/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -609,33 +609,6 @@ namespace Owin.Security.OpenIdConnect.Extensions {
         }
 
         /// <summary>
-        /// Copies the authentication properties to another instance.
-        /// </summary>
-        /// <param name="source">The source instance.</param>
-        /// <param name="destination">The destination instance.</param>
-        public static void CopyTo(
-            [NotNull] this AuthenticationProperties source,
-            [NotNull] AuthenticationProperties destination) {
-            if (source == null) {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (destination == null) {
-                throw new ArgumentNullException(nameof(destination));
-            }
-
-            // Don't copy values if the source
-            // and destination instances are identical.
-            if (ReferenceEquals(destination, source)) {
-                return;
-            }
-
-            foreach (var property in source.Dictionary) {
-                destination.Dictionary[property.Key] = property.Value;
-            }
-        }
-
-        /// <summary>
         /// Gets a given property from the authentication ticket.
         /// </summary>
         /// <param name="ticket">The authentication ticket.</param>

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -58,11 +58,6 @@ namespace Owin.Security.OpenIdConnect.Server {
                 return notification.AuthorizationCode;
             }
 
-            // Allow the application to change the authentication
-            // ticket from the SerializeAuthorizationCode event.
-            ticket = notification.Ticket;
-            ticket.Properties.CopyTo(properties);
-
             if (notification.DataFormat == null) {
                 return null;
             }
@@ -135,11 +130,6 @@ namespace Owin.Security.OpenIdConnect.Server {
             if (!string.IsNullOrEmpty(notification.AccessToken)) {
                 return notification.AccessToken;
             }
-
-            // Allow the application to change the authentication
-            // ticket from the SerializeAccessTokenAsync event.
-            ticket = notification.Ticket;
-            ticket.Properties.CopyTo(properties);
 
             if (notification.SecurityTokenHandler == null) {
                 return notification.DataFormat?.Protect(ticket);
@@ -349,11 +339,6 @@ namespace Owin.Security.OpenIdConnect.Server {
                 return notification.IdentityToken;
             }
 
-            // Allow the application to change the authentication
-            // ticket from the SerializeIdentityTokenAsync event.
-            ticket = notification.Ticket;
-            ticket.Properties.CopyTo(properties);
-
             if (notification.SecurityTokenHandler == null) {
                 return null;
             }
@@ -538,11 +523,6 @@ namespace Owin.Security.OpenIdConnect.Server {
             if (!string.IsNullOrEmpty(notification.RefreshToken)) {
                 return notification.RefreshToken;
             }
-
-            // Allow the application to change the authentication
-            // ticket from the SerializeRefreshTokenAsync event.
-            ticket = notification.Ticket;
-            ticket.Properties.CopyTo(properties);
 
             return notification.DataFormat?.Protect(ticket);
         }


### PR DESCRIPTION
This extension is no longer necessary as the `Ticket` properties exposed by the `Serialize*Token` context classes have been updated to be read-only (custom claims and properties can still be added to `Ticket.Principal.Identity` and `Ticket.Properties` without replacing the `AuthenticationTicket` instance).