### PR TITLE
Rework the resources/scopes handling to avoid returning a refresh token exposing a limited set of resources/scopes

### DIFF
--- a/samples/Mvc/Mvc.Client/Startup.cs
+++ b/samples/Mvc/Mvc.Client/Startup.cs
@@ -33,6 +33,11 @@ namespace Mvc.Client {
                 RequireHttpsMetadata = false,
                 SaveTokens = true,
 
+                // Note: setting the Authority allows the OIDC client middleware to automatically
+                // retrieve the identity provider's configuration and spare you from setting
+                // the different endpoints URIs or the token validation parameters explicitly.
+                Authority = "http://localhost:54540/",
+
                 // Note: these settings must match the application details
                 // inserted in the database at the server level.
                 ClientId = "myClient",
@@ -42,10 +47,8 @@ namespace Mvc.Client {
                 // Use the authorization code flow.
                 ResponseType = OpenIdConnectResponseTypes.Code,
 
-                // Note: setting the Authority allows the OIDC client middleware to automatically
-                // retrieve the identity provider's configuration and spare you from setting
-                // the different endpoints URIs or the token validation parameters explicitly.
-                Authority = "http://localhost:54540/"
+                // Specify the "offline_access" scope to retrieve a refresh token.
+                Scope = { "offline_access" }
             });
 
             app.UseStaticFiles();

--- a/samples/Mvc/Mvc.Server/Controllers/AuthorizationController.cs
+++ b/samples/Mvc/Mvc.Server/Controllers/AuthorizationController.cs
@@ -137,7 +137,8 @@ namespace Mvc.Server.Controllers {
             ticket.SetScopes(new[] {
                 /* openid: */ OpenIdConnectConstants.Scopes.OpenId,
                 /* email: */ OpenIdConnectConstants.Scopes.Email,
-                /* profile: */ OpenIdConnectConstants.Scopes.Profile
+                /* profile: */ OpenIdConnectConstants.Scopes.Profile,
+                /* offline_access: */ OpenIdConnectConstants.Scopes.OfflineAccess
             }.Intersect(request.GetScopes()));
 
             // Set the resources servers the access token should be issued for.

--- a/samples/Nancy/Nancy.Client/Startup.cs
+++ b/samples/Nancy/Nancy.Client/Startup.cs
@@ -26,6 +26,11 @@ namespace Nancy.Client {
             app.UseOpenIdConnectAuthentication(new OpenIdConnectAuthenticationOptions {
                 AuthenticationMode = AuthenticationMode.Active,
 
+                // Note: setting the Authority allows the OIDC client middleware to automatically
+                // retrieve the identity provider's configuration and spare you from setting
+                // the different endpoints URIs or the token validation parameters explicitly.
+                Authority = "http://localhost:54541/",
+
                 // Note: these settings must match the application details inserted in
                 // the database at the server level (see ApplicationContextInitializer.cs).
                 ClientId = "myClient",
@@ -33,10 +38,7 @@ namespace Nancy.Client {
                 RedirectUri = "http://localhost:56765/oidc",
                 PostLogoutRedirectUri = "http://localhost:56765/",
 
-                // Note: setting the Authority allows the OIDC client middleware to automatically
-                // retrieve the identity provider's configuration and spare you from setting
-                // the different endpoints URIs or the token validation parameters explicitly.
-                Authority = "http://localhost:54541/",
+                Scope = "openid profile offline_access",
 
                 // Note: by default, the OIDC client throws an OpenIdConnectProtocolException
                 // when an error occurred during the authentication/authorization process.

--- a/samples/Nancy/Nancy.Server/Modules/AuthorizationModule.cs
+++ b/samples/Nancy/Nancy.Server/Modules/AuthorizationModule.cs
@@ -130,7 +130,8 @@ namespace Nancy.Server.Modules {
                 ticket.SetScopes(new[] {
                     /* openid: */ OpenIdConnectConstants.Scopes.OpenId,
                     /* email: */ OpenIdConnectConstants.Scopes.Email,
-                    /* profile: */ OpenIdConnectConstants.Scopes.Profile
+                    /* profile: */ OpenIdConnectConstants.Scopes.Profile,
+                    /* offline_access: */ OpenIdConnectConstants.Scopes.OfflineAccess
                 }.Intersect(request.GetScopes()));
 
                 // Set the resources servers the access token should be issued for.

--- a/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -28,7 +28,9 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(message));
             }
 
-            return message.Resource?.Split(' ') ?? Enumerable.Empty<string>();
+            return message.Resource?.Split(' ')
+                                   ?.Distinct(StringComparer.Ordinal)
+                   ?? Enumerable.Empty<string>();
         }
 
         /// <summary>
@@ -40,7 +42,9 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(message));
             }
 
-            return message.Scope?.Split(' ') ?? Enumerable.Empty<string>();
+            return message.Scope?.Split(' ')
+                                ?.Distinct(StringComparer.Ordinal)
+                   ?? Enumerable.Empty<string>();
         }
 
         /// <summary>
@@ -598,22 +602,40 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
         }
 
         /// <summary>
+        /// Gets a given property from the authentication properties.
+        /// </summary>
+        /// <param name="properties">The authentication properties.</param>
+        /// <param name="property">The specific property to look for.</param>
+        /// <returns>The value corresponding to the property, or <c>null</c> if the property cannot be found.</returns>
+        public static string GetProperty([NotNull] this AuthenticationProperties properties, [NotNull] string property) {
+            if (properties == null) {
+                throw new ArgumentNullException(nameof(properties));
+            }
+
+            if (string.IsNullOrEmpty(property)) {
+                throw new ArgumentException($"{nameof(property)} cannot be null or empty.", nameof(property));
+            }
+
+            string value;
+            if (!properties.Items.TryGetValue(property, out value)) {
+                return null;
+            }
+
+            return value;
+        }
+
+        /// <summary>
         /// Gets a given property from the authentication ticket.
         /// </summary>
         /// <param name="ticket">The authentication ticket.</param>
         /// <param name="property">The specific property to look for.</param>
         /// <returns>The value corresponding to the property, or <c>null</c> if the property cannot be found.</returns>
-        public static string GetProperty([NotNull] this AuthenticationTicket ticket, string property) {
+        public static string GetProperty([NotNull] this AuthenticationTicket ticket, [NotNull] string property) {
             if (ticket == null) {
                 throw new ArgumentNullException(nameof(ticket));
             }
 
-            string value;
-            if (!ticket.Properties.Items.TryGetValue(property, out value)) {
-                return null;
-            }
-
-            return value;
+            return ticket.Properties.GetProperty(property);
         }
 
         /// <summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/SerializeRefreshTokenContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/SerializeRefreshTokenContext.cs
@@ -37,11 +37,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
         }
 
         /// <summary>
-        /// Gets the authentication ticket to serialize.
-        /// </summary>
-        public AuthenticationTicket Ticket { get; }
-
-        /// <summary>
         /// Gets the options used by the OpenID Connect server.
         /// </summary>
         public OpenIdConnectServerOptions Options { get; }

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -420,24 +420,18 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 // to avoid modifying the properties set on the original ticket.
                 var properties = new AuthenticationProperties(context.Properties).Copy();
 
-                string resources;
-                if (!properties.Items.TryGetValue(OpenIdConnectConstants.Properties.Resources, out resources)) {
-                    Logger.LogInformation("No explicit resource was associated with the authentication ticket: " +
-                                          "the access token will be issued without any audience attached.");
-                }
-
                 // Note: when the "resource" parameter added to the OpenID Connect response
-                // is identical to the request parameter, setting it is not necessary.
-                if (!string.IsNullOrEmpty(request.Resource) &&
+                // is identical to the request parameter, returning it is not necessary.
+                var resources = properties.GetProperty(OpenIdConnectConstants.Properties.Resources);
+                if (!string.IsNullOrEmpty(request.Resource) && !string.IsNullOrEmpty(resources) &&
                     !string.Equals(request.Resource, resources, StringComparison.Ordinal)) {
                     response.Resource = resources;
                 }
 
                 // Note: when the "scope" parameter added to the OpenID Connect response
-                // is identical to the request parameter, setting it is not necessary.
-                string scopes;
-                properties.Items.TryGetValue(OpenIdConnectConstants.Properties.Scopes, out scopes);
-                if (!string.IsNullOrEmpty(request.Scope) &&
+                // is identical to the request parameter, returning it is not necessary.
+                var scopes = properties.GetProperty(OpenIdConnectConstants.Properties.Scopes);
+                if (!string.IsNullOrEmpty(request.Scope) && !string.IsNullOrEmpty(scopes) &&
                     !string.Equals(request.Scope, scopes, StringComparison.Ordinal)) {
                     response.Scope = scopes;
                 }

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -156,6 +156,10 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 throw new InvalidOperationException("The authentication ticket cannot be replaced.");
             }
 
+            if (!notification.Audiences.Any()) {
+                Logger.LogInformation("No explicit audience was associated with the access token.");
+            }
+
             if (notification.SecurityTokenHandler == null) {
                 return notification.DataFormat?.Protect(ticket);
             }
@@ -179,7 +183,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
             // Create a new claim per scope item, that will result
             // in a "scope" array being added in the access token.
-            foreach (var scope in ticket.GetScopes()) {
+            foreach (var scope in notification.Scopes) {
                 identity.AddClaim(OpenIdConnectConstants.Claims.Scope, scope);
             }
 
@@ -206,13 +210,12 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 }
 
                 // Store the audiences as claims.
-                foreach (var audience in ticket.GetAudiences()) {
+                foreach (var audience in notification.Audiences) {
                     identity.AddClaim(OpenIdConnectConstants.Claims.Audience, audience);
                 }
 
                 // Extract the presenters from the authentication ticket.
-                var presenters = ticket.GetPresenters().ToArray();
-
+                var presenters = notification.Presenters.ToArray();
                 switch (presenters.Length) {
                     case 0: break;
 
@@ -375,7 +378,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             }
 
             // Store the audiences as claims.
-            foreach (var audience in ticket.GetAudiences()) {
+            foreach (var audience in notification.Audiences) {
                 identity.AddClaim(OpenIdConnectConstants.Claims.Audience, audience);
             }
 
@@ -418,8 +421,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             }
 
             // Extract the presenters from the authentication ticket.
-            var presenters = ticket.GetPresenters().ToArray();
-
+            var presenters = notification.Presenters.ToArray();
             switch (presenters.Length) {
                 case 0: break;
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -73,7 +73,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             }
 
             // Missing or invalid requests are ignored in HandleAuthenticateAsync:
-            // in this case, Skip is used to indicate authentication failed.
+            // in this case, Skip is used to indicate that authentication failed.
             if (request == null) {
                 return AuthenticateResult.Skip();
             }

--- a/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -39,7 +39,9 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(message));
             }
 
-            return message.Resource?.Split(' ') ?? Enumerable.Empty<string>();
+            return message.Resource?.Split(' ')
+                                   ?.Distinct(StringComparer.Ordinal)
+                   ?? Enumerable.Empty<string>();
         }
 
         /// <summary>
@@ -51,7 +53,9 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(message));
             }
 
-            return message.Scope?.Split(' ') ?? Enumerable.Empty<string>();
+            return message.Scope?.Split(' ')
+                                ?.Distinct(StringComparer.Ordinal)
+                   ?? Enumerable.Empty<string>();
         }
 
         /// <summary>
@@ -609,22 +613,40 @@ namespace Owin.Security.OpenIdConnect.Extensions {
         }
 
         /// <summary>
+        /// Gets a given property from the authentication properties.
+        /// </summary>
+        /// <param name="properties">The authentication properties.</param>
+        /// <param name="property">The specific property to look for.</param>
+        /// <returns>The value corresponding to the property, or <c>null</c> if the property cannot be found.</returns>
+        public static string GetProperty([NotNull] this AuthenticationProperties properties, [NotNull] string property) {
+            if (properties == null) {
+                throw new ArgumentNullException(nameof(properties));
+            }
+
+            if (string.IsNullOrEmpty(property)) {
+                throw new ArgumentException($"{nameof(property)} cannot be null or empty.", nameof(property));
+            }
+
+            string value;
+            if (!properties.Dictionary.TryGetValue(property, out value)) {
+                return null;
+            }
+
+            return value;
+        }
+
+        /// <summary>
         /// Gets a given property from the authentication ticket.
         /// </summary>
         /// <param name="ticket">The authentication ticket.</param>
         /// <param name="property">The specific property to look for.</param>
         /// <returns>The value corresponding to the property, or <c>null</c> if the property cannot be found.</returns>
-        public static string GetProperty([NotNull] this AuthenticationTicket ticket, string property) {
+        public static string GetProperty([NotNull] this AuthenticationTicket ticket, [NotNull] string property) {
             if (ticket == null) {
                 throw new ArgumentNullException(nameof(ticket));
             }
 
-            string value;
-            if (!ticket.Properties.Dictionary.TryGetValue(property, out value)) {
-                return null;
-            }
-
-            return value;
+            return ticket.Properties.GetProperty(property);
         }
 
         /// <summary>

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -419,24 +419,18 @@ namespace Owin.Security.OpenIdConnect.Server {
                 // to avoid modifying the properties set on the original ticket.
                 var properties = context.Properties.Copy();
 
-                string resources;
-                if (!properties.Dictionary.TryGetValue(OpenIdConnectConstants.Properties.Resources, out resources)) {
-                    Options.Logger.LogInformation("No explicit resource was associated with the authentication ticket: " +
-                                                  "the access token will be issued without any audience attached.");
-                }
-
                 // Note: when the "resource" parameter added to the OpenID Connect response
-                // is identical to the request parameter, setting it is not necessary.
-                if (!string.IsNullOrEmpty(request.Resource) &&
+                // is identical to the request parameter, returning it is not necessary.
+                var resources = properties.GetProperty(OpenIdConnectConstants.Properties.Resources);
+                if (!string.IsNullOrEmpty(request.Resource) && !string.IsNullOrEmpty(resources) &&
                     !string.Equals(request.Resource, resources, StringComparison.Ordinal)) {
                     response.Resource = resources;
                 }
 
                 // Note: when the "scope" parameter added to the OpenID Connect response
-                // is identical to the request parameter, setting it is not necessary.
-                string scopes;
-                properties.Dictionary.TryGetValue(OpenIdConnectConstants.Properties.Scopes, out scopes);
-                if (!string.IsNullOrEmpty(request.Scope) &&
+                // is identical to the request parameter, returning it is not necessary.
+                var scopes = properties.GetProperty(OpenIdConnectConstants.Properties.Scopes);
+                if (!string.IsNullOrEmpty(request.Scope) && !string.IsNullOrEmpty(scopes) &&
                     !string.Equals(request.Scope, scopes, StringComparison.Ordinal)) {
                     response.Scope = scopes;
                 }

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
@@ -279,9 +279,36 @@ namespace Owin.Security.OpenIdConnect.Server {
                     }
                 }
 
-                if (!string.IsNullOrEmpty(request.Scope)) {
+                if (request.IsRefreshTokenGrantType() && !string.IsNullOrEmpty(request.Resource)) {
+                    // When an explicit resource parameter has been included in the token request
+                    // but was missing from the initial request, the request MUST be rejected.
+                    var resources = ticket.GetResources();
+                    if (!resources.Any()) {
+                        Options.Logger.LogError("The token request was rejected because the 'resource' parameter was not allowed.");
+
+                        return await SendTokenResponseAsync(request, new OpenIdConnectMessage {
+                            Error = OpenIdConnectConstants.Errors.InvalidGrant,
+                            ErrorDescription = "Token request cannot contain a resource parameter" +
+                                               "if the authorization request didn't contain one"
+                        });
+                    }
+
+                    // When an explicit resource parameter has been included in the token request,
+                    // the authorization server MUST ensure that it doesn't contain resources
+                    // that were not allowed during the initial authorization/token request.
+                    else if (!new HashSet<string>(resources).IsSupersetOf(request.GetResources())) {
+                        Options.Logger.LogError("The token request was rejected because the 'resource' parameter was not valid.");
+
+                        return await SendTokenResponseAsync(request, new OpenIdConnectMessage {
+                            Error = OpenIdConnectConstants.Errors.InvalidGrant,
+                            ErrorDescription = "Token request doesn't contain a valid resource parameter"
+                        });
+                    }
+                }
+
+                if (request.IsRefreshTokenGrantType() && !string.IsNullOrEmpty(request.Scope)) {
                     // When an explicit scope parameter has been included in the token request
-                    // but was missing from the authorization request, the request MUST be rejected.
+                    // but was missing from the initial request, the request MUST be rejected.
                     // See http://tools.ietf.org/html/rfc6749#section-6
                     var scopes = ticket.GetScopes();
                     if (!scopes.Any()) {
@@ -296,7 +323,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
                     // When an explicit scope parameter has been included in the token request,
                     // the authorization server MUST ensure that it doesn't contain scopes
-                    // that were not allowed during the authorization request.
+                    // that were not allowed during the initial authorization/token request.
                     // See https://tools.ietf.org/html/rfc6749#section-6
                     else if (!new HashSet<string>(scopes).IsSupersetOf(request.GetScopes())) {
                         Options.Logger.LogError("The token request was rejected because the 'scope' parameter was not valid.");
@@ -306,10 +333,6 @@ namespace Owin.Security.OpenIdConnect.Server {
                             ErrorDescription = "Token request doesn't contain a valid scope parameter"
                         });
                     }
-
-                    // Replace the scopes initially granted by the scopes
-                    // listed by the client application in the token request.
-                    ticket.SetScopes(request.GetScopes());
                 }
 
                 if (request.IsAuthorizationCodeGrantType()) {
@@ -476,24 +499,38 @@ namespace Owin.Security.OpenIdConnect.Server {
                 // to avoid modifying the properties set on the original ticket.
                 var properties = ticket.Properties.Copy();
 
-                string resources;
-                if (!properties.Dictionary.TryGetValue(OpenIdConnectConstants.Properties.Resources, out resources)) {
-                    Options.Logger.LogInformation("No explicit resource has been associated with the authentication ticket: " +
-                                                  "the access token will thus be issued without any audience attached.");
+                // When receiving a grant_type=refresh_token request, determine whether the client application
+                // requests a limited set of resources and replace the "resources" property if necessary.
+                if (request.IsRefreshTokenGrantType() && !string.IsNullOrEmpty(request.Resource)) {
+                    // Replace the resources initially granted by the resources listed by the client application in the token request.
+                    // Note: at this stage, request.GetResources() cannot return more items than the ones that were initially granted
+                    // by the resource owner as the "resources" parameter is always validated when receiving the token request.
+                    properties.Dictionary[OpenIdConnectConstants.Properties.Resources] = string.Join(" ", request.GetResources());
                 }
 
                 // Note: when the "resource" parameter added to the OpenID Connect response
-                // is identical to the request parameter, keeping it is not necessary.
-                if (request.IsAuthorizationCodeGrantType() || (!string.IsNullOrEmpty(request.Resource) &&
+                // is identical to the request parameter, returning it is not necessary.
+                var resources = properties.GetProperty(OpenIdConnectConstants.Properties.Resources);
+                if (request.IsAuthorizationCodeGrantType() || (!string.IsNullOrEmpty(resources) &&
+                                                               !string.IsNullOrEmpty(request.Resource) &&
                                                                !string.Equals(request.Resource, resources, StringComparison.Ordinal))) {
                     response.Resource = resources;
                 }
 
+                // When receiving a grant_type=refresh_token request, determine whether the client application
+                // requests a limited set of scopes and replace the "scopes" property if necessary.
+                if (request.IsRefreshTokenGrantType() && !string.IsNullOrEmpty(request.Scope)) {
+                    // Replace the scopes initially granted by the scopes listed by the client application in the token request.
+                    // Note: at this stage, request.GetScopes() cannot return more items than the ones that were initially granted
+                    // by the resource owner as the "scope" parameter is always validated when receiving the token request.
+                    properties.Dictionary[OpenIdConnectConstants.Properties.Scopes] = string.Join(" ", request.GetScopes());
+                }
+
                 // Note: when the "scope" parameter added to the OpenID Connect response
-                // is identical to the request parameter, keeping it is not necessary.
-                string scopes;
-                properties.Dictionary.TryGetValue(OpenIdConnectConstants.Properties.Scopes, out scopes);
-                if (request.IsAuthorizationCodeGrantType() || (!string.IsNullOrEmpty(request.Scope) &&
+                // is identical to the request parameter, returning it is not necessary.
+                var scopes = properties.GetProperty(OpenIdConnectConstants.Properties.Scopes);
+                if (request.IsAuthorizationCodeGrantType() || (!string.IsNullOrEmpty(scopes) &&
+                                                               !string.IsNullOrEmpty(request.Scope) &&
                                                                !string.Equals(request.Scope, scopes, StringComparison.Ordinal))) {
                     response.Scope = scopes;
                 }

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -147,6 +147,10 @@ namespace Owin.Security.OpenIdConnect.Server {
                 return null;
             }
 
+            if (!notification.Audiences.Any()) {
+                Options.Logger.LogInformation("No explicit audience was associated with the access token.");
+            }
+
             if (notification.SecurityTokenHandler == null) {
                 return notification.DataFormat?.Protect(ticket);
             }
@@ -167,7 +171,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             // Create a new claim per scope item, that will result
             // in a "scope" array being added in the access token.
-            foreach (var scope in ticket.GetScopes()) {
+            foreach (var scope in notification.Scopes) {
                 ticket.Identity.AddClaim(OpenIdConnectConstants.Claims.Scope, scope);
             }
 
@@ -194,13 +198,12 @@ namespace Owin.Security.OpenIdConnect.Server {
                 }
 
                 // Store the audiences as claims.
-                foreach (var audience in ticket.GetAudiences()) {
+                foreach (var audience in notification.Audiences) {
                     ticket.Identity.AddClaim(OpenIdConnectConstants.Claims.Audience, audience);
                 }
 
                 // Extract the presenters from the authentication ticket.
-                var presenters = ticket.GetPresenters().ToArray();
-
+                var presenters = notification.Presenters.ToArray();
                 switch (presenters.Length) {
                     case 0: break;
 
@@ -370,7 +373,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             }
 
             // Store the audiences as claims.
-            foreach (var audience in ticket.GetAudiences()) {
+            foreach (var audience in notification.Audiences) {
                 ticket.Identity.AddClaim(OpenIdConnectConstants.Claims.Audience, audience);
             }
 
@@ -413,8 +416,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             }
 
             // Extract the presenters from the authentication ticket.
-            var presenters = ticket.GetPresenters().ToArray();
-
+            var presenters = notification.Presenters.ToArray();
             switch (presenters.Length) {
                 case 0: break;
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -18,8 +18,6 @@ using Owin.Security.OpenIdConnect.Extensions;
 
 namespace Owin.Security.OpenIdConnect.Server {
     internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions> {
-        // Implementing AuthenticateCoreAsync allows the inner application
-        // to retrieve the identity extracted from the optional id_token_hint.
         protected override async Task<AuthenticationTicket> AuthenticateCoreAsync() {
             var notification = new MatchEndpointContext(Context, Options);
 
@@ -71,7 +69,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             }
 
             // Missing or invalid requests are ignored in AuthenticateCoreAsync:
-            // in this case, null is always returned to indicate authentication failed.
+            // in this case, null is returned to indicate that authentication failed.
             if (request == null) {
                 return null;
             }


### PR DESCRIPTION
In the current bits, specifying a `scope` parameter in a refresh token request controls the `scopes` list associated with all the tokens issued by ASOS as part of the refresh token response, not just the access token. In practice, it means that the refresh token gets a more limited scope than the one initially granted, as requested by the client application when specifying an explicit `scope` parameter in the refresh token request.

Though logical and convenient, this is not fully standard compliant, as the `scope` parameter should only affect the access token and not the list stored in the refresh token, which must be the same as the one retrieved from the original refresh token.

> If a new refresh token is issued, the refresh token scope MUST be identical to that of the refresh token included by the client in the request.

This PR extends the same concept to `resource`.