### PR TITLE
Update the OWIN/Katana bits to use the vNext Data Protection stack to encrypt the RSA keys and improve the keys directory detection logic

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
@@ -154,7 +154,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID"))) {
                 path = Environment.GetEnvironmentVariable("HOME");
                 if (!string.IsNullOrEmpty(path)) {
-                    return GetKeyStorageDirectoryFromBasePath(path);
+                    try {
+                        return GetKeyStorageDirectoryFromBasePath(path);
+                    }
+
+                    catch { }
                 }
             }
 
@@ -163,7 +167,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
             path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
             if (!string.IsNullOrEmpty(path)) {
-                return GetKeyStorageDirectoryFromBasePath(path);
+                try {
+                    return GetKeyStorageDirectoryFromBasePath(path);
+                }
+
+                catch { }
             }
 #else
 
@@ -171,41 +179,61 @@ namespace AspNet.Security.OpenIdConnect.Server {
             // using the LOCALAPPDATA environment variable.
             path = Environment.GetEnvironmentVariable("LOCALAPPDATA");
             if (!string.IsNullOrEmpty(path)) {
-                return GetKeyStorageDirectoryFromBasePath(path);
+                try {
+                    return GetKeyStorageDirectoryFromBasePath(path);
+                }
+
+                catch { }
             }
 
             // If the LOCALAPPDATA environment variable was not found,
             // try to determine the actual AppData/Local path from USERPROFILE.
             path = Environment.GetEnvironmentVariable("USERPROFILE");
             if (!string.IsNullOrEmpty(path)) {
-                return GetKeyStorageDirectoryFromBasePath(Path.Combine(path, "AppData", "Local"));
+                try {
+                    return GetKeyStorageDirectoryFromBasePath(Path.Combine(path, "AppData", "Local"));
+                }
+
+                catch { }
             }
 
             // On Linux environments, use the HOME variable.
             path = Environment.GetEnvironmentVariable("HOME");
             if (!string.IsNullOrEmpty(path)) {
-                return new DirectoryInfo(Path.Combine(path, ".aspnet", "aspnet-contrib", "aspnet-oidc-server"));
+                try {
+                    return Directory.CreateDirectory(Path.Combine(path, ".aspnet", "aspnet-contrib", "oidc-server"));
+                }
+
+                catch { }
             }
 #endif
 
             // Use the ASPNET_TEMP environment variable when specified.
             path = Environment.GetEnvironmentVariable("ASPNET_TEMP");
             if (!string.IsNullOrEmpty(path)) {
-                return GetKeyStorageDirectoryFromBasePath(path);
+                try {
+                    return GetKeyStorageDirectoryFromBasePath(path);
+                }
+
+                catch { }
             }
 
             // Note: returning the TEMP directory is safe as keys are always encrypted using the
             // data protection system, making the keys unreadable outside this environment.
             path = Path.GetTempPath();
             if (!string.IsNullOrEmpty(path)) {
-                return GetKeyStorageDirectoryFromBasePath(path);
+                try {
+                    return GetKeyStorageDirectoryFromBasePath(path);
+                }
+
+                catch { }
             }
 
             throw new InvalidOperationException("No directory can be found to store the RSA keys.");
         }
 
         private static DirectoryInfo GetKeyStorageDirectoryFromBasePath(string path) {
-            return new DirectoryInfo(Path.Combine(path, "ASP.NET", "aspnet-contrib", "aspnet-oidc-server"));
+            return Directory.CreateDirectory(Path.Combine(path, "ASP.NET", "aspnet-contrib", "oidc-server"));
         }
 
         internal static string GetIssuer(this HttpContext context, OpenIdConnectServerOptions options) {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
@@ -5,14 +5,19 @@
  */
 
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Text.Encodings.Web;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 
 namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
@@ -29,6 +34,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public OpenIdConnectServerMiddleware(
             [NotNull] RequestDelegate next,
             [NotNull] IOptions<OpenIdConnectServerOptions> options,
+            [NotNull] IHostingEnvironment environment,
             [NotNull] ILoggerFactory loggerFactory,
             [NotNull] IDistributedCache cache,
             [NotNull] HtmlEncoder htmlEncoder,
@@ -106,6 +112,75 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
             if (Options.HtmlEncoder == null) {
                 Options.HtmlEncoder = htmlEncoder;
+            }
+
+            // If no key has been explicitly added, use the fallback mode.
+            if (Options.SigningCredentials.Count == 0) {
+                if (environment.IsProduction()) {
+                    Logger.LogWarning("No explicit signing credentials have been registered. " +
+                                      "Using a X.509 certificate stored in the machine store " +
+                                      "is recommended for production environments.");
+                }
+
+                var directory = OpenIdConnectServerHelpers.GetDefaultKeyStorageDirectory();
+                Debug.Assert(directory != null);
+
+                // Get a data protector from the services provider.
+                var protector = dataProtectionProvider.CreateProtector(
+                    nameof(OpenIdConnectServerMiddleware),
+                    Options.AuthenticationScheme, "Keys", "v1");
+
+                foreach (var file in directory.EnumerateFiles("*.key")) {
+                    using (var buffer = new MemoryStream())
+                    using (var stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.Read)) {
+                        // Copy the key content to the buffer.
+                        stream.CopyTo(buffer);
+
+                        // Extract the key material using the data protector.
+                        // Ignore the key if the decryption process failed.
+                        string usage;
+                        var parameters = OpenIdConnectServerHelpers.DecryptKey(protector, buffer.ToArray(), out usage);
+                        if (parameters == null) {
+                            Logger.LogDebug("An invalid/incompatible key was ignored: {Key}.", file.FullName);
+
+                            continue;
+                        }
+
+                        // Only add the key if it corresponds to the intended usage.
+                        if (!string.Equals(usage, "Signing", StringComparison.OrdinalIgnoreCase)) {
+                            continue;
+                        }
+
+                        Logger.LogInformation("An existing key was automatically added to the " +
+                                              "signing credentials list: {Key}.", file.FullName);
+
+                        // Add the key to the signing credentials list.
+                        Options.SigningCredentials.AddKey(new RsaSecurityKey(parameters.Value));
+                    }
+                }
+
+                // If no signing key has been found, generate and persist a new RSA key.
+                if (Options.SigningCredentials.Count == 0) {
+                    // Generate a new RSA key and export its public/private parameters.
+                    var provider = OpenIdConnectServerHelpers.GenerateKey(size: 2048);
+                    var parameters = provider.ExportParameters(/* includePrivateParameters */ true);
+
+                    // Generate a new file name for the key and determine its absolute path.
+                    var path = Path.Combine(directory.FullName, Guid.NewGuid().ToString() + ".key");
+
+                    using (var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write)) {
+                        // Encrypt the key using the data protector.
+                        var bytes = OpenIdConnectServerHelpers.EncryptKey(protector, parameters, usage: "Signing");
+
+                        // Write the encrypted key to the file stream.
+                        stream.Write(bytes, 0, bytes.Length);
+                    }
+
+                    Logger.LogInformation("A new RSA key was automatically generated, added to the " +
+                                          "signing credentials list and persisted on the disk: {Path}.", path);
+
+                    Options.SigningCredentials.AddKey(new RsaSecurityKey(parameters));
+                }
             }
         }
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
@@ -19,7 +19,6 @@ using Microsoft.IdentityModel.Protocols;
 using Microsoft.Owin;
 using Microsoft.Owin.BuilderProperties;
 using Microsoft.Owin.Security;
-using Microsoft.Owin.Security.DataProtection;
 using Owin.Security.OpenIdConnect.Extensions;
 using Owin.Security.OpenIdConnect.Server;
 
@@ -58,7 +57,7 @@ namespace Owin {
 
             configuration(options);
 
-            return app.UseOpenIdConnectServer(options);
+            return app.Use(typeof(OpenIdConnectServerMiddleware), app, options);
         }
 
         /// <summary>
@@ -76,122 +75,6 @@ namespace Owin {
 
             if (options == null) {
                 throw new ArgumentNullException(nameof(options));
-            }
-
-            // If no key has been explicitly added, use the fallback mode.
-            if (options.EncryptingCredentials.Count == 0 ||
-                options.SigningCredentials.Count == 0) {
-                var directory = OpenIdConnectServerHelpers.GetDefaultKeyStorageDirectory();
-
-                // Ensure the directory exists.
-                if (!directory.Exists) {
-                    directory.Create();
-                    directory.Refresh();
-                }
-
-                // Get a data protector from the services provider.
-                var protector = app.CreateDataProtector(
-                    typeof(OpenIdConnectServerMiddleware).Namespace,
-                    options.AuthenticationType, "Keys", "v1");
-
-                // Initialize a default logger if none has been explicitly registered.
-                var logger = options.Logger ?? new LoggerFactory().CreateLogger<OpenIdConnectServerMiddleware>();
-
-                foreach (var file in directory.EnumerateFiles("*.key")) {
-                    using (var buffer = new MemoryStream())
-                    using (var stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.Read)) {
-                        // Copy the key content to the buffer.
-                        stream.CopyTo(buffer);
-
-                        // Extract the key material using the data protector.
-                        // Ignore the key if the decryption process failed.
-                        string usage;
-                        var parameters = OpenIdConnectServerHelpers.DecryptKey(protector, buffer.ToArray(), out usage);
-                        if (parameters == null) {
-                            logger.LogDebug("An invalid/incompatible key was ignored: {Key}.", file.FullName);
-
-                            continue;
-                        }
-
-                        if (string.Equals(usage, "Encryption", StringComparison.OrdinalIgnoreCase)) {
-                            // Only add the encryption key if none has been explictly added.
-                            if (options.EncryptingCredentials.Count != 0) {
-                                continue;
-                            }
-
-                            var algorithm = RSA.Create();
-                            algorithm.ImportParameters(parameters.Value);
-
-                            // Add the key to the encryption credentials list.
-                            options.EncryptingCredentials.AddKey(new RsaSecurityKey(algorithm));
-
-                            logger.LogInformation("An existing key was automatically added to the " +
-                                                  "encryption credentials list: {Key}.", file.FullName);
-                        }
-
-                        else if (string.Equals(usage, "Signing", StringComparison.OrdinalIgnoreCase)) {
-                            // Only add the signing key if none has been explictly added.
-                            if (options.SigningCredentials.Count != 0) {
-                                continue;
-                            }
-
-                            var algorithm = RSA.Create();
-                            algorithm.ImportParameters(parameters.Value);
-
-                            // Add the key to the signing credentials list.
-                            options.SigningCredentials.AddKey(new RsaSecurityKey(algorithm));
-
-                            logger.LogInformation("An existing key was automatically added to the " +
-                                                  "signing credentials list: {Key}.", file.FullName);
-                        }
-                    }
-                }
-
-                // If no encryption key has been found, generate and persist a new RSA key.
-                if (options.EncryptingCredentials.Count == 0) {
-                    // Generate a new RSA key and export its public/private parameters.
-                    var algorithm = OpenIdConnectServerHelpers.GenerateKey(size: 2048);
-                    var parameters = algorithm.ExportParameters(/* includePrivateParameters: */ true);
-
-                    // Generate a new file name for the key and determine its absolute path.
-                    var path = Path.Combine(directory.FullName, Guid.NewGuid().ToString() + ".key");
-
-                    using (var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write)) {
-                        // Encrypt the key using the data protector.
-                        var bytes = OpenIdConnectServerHelpers.EncryptKey(protector, parameters, usage: "Encryption");
-
-                        // Write the encrypted key to the file stream.
-                        stream.Write(bytes, 0, bytes.Length);
-                    }
-
-                    options.EncryptingCredentials.AddKey(new RsaSecurityKey(algorithm));
-
-                    logger.LogInformation("A new RSA key was automatically generated, added to the " +
-                                          "encryption credentials list and persisted on the disk: {Path}.", path);
-                }
-
-                // If no signing key has been found, generate and persist a new RSA key.
-                if (options.SigningCredentials.Count == 0) {
-                    // Generate a new RSA key and export its public/private parameters.
-                    var algorithm = OpenIdConnectServerHelpers.GenerateKey(size: 2048);
-                    var parameters = algorithm.ExportParameters(/* includePrivateParameters: */ true);
-
-                    // Generate a new file name for the key and determine its absolute path.
-                    var path = Path.Combine(directory.FullName, Guid.NewGuid().ToString() + ".key");
-
-                    using (var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write)) {
-                        // Encrypt the key using the data protector.
-                        var bytes = OpenIdConnectServerHelpers.EncryptKey(protector, parameters, usage: "Signing");
-
-                        // Write the encrypted key to the file stream.
-                        stream.Write(bytes, 0, bytes.Length);
-                    }
-
-                    options.SigningCredentials.AddKey(new RsaSecurityKey(algorithm));
-
-                    logger.LogInformation("A new RSA key was automatically generated, added to the " +
-                                          "signing credentials list and persisted on the disk: {Path}.", path);
-                }
             }
 
             return app.Use(typeof(OpenIdConnectServerMiddleware), app, options);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
@@ -4,8 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Owin;
-using Microsoft.Owin.Security.DataProtection;
 
 namespace Owin.Security.OpenIdConnect.Server {
     internal static class OpenIdConnectServerHelpers {
@@ -146,7 +146,11 @@ namespace Owin.Security.OpenIdConnect.Server {
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID"))) {
                 path = Environment.GetEnvironmentVariable("HOME");
                 if (!string.IsNullOrEmpty(path)) {
-                    return GetKeyStorageDirectoryFromBasePath(path);
+                    try {
+                        return GetKeyStorageDirectoryFromBasePath(path);
+                    }
+
+                    catch { }
                 }
             }
 
@@ -154,47 +158,49 @@ namespace Owin.Security.OpenIdConnect.Server {
             path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
             if (!string.IsNullOrEmpty(path)) {
-                return GetKeyStorageDirectoryFromBasePath(path);
-            }
+                try {
+                    return GetKeyStorageDirectoryFromBasePath(path);
+                }
 
-            // Try to resolve the AppData/Local folder
-            // using the LOCALAPPDATA environment variable.
-            path = Environment.GetEnvironmentVariable("LOCALAPPDATA");
-            if (!string.IsNullOrEmpty(path)) {
-                return GetKeyStorageDirectoryFromBasePath(path);
-            }
-
-            // If the LOCALAPPDATA environment variable was not found,
-            // try to determine the actual AppData/Local path from USERPROFILE.
-            path = Environment.GetEnvironmentVariable("USERPROFILE");
-            if (!string.IsNullOrEmpty(path)) {
-                return GetKeyStorageDirectoryFromBasePath(Path.Combine(path, "AppData", "Local"));
+                catch { }
             }
 
             // On Linux environments, use the HOME variable.
             path = Environment.GetEnvironmentVariable("HOME");
             if (!string.IsNullOrEmpty(path)) {
-                return new DirectoryInfo(Path.Combine(path, ".aspnet", "aspnet-contrib", "owin-oidc-server"));
+                try {
+                    return Directory.CreateDirectory(Path.Combine(path, ".aspnet", "aspnet-contrib", "oidc-server"));
+                }
+
+                catch { }
             }
 
             // Use the ASPNET_TEMP environment variable when specified.
             path = Environment.GetEnvironmentVariable("ASPNET_TEMP");
             if (!string.IsNullOrEmpty(path)) {
-                return GetKeyStorageDirectoryFromBasePath(path);
+                try {
+                    return GetKeyStorageDirectoryFromBasePath(path);
+                }
+
+                catch { }
             }
 
             // Note: returning the TEMP directory is safe as keys are always encrypted using the
             // data protection system, making the keys unreadable outside this environment.
             path = Path.GetTempPath();
             if (!string.IsNullOrEmpty(path)) {
-                return GetKeyStorageDirectoryFromBasePath(path);
+                try {
+                    return GetKeyStorageDirectoryFromBasePath(path);
+                }
+
+                catch { }
             }
 
             throw new InvalidOperationException("No directory can be found to store the RSA keys.");
         }
 
         private static DirectoryInfo GetKeyStorageDirectoryFromBasePath(string path) {
-            return new DirectoryInfo(Path.Combine(path, "ASP.NET", "aspnet-contrib", "owin-oidc-server"));
+            return Directory.CreateDirectory(Path.Combine(path, "ASP.NET", "aspnet-contrib", "oidc-server"));
         }
 
         internal static string GetIssuer(this IOwinContext context, OpenIdConnectServerOptions options) {


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/252.