### PR TITLE
Update the introspection/discovery/token endpoints to support pass-through mode

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -507,6 +507,10 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 return;
             }
 
+            else if (notification.Skipped) {
+                return;
+            }
+
             await ApplyAuthorizationResponseAsync(request, response);
         }
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
@@ -89,6 +89,10 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 return true;
             }
 
+            else if (notification.Skipped) {
+                return false;
+            }
+
             return false;
         }
 
@@ -127,6 +131,10 @@ namespace AspNet.Security.OpenIdConnect.Server {
             await Options.Provider.ApplyLogoutResponse(notification);
 
             if (notification.HandledResponse) {
+                return;
+            }
+
+            else if (notification.Skipped) {
                 return;
             }
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -274,6 +274,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
                     writer.WriteLine("</html>");
                     writer.Flush();
 
+                    Response.StatusCode = 200;
                     Response.ContentLength = buffer.Length;
                     Response.ContentType = "text/html;charset=UTF-8";
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -400,12 +400,10 @@ namespace Owin.Security.OpenIdConnect.Server {
                 if (string.IsNullOrEmpty(response.Code)) {
                     Options.Logger.WriteError("SerializeAuthorizationCodeAsync returned no authorization code");
 
-                    await SendNativeErrorPageAsync(new OpenIdConnectMessage {
+                    return await SendNativeErrorPageAsync(new OpenIdConnectMessage {
                         Error = OpenIdConnectConstants.Errors.ServerError,
                         ErrorDescription = "no valid authorization code was issued"
                     });
-
-                    return true;
                 }
             }
 
@@ -446,12 +444,10 @@ namespace Owin.Security.OpenIdConnect.Server {
                 if (string.IsNullOrEmpty(response.AccessToken)) {
                     Options.Logger.WriteError("SerializeAccessTokenAsync returned no access token.");
 
-                    await SendNativeErrorPageAsync(new OpenIdConnectMessage {
+                    return await SendNativeErrorPageAsync(new OpenIdConnectMessage {
                         Error = OpenIdConnectConstants.Errors.ServerError,
                         ErrorDescription = "no valid access token was issued"
                     });
-
-                    return true;
                 }
 
                 // properties.ExpiresUtc is automatically set by SerializeAccessTokenAsync but the end user
@@ -478,12 +474,10 @@ namespace Owin.Security.OpenIdConnect.Server {
                 if (string.IsNullOrEmpty(response.IdToken)) {
                     Options.Logger.WriteError("SerializeIdentityTokenAsync returned no identity token.");
 
-                    await SendNativeErrorPageAsync(new OpenIdConnectMessage {
+                    return await SendNativeErrorPageAsync(new OpenIdConnectMessage {
                         Error = OpenIdConnectConstants.Errors.ServerError,
                         ErrorDescription = "no valid identity token was issued"
                     });
-
-                    return true;
                 }
             }
 
@@ -500,6 +494,10 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             if (notification.HandledResponse) {
                 return true;
+            }
+
+            else if (notification.Skipped) {
+                return false;
             }
 
             return await ApplyAuthorizationResponseAsync(request, response);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -20,7 +20,7 @@ using Owin.Security.OpenIdConnect.Extensions;
 
 namespace Owin.Security.OpenIdConnect.Server {
     internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions> {
-        private async Task InvokeIntrospectionEndpointAsync() {
+        private async Task<bool> InvokeIntrospectionEndpointAsync() {
             OpenIdConnectMessage request;
 
             // See https://tools.ietf.org/html/rfc7662#section-2.1
@@ -34,25 +34,21 @@ namespace Owin.Security.OpenIdConnect.Server {
             else if (string.Equals(Request.Method, "POST", StringComparison.OrdinalIgnoreCase)) {
                 // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization
                 if (string.IsNullOrEmpty(Request.ContentType)) {
-                    await SendErrorPayloadAsync(new OpenIdConnectMessage {
+                    return await SendErrorPayloadAsync(new OpenIdConnectMessage {
                         Error = OpenIdConnectConstants.Errors.InvalidRequest,
                         ErrorDescription = "A malformed introspection request has been received: " +
                             "the mandatory 'Content-Type' header was missing from the POST request."
                     });
-
-                    return;
                 }
 
                 // May have media/type; charset=utf-8, allow partial match.
                 if (!Request.ContentType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase)) {
-                    await SendErrorPayloadAsync(new OpenIdConnectMessage {
+                    return await SendErrorPayloadAsync(new OpenIdConnectMessage {
                         Error = OpenIdConnectConstants.Errors.InvalidRequest,
                         ErrorDescription = "A malformed introspection request has been received: " +
                             "the 'Content-Type' header contained an unexcepted value. " +
                             "Make sure to use 'application/x-www-form-urlencoded'."
                     });
-
-                    return;
                 }
 
                 request = new OpenIdConnectMessage(await Request.ReadFormAsync()) {
@@ -63,24 +59,23 @@ namespace Owin.Security.OpenIdConnect.Server {
             else {
                 Options.Logger.WriteInformation("A malformed request has been received by the introspection endpoint.");
 
-                await SendErrorPageAsync(new OpenIdConnectMessage {
+                return await SendErrorPageAsync(new OpenIdConnectMessage {
                     Error = OpenIdConnectConstants.Errors.InvalidRequest,
                     ErrorDescription = "A malformed introspection request has been received: " +
                                        "make sure to use either GET or POST."
                 });
-
-                return;
             }
 
             if (string.IsNullOrWhiteSpace(request.Token)) {
-                await SendErrorPayloadAsync(new OpenIdConnectMessage {
+                return await SendErrorPayloadAsync(new OpenIdConnectMessage {
                     Error = OpenIdConnectConstants.Errors.InvalidRequest,
                     ErrorDescription = "A malformed introspection request has been received: " +
                         "a 'token' parameter with an access, refresh, or identity token is required."
                 });
-
-                return;
             }
+
+            // Insert the introspection request in the OWIN context.
+            Context.SetOpenIdConnectRequest(request);
 
             // When client_id and client_secret are both null, try to extract them from the Authorization header.
             // See http://tools.ietf.org/html/rfc6749#section-2.3.1 and
@@ -110,25 +105,21 @@ namespace Owin.Security.OpenIdConnect.Server {
             if (validatingContext.IsRejected) {
                 Options.Logger.WriteError("The introspection request was rejected.");
 
-                await SendErrorPayloadAsync(new OpenIdConnectMessage {
+                return await SendErrorPayloadAsync(new OpenIdConnectMessage {
                     Error = validatingContext.Error ?? OpenIdConnectConstants.Errors.InvalidRequest,
                     ErrorDescription = validatingContext.ErrorDescription,
                     ErrorUri = validatingContext.ErrorUri
                 });
-
-                return;
             }
 
             // Ensure that the client_id has been set from the ValidateIntrospectionRequest event.
             else if (validatingContext.IsValidated && string.IsNullOrEmpty(request.ClientId)) {
                 Options.Logger.WriteError("The introspection request was validated but the client_id was not set.");
 
-                await SendErrorPayloadAsync(new OpenIdConnectMessage {
+                return await SendErrorPayloadAsync(new OpenIdConnectMessage {
                     Error = OpenIdConnectConstants.Errors.ServerError,
                     ErrorDescription = "An internal server error occurred."
                 });
-
-                return;
             }
 
             AuthenticationTicket ticket = null;
@@ -162,11 +153,9 @@ namespace Owin.Security.OpenIdConnect.Server {
             if (ticket == null) {
                 Options.Logger.WriteInformation("The introspection request was rejected because the token was invalid.");
 
-                await SendPayloadAsync(new JObject {
+                return await SendPayloadAsync(new JObject {
                     [OpenIdConnectConstants.Claims.Active] = false
                 });
-
-                return;
             }
 
             // Note: unlike refresh or identity tokens that can only be validated by client applications,
@@ -176,11 +165,9 @@ namespace Owin.Security.OpenIdConnect.Server {
                 Options.Logger.WriteWarning("The introspection request was rejected " +
                                             "because the caller was not authenticated.");
 
-                await SendPayloadAsync(new JObject {
+                return await SendPayloadAsync(new JObject {
                     [OpenIdConnectConstants.Claims.Active] = false
                 });
-
-                return;
             }
 
             // If the ticket is already expired, directly return active=false.
@@ -188,11 +175,9 @@ namespace Owin.Security.OpenIdConnect.Server {
                 ticket.Properties.ExpiresUtc < Options.SystemClock.UtcNow) {
                 Options.Logger.WriteVerbose("expired token");
 
-                await SendPayloadAsync(new JObject {
+                return await SendPayloadAsync(new JObject {
                     [OpenIdConnectConstants.Claims.Active] = false
                 });
-
-                return;
             }
 
             // When a client_id can be inferred from the introspection request,
@@ -204,11 +189,9 @@ namespace Owin.Security.OpenIdConnect.Server {
                     Options.Logger.WriteWarning("The introspection request was rejected because the access token " +
                                                 "was issued to a different client or for another resource server.");
 
-                    await SendPayloadAsync(new JObject {
+                    return await SendPayloadAsync(new JObject {
                         [OpenIdConnectConstants.Claims.Active] = false
                     });
-
-                    return;
                 }
 
                 // Reject the request if the caller is not listed as a valid audience.
@@ -216,11 +199,9 @@ namespace Owin.Security.OpenIdConnect.Server {
                     Options.Logger.WriteWarning("The introspection request was rejected because the " +
                                                 "identity token was issued to a different client.");
 
-                    await SendPayloadAsync(new JObject {
+                    return await SendPayloadAsync(new JObject {
                         [OpenIdConnectConstants.Claims.Active] = false
                     });
-
-                    return;
                 }
 
                 // Reject the introspection request if the caller doesn't
@@ -229,16 +210,11 @@ namespace Owin.Security.OpenIdConnect.Server {
                     Options.Logger.WriteWarning("The introspection request was rejected because the " +
                                                 "refresh token was issued to a different client.");
 
-                    await SendPayloadAsync(new JObject {
+                    return await SendPayloadAsync(new JObject {
                         [OpenIdConnectConstants.Claims.Active] = false
                     });
-
-                    return;
                 }
             }
-
-            // Insert the introspection request in the ASP.NET context.
-            Context.SetOpenIdConnectRequest(request);
 
             var notification = new HandleIntrospectionRequestContext(Context, Options, request, ticket);
             notification.Active = true;
@@ -309,7 +285,11 @@ namespace Owin.Security.OpenIdConnect.Server {
             ticket = notification.Ticket;
 
             if (notification.HandledResponse) {
-                return;
+                return true;
+            }
+
+            else if (notification.Skipped) {
+                return false;
             }
 
             var payload = new JObject();
@@ -376,7 +356,11 @@ namespace Owin.Security.OpenIdConnect.Server {
             await Options.Provider.ApplyIntrospectionResponse(context);
 
             if (context.HandledResponse) {
-                return;
+                return true;
+            }
+
+            else if (context.Skipped) {
+                return false;
             }
 
             using (var buffer = new MemoryStream())
@@ -393,6 +377,8 @@ namespace Owin.Security.OpenIdConnect.Server {
 
                 buffer.Seek(offset: 0, loc: SeekOrigin.Begin);
                 await buffer.CopyToAsync(Response.Body, 4096, Request.CallCancelled);
+
+                return true;
             }
         }
     }

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
@@ -84,6 +84,10 @@ namespace Owin.Security.OpenIdConnect.Server {
                 return true;
             }
 
+            else if (notification.Skipped) {
+                return false;
+            }
+
             return false;
         }
 
@@ -124,6 +128,10 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             if (notification.HandledResponse) {
                 return true;
+            }
+
+            else if (notification.Skipped) {
+                return false;
             }
 
             // Stop processing the request if no explicit

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -344,6 +344,7 @@ namespace Owin.Security.OpenIdConnect.Server {
                     writer.WriteLine("</html>");
                     writer.Flush();
 
+                    Response.StatusCode = 200;
                     Response.ContentLength = buffer.Length;
                     Response.ContentType = "text/html;charset=UTF-8";
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -191,12 +191,10 @@ namespace Owin.Security.OpenIdConnect.Server {
                 if (notification.IsAuthorizationEndpoint || notification.IsLogoutEndpoint) {
                     Options.Logger.WriteWarning("The HTTP request was rejected because AllowInsecureHttp was false.");
 
-                    await SendNativeErrorPageAsync(new OpenIdConnectMessage {
+                    return await SendNativeErrorPageAsync(new OpenIdConnectMessage {
                         Error = OpenIdConnectConstants.Errors.InvalidRequest,
                         ErrorDescription = "This server only accepts HTTPS requests."
                     });
-
-                    return true;
                 }
 
                 // Return a JSON error for endpoints that don't involve the user participation.
@@ -205,12 +203,10 @@ namespace Owin.Security.OpenIdConnect.Server {
                          notification.IsCryptographyEndpoint) {
                     Options.Logger.WriteWarning("The HTTP request was rejected because AllowInsecureHttp was false.");
 
-                    await SendErrorPayloadAsync(new OpenIdConnectMessage {
+                    return await SendErrorPayloadAsync(new OpenIdConnectMessage {
                         Error = OpenIdConnectConstants.Errors.InvalidRequest,
                         ErrorDescription = "This server only accepts HTTPS requests."
                     });
-
-                    return true;
                 }
             }
 
@@ -223,13 +219,11 @@ namespace Owin.Security.OpenIdConnect.Server {
             }
 
             else if (notification.IsTokenEndpoint) {
-                await InvokeTokenEndpointAsync();
-                return true;
+                return await InvokeTokenEndpointAsync();
             }
 
             else if (notification.IsIntrospectionEndpoint) {
-                await InvokeIntrospectionEndpointAsync();
-                return true;
+                return await InvokeIntrospectionEndpointAsync();
             }
 
             else if (notification.IsUserinfoEndpoint) {
@@ -237,13 +231,11 @@ namespace Owin.Security.OpenIdConnect.Server {
             }
 
             else if (notification.IsConfigurationEndpoint) {
-                await InvokeConfigurationEndpointAsync();
-                return true;
+                return await InvokeConfigurationEndpointAsync();
             }
 
             else if (notification.IsCryptographyEndpoint) {
-                await InvokeCryptographyEndpointAsync();
-                return true;
+                return await InvokeCryptographyEndpointAsync();
             }
 
             return false;
@@ -441,13 +433,10 @@ namespace Owin.Security.OpenIdConnect.Server {
             }
 
             // Render the default error page.
-            await SendNativeErrorPageAsync(response);
-
-            // Return true to stop processing the request.
-            return true;
+            return await SendNativeErrorPageAsync(response);
         }
 
-        private async Task SendNativeErrorPageAsync(OpenIdConnectMessage response) {
+        private async Task<bool> SendNativeErrorPageAsync(OpenIdConnectMessage response) {
             using (var buffer = new MemoryStream())
             using (var writer = new StreamWriter(buffer)) {
                 foreach (var parameter in response.Parameters) {
@@ -466,10 +455,13 @@ namespace Owin.Security.OpenIdConnect.Server {
 
                 buffer.Seek(offset: 0, loc: SeekOrigin.Begin);
                 await buffer.CopyToAsync(Response.Body, 4096, Request.CallCancelled);
+
+                // Return true to stop processing the request.
+                return true;
             }
         }
 
-        private async Task SendPayloadAsync(JToken payload) {
+        private async Task<bool> SendPayloadAsync(JToken payload) {
             using (var buffer = new MemoryStream())
             using (var writer = new JsonTextWriter(new StreamWriter(buffer))) {
                 payload.WriteTo(writer);
@@ -480,10 +472,13 @@ namespace Owin.Security.OpenIdConnect.Server {
 
                 buffer.Seek(offset: 0, loc: SeekOrigin.Begin);
                 await buffer.CopyToAsync(Response.Body, 4096, Request.CallCancelled);
+
+                // Return true to stop processing the request.
+                return true;
             }
         }
 
-        private async Task SendErrorPayloadAsync(OpenIdConnectMessage response) {
+        private async Task<bool> SendErrorPayloadAsync(OpenIdConnectMessage response) {
             using (var buffer = new MemoryStream())
             using (var writer = new JsonTextWriter(new StreamWriter(buffer))) {
                 var payload = new JObject();
@@ -511,6 +506,9 @@ namespace Owin.Security.OpenIdConnect.Server {
 
                 buffer.Seek(offset: 0, loc: SeekOrigin.Begin);
                 await buffer.CopyToAsync(Response.Body, 4096, Request.CallCancelled);
+
+                // Return true to stop processing the request.
+                return true;
             }
         }
 


### PR DESCRIPTION
The `introspection`/`configuration`/`cryptography`/`token` endpoints now support calling `SkipToNextMiddleware()` to bypass the default logic and invoke the next middleware in the pipeline, which allows advanced scenarios like handling `introspection`/`configuration`/`cryptography`/`token` requests outside ASOS (e.g in a MVC/Web API controller).