### PR TITLE
Implement token revocation support

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
+++ b/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
@@ -88,6 +88,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             public const string UnauthorizedClient = "unauthorized_client";
             public const string UnsupportedGrantType = "unsupported_grant_type";
             public const string UnsupportedResponseType = "unsupported_response_type";
+            public const string UnsupportedTokenType = "unsupported_token_type";
         }
 
         public static class GrantTypes {
@@ -182,14 +183,20 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             public const string Public = "public";
         }
 
+        public static class TokenTypeHints {
+            public const string AccessToken = "access_token";
+            public const string IdToken = "id_token";
+            public const string RefreshToken = "refresh_token";
+        }
+
         public static class TokenTypes {
             public const string Bearer = "Bearer";
         }
 
         public static class Usages {
             public const string AccessToken = "access_token";
-            public const string Code = "code";
-            public const string IdToken = "id_token";
+            public const string AuthorizationCode = "code";
+            public const string IdentityToken = "id_token";
             public const string RefreshToken = "refresh_token";
         }
     }

--- a/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -908,7 +908,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.Usages.Code, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.Usages.AuthorizationCode, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -946,7 +946,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.Usages.IdToken, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.Usages.IdentityToken, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ApplyRevocationResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ApplyRevocationResponseContext.cs
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using AspNet.Security.OpenIdConnect.Extensions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Newtonsoft.Json.Linq;
+
+namespace AspNet.Security.OpenIdConnect.Server {
+    /// <summary>
+    /// An event raised before the authorization server starts
+    /// writing the revocation response to the response stream.
+    /// </summary>
+    public class ApplyRevocationResponseContext : BaseControlContext {
+        /// <summary>
+        /// Creates an instance of this context.
+        /// </summary>
+        public ApplyRevocationResponseContext(
+            HttpContext context,
+            OpenIdConnectServerOptions options,
+            OpenIdConnectMessage request,
+            JObject response)
+            : base(context) {
+            Options = options;
+            Request = Request;
+            Response = response;
+        }
+
+        /// <summary>
+        /// Gets the options used by the OpenID Connect server.
+        /// </summary>
+        public OpenIdConnectServerOptions Options { get; }
+
+        /// <summary>
+        /// Gets the revocation request. 
+        /// </summary>
+        public new OpenIdConnectMessage Request { get; }
+
+        /// <summary>
+        /// Gets the JSON payload returned to the caller.
+        /// </summary>
+        public new JObject Response { get; }
+
+        /// <summary>
+        /// Gets the error code returned to the client application.
+        /// When the response indicates a successful response,
+        /// this property returns <c>null</c>.
+        /// </summary>
+        public string Error => Response[OpenIdConnectConstants.Parameters.Error]?.Value<string>();
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/HandleRevocationRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/HandleRevocationRequestContext.cs
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace AspNet.Security.OpenIdConnect.Server {
+    /// <summary>
+    /// An event raised before the authorization server handles
+    /// the request made to the token revocation endpoint.
+    /// </summary>
+    public class HandleRevocationRequestContext : BaseControlContext {
+        /// <summary>
+        /// Creates an instance of this context.
+        /// </summary>
+        public HandleRevocationRequestContext(
+            HttpContext context,
+            OpenIdConnectServerOptions options,
+            OpenIdConnectMessage request,
+            AuthenticationTicket ticket)
+            : base(context) {
+            Options = options;
+            Request = request;
+            Ticket = ticket;
+        }
+
+        /// <summary>
+        /// Gets the options used by the OpenID Connect server.
+        /// </summary>
+        public OpenIdConnectServerOptions Options { get; }
+
+        /// <summary>
+        /// Gets the revocation request.
+        /// </summary>
+        public new OpenIdConnectMessage Request { get; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether
+        /// the token was successfully revoked.
+        /// </summary>
+        public bool Revoked { get; set; }
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/MatchEndpointContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/MatchEndpointContext.cs
@@ -48,6 +48,21 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public bool IsCryptographyEndpoint { get; private set; }
 
         /// <summary>
+        /// Gets whether or not the endpoint is an introspection endpoint.
+        /// </summary>
+        public bool IsIntrospectionEndpoint { get; private set; }
+
+        /// <summary>
+        /// Gets whether or not the endpoint is a logout endpoint.
+        /// </summary>
+        public bool IsLogoutEndpoint { get; private set; }
+
+        /// <summary>
+        /// Gets whether or not the endpoint is a revocation endpoint.
+        /// </summary>
+        public bool IsRevocationEndpoint { get; private set; }
+
+        /// <summary>
         /// Gets whether or not the endpoint is an
         /// OAuth2/OpenID Connect token endpoint.
         /// </summary>
@@ -59,26 +74,17 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public bool IsUserinfoEndpoint { get; private set; }
 
         /// <summary>
-        /// Gets whether or not the endpoint is an introspection endpoint.
-        /// </summary>
-        public bool IsIntrospectionEndpoint { get; private set; }
-
-        /// <summary>
-        /// Gets whether or not the endpoint is a logout endpoint.
-        /// </summary>
-        public bool IsLogoutEndpoint { get; private set; }
-
-        /// <summary>
         /// Sets the endpoint type to the authorization endpoint.
         /// </summary>
         public void MatchesAuthorizationEndpoint() {
             IsAuthorizationEndpoint = true;
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = false;
             IsIntrospectionEndpoint = false;
             IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
         }
 
         /// <summary>
@@ -88,10 +94,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsAuthorizationEndpoint = false;
             IsConfigurationEndpoint = true;
             IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = false;
             IsIntrospectionEndpoint = false;
             IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
         }
 
         /// <summary>
@@ -101,36 +108,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsAuthorizationEndpoint = false;
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = true;
+            IsIntrospectionEndpoint = false;
+            IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
             IsTokenEndpoint = false;
             IsUserinfoEndpoint = false;
-            IsIntrospectionEndpoint = false;
-            IsLogoutEndpoint = false;
-        }
-
-        /// <summary>
-        /// Sets the endpoint type to token endpoint.
-        /// </summary>
-        public void MatchesTokenEndpoint() {
-            IsAuthorizationEndpoint = false;
-            IsConfigurationEndpoint = false;
-            IsCryptographyEndpoint = false;
-            IsTokenEndpoint = true;
-            IsUserinfoEndpoint = false;
-            IsIntrospectionEndpoint = false;
-            IsLogoutEndpoint = false;
-        }
-
-        /// <summary>
-        /// Sets the endpoint type to userinfo endpoint.
-        /// </summary>
-        public void MatchesUserinfoEndpoint() {
-            IsAuthorizationEndpoint = false;
-            IsConfigurationEndpoint = false;
-            IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = true;
-            IsIntrospectionEndpoint = false;
-            IsLogoutEndpoint = false;
         }
 
         /// <summary>
@@ -140,10 +122,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsAuthorizationEndpoint = false;
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = false;
             IsIntrospectionEndpoint = true;
             IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
         }
 
         /// <summary>
@@ -153,10 +136,53 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsAuthorizationEndpoint = false;
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = false;
             IsIntrospectionEndpoint = false;
             IsLogoutEndpoint = true;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
+        }
+
+        /// <summary>
+        /// Sets the endpoint type to revocation endpoint.
+        /// </summary>
+        public void MatchesRevocationEndpoint() {
+            IsAuthorizationEndpoint = false;
+            IsConfigurationEndpoint = false;
+            IsCryptographyEndpoint = false;
+            IsIntrospectionEndpoint = false;
+            IsLogoutEndpoint = false;
+            IsRevocationEndpoint = true;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
+        }
+
+        /// <summary>
+        /// Sets the endpoint type to token endpoint.
+        /// </summary>
+        public void MatchesTokenEndpoint() {
+            IsAuthorizationEndpoint = false;
+            IsConfigurationEndpoint = false;
+            IsCryptographyEndpoint = false;
+            IsIntrospectionEndpoint = false;
+            IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = true;
+            IsUserinfoEndpoint = false;
+        }
+
+        /// <summary>
+        /// Sets the endpoint type to userinfo endpoint.
+        /// </summary>
+        public void MatchesUserinfoEndpoint() {
+            IsAuthorizationEndpoint = false;
+            IsConfigurationEndpoint = false;
+            IsCryptographyEndpoint = false;
+            IsIntrospectionEndpoint = false;
+            IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = true;
         }
 
         /// <summary>
@@ -166,10 +192,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
             IsAuthorizationEndpoint = false;
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = false;
             IsIntrospectionEndpoint = false;
             IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
         }
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateIntrospectionRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateIntrospectionRequestContext.cs
@@ -4,6 +4,7 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using AspNet.Security.OpenIdConnect.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
@@ -24,5 +25,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
             OpenIdConnectMessage request)
             : base(context, options, request) {
         }
+
+        /// <summary>
+        /// Gets the optional token_type_hint parameter extracted from the
+        /// introspection request, or <c>null</c> if it cannot be found.
+        /// </summary>
+        public string TokenTypeHint => Request.GetParameter(OpenIdConnectConstants.Parameters.TokenTypeHint);
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateRevocationRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ValidateRevocationRequestContext.cs
@@ -4,23 +4,23 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-using Microsoft.IdentityModel.Protocols;
-using Microsoft.Owin;
-using Owin.Security.OpenIdConnect.Extensions;
+using AspNet.Security.OpenIdConnect.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
-namespace Owin.Security.OpenIdConnect.Server {
+namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
-    /// Provides context information used when validating an introspection request.
+    /// Provides context information used when validating a revocation request.
     /// </summary>
-    public class ValidateIntrospectionRequestContext : BaseValidatingClientContext {
+    public class ValidateRevocationRequestContext : BaseValidatingClientContext {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ValidateIntrospectionRequestContext"/> class.
+        /// Initializes a new instance of the <see cref="ValidateRevocationRequestContext"/> class.
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
         /// <param name="request"></param>
-        public ValidateIntrospectionRequestContext(
-            IOwinContext context,
+        public ValidateRevocationRequestContext(
+            HttpContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)
             : base(context, options, request) {
@@ -28,7 +28,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Gets the optional token_type_hint parameter extracted from the
-        /// introspection request, or <c>null</c> if it cannot be found.
+        /// revocation request, or <c>null</c> if it cannot be found.
         /// </summary>
         public string TokenTypeHint => Request.GetParameter(OpenIdConnectConstants.Parameters.TokenTypeHint);
     }

--- a/src/AspNet.Security.OpenIdConnect.Server/IOpenIdConnectServerProvider.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/IOpenIdConnectServerProvider.cs
@@ -60,6 +60,13 @@ namespace AspNet.Security.OpenIdConnect.Server {
         Task ValidateLogoutRequest(ValidateLogoutRequestContext context);
 
         /// <summary>
+        /// Called for each request to the revocation endpoint to determine if the request is valid and should continue.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        Task ValidateRevocationRequest(ValidateRevocationRequestContext context);
+
+        /// <summary>
         /// Called for each request to the token endpoint to determine if the request is valid and should continue.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -188,6 +195,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
         Task HandleLogoutRequest(HandleLogoutRequestContext context);
 
         /// <summary>
+        /// Called by the client applications to revoke an access or refresh token.
+        /// An application may implement this call in order to do any final modification to the revocation response.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        Task HandleRevocationRequest(HandleRevocationRequestContext context);
+
+        /// <summary>
         /// Called at the final stage of a successful Token endpoint request.
         /// An application may implement this call in order to do any final 
         /// modification of the claims being used to issue access or refresh tokens. 
@@ -255,6 +270,15 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
         Task ApplyLogoutResponse(ApplyLogoutResponseContext context);
+
+        /// <summary>
+        /// Called before the authorization server starts emitting the revocation response to the response stream.
+        /// If the web application wishes to produce the token status and metadata directly in this call, it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        Task ApplyRevocationResponse(ApplyRevocationResponseContext context);
 
         /// <summary>
         /// Called before the TokenEndpoint redirects its response to the caller.

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerDefaults.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerDefaults.cs
@@ -32,16 +32,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public const string CryptographyEndpointPath = "/.well-known/jwks";
 
         /// <summary>
-        /// Default value for <see cref="OpenIdConnectServerOptions.TokenEndpointPath"/>.
-        /// </summary>
-        public const string TokenEndpointPath = "/connect/token";
-
-        /// <summary>
-        /// Default value for <see cref="OpenIdConnectServerOptions.UserinfoEndpointPath"/>.
-        /// </summary>
-        public const string UserinfoEndpointPath = "/connect/userinfo";
-
-        /// <summary>
         /// Default value for <see cref="OpenIdConnectServerOptions.IntrospectionEndpointPath"/>.
         /// </summary>
         public const string IntrospectionEndpointPath = "/connect/introspect";
@@ -50,5 +40,20 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// Default value for <see cref="OpenIdConnectServerOptions.LogoutEndpointPath"/>.
         /// </summary>
         public const string LogoutEndpointPath = "/connect/logout";
+
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.RevocationEndpointPath"/>.
+        /// </summary>
+        public const string RevocationEndpointPath = "/connect/revoke";
+
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.TokenEndpointPath"/>.
+        /// </summary>
+        public const string TokenEndpointPath = "/connect/token";
+
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.UserinfoEndpointPath"/>.
+        /// </summary>
+        public const string UserinfoEndpointPath = "/connect/userinfo";
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -137,16 +137,16 @@ namespace AspNet.Security.OpenIdConnect.Server {
             // the type of the token sent by the client application.
             // See https://tools.ietf.org/html/rfc7662#section-2.1
             switch (request.GetTokenTypeHint()) {
-                case OpenIdConnectConstants.Usages.AccessToken:
+                case OpenIdConnectConstants.TokenTypeHints.AccessToken:
                     ticket = await DeserializeAccessTokenAsync(request.GetToken(), request);
                     break;
 
-                case OpenIdConnectConstants.Usages.RefreshToken:
-                    ticket = await DeserializeRefreshTokenAsync(request.GetToken(), request);
+                case OpenIdConnectConstants.TokenTypeHints.IdToken:
+                    ticket = await DeserializeIdentityTokenAsync(request.GetToken(), request);
                     break;
 
-                case OpenIdConnectConstants.Usages.IdToken:
-                    ticket = await DeserializeIdentityTokenAsync(request.GetToken(), request);
+                case OpenIdConnectConstants.TokenTypeHints.RefreshToken:
+                    ticket = await DeserializeRefreshTokenAsync(request.GetToken(), request);
                     break;
             }
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -1,0 +1,227 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using AspNet.Security.OpenIdConnect.Extensions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.Net.Http.Headers;
+using Newtonsoft.Json.Linq;
+
+namespace AspNet.Security.OpenIdConnect.Server {
+    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions> {
+        private async Task<bool> InvokeRevocationEndpointAsync() {
+            if (!string.Equals(Request.Method, "POST", StringComparison.OrdinalIgnoreCase)) {
+                Logger.LogError("The revocation request was rejected because an invalid " +
+                                "HTTP method was received: {Method}.", Request.Method);
+
+                return await SendRevocationResponseAsync(null, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                    ErrorDescription = "A malformed revocation request has been received: " +
+                                       "make sure to use either GET or POST."
+                });
+            }
+
+            // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization
+            if (string.IsNullOrEmpty(Request.ContentType)) {
+                Logger.LogError("The revocation request was rejected because " +
+                                "the mandatory 'Content-Type' header was missing.");
+
+                return await SendRevocationResponseAsync(null, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                    ErrorDescription = "A malformed revocation request has been received: " +
+                        "the mandatory 'Content-Type' header was missing from the POST request."
+                });
+            }
+
+            // May have media/type; charset=utf-8, allow partial match.
+            if (!Request.ContentType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase)) {
+                Logger.LogError("The revocation request was rejected because an invalid 'Content-Type' " +
+                                "header was received: {ContentType}.", Request.ContentType);
+
+                return await SendRevocationResponseAsync(null, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                    ErrorDescription = "A malformed revocation request has been received: " +
+                        "the 'Content-Type' header contained an unexcepted value. " +
+                        "Make sure to use 'application/x-www-form-urlencoded'."
+                });
+            }
+
+            var form = await Request.ReadFormAsync(Context.RequestAborted);
+
+            var request = new OpenIdConnectMessage(form.ToDictionary());
+
+            if (string.IsNullOrWhiteSpace(request.GetToken())) {
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                    ErrorDescription = "A malformed revocation request has been received: " +
+                        "a 'token' parameter with an access or refresh token is required."
+                });
+            }
+
+            // Insert the revocation request in the ASP.NET context.
+            Context.SetOpenIdConnectRequest(request);
+
+            // When client_id and client_secret are both null, try to extract them from the Authorization header.
+            // See http://tools.ietf.org/html/rfc6749#section-2.3.1 and
+            // http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
+            if (string.IsNullOrEmpty(request.ClientId) && string.IsNullOrEmpty(request.ClientSecret)) {
+                string header = Request.Headers[HeaderNames.Authorization];
+                if (!string.IsNullOrEmpty(header) && header.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase)) {
+                    try {
+                        var value = header.Substring("Basic ".Length).Trim();
+                        var data = Encoding.UTF8.GetString(Convert.FromBase64String(value));
+
+                        var index = data.IndexOf(':');
+                        if (index >= 0) {
+                            request.ClientId = data.Substring(0, index);
+                            request.ClientSecret = data.Substring(index + 1);
+                        }
+                    }
+
+                    catch (FormatException) { }
+                    catch (ArgumentException) { }
+                }
+            }
+
+            var context = new ValidateRevocationRequestContext(Context, Options, request);
+            await Options.Provider.ValidateRevocationRequest(context);
+
+            if (context.IsRejected) {
+                Logger.LogInformation("The revocation request was rejected by application code.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = context.Error ?? OpenIdConnectConstants.Errors.InvalidRequest,
+                    ErrorDescription = context.ErrorDescription,
+                    ErrorUri = context.ErrorUri
+                });
+            }
+
+            // Ensure that the client_id has been set from the ValidateRevocationRequest event.
+            else if (context.IsValidated && string.IsNullOrEmpty(request.ClientId)) {
+                Logger.LogError("The revocation request was validated but the client_id was not set.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.ServerError,
+                    ErrorDescription = "An internal server error occurred."
+                });
+            }
+
+            AuthenticationTicket ticket = null;
+
+            // Note: use the "token_type_hint" parameter to determine
+            // the type of the token sent by the client application.
+            // See https://tools.ietf.org/html/rfc7009#section-2.1
+            switch (request.GetTokenTypeHint()) {
+                case OpenIdConnectConstants.TokenTypeHints.AccessToken:
+                    ticket = await DeserializeAccessTokenAsync(request.GetToken(), request);
+                    break;
+
+                case OpenIdConnectConstants.TokenTypeHints.RefreshToken:
+                    ticket = await DeserializeRefreshTokenAsync(request.GetToken(), request);
+                    break;
+            }
+
+            // Note: if the token can't be found using "token_type_hint",
+            // the search must be extended to all supported token types.
+            // See https://tools.ietf.org/html/rfc7009#section-2.1
+            if (ticket == null) {
+                ticket = await DeserializeAccessTokenAsync(request.GetToken(), request) ??
+                         await DeserializeRefreshTokenAsync(request.GetToken(), request);
+            }
+
+            if (ticket == null) {
+                Logger.LogInformation("The revocation request was ignored because the token was invalid.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage());
+            }
+
+            // If the ticket is already expired, directly return a 200 response.
+            else if (ticket.Properties.ExpiresUtc.HasValue &&
+                     ticket.Properties.ExpiresUtc < Options.SystemClock.UtcNow) {
+                Logger.LogInformation("The revocation request was ignored because the token was already expired.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage());
+            }
+
+            // Note: unlike refresh tokens that can only be revoked by client applications,
+            // access tokens can be revoked by either resource servers or client applications:
+            // in both cases, the caller must be authenticated if the ticket is marked as confidential.
+            if (context.IsSkipped && ticket.IsConfidential()) {
+                Logger.LogWarning("The revocation request was rejected because the caller was not authenticated.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest
+                });
+            }
+
+            // When a client_id can be inferred from the revocation request,
+            // ensure that the client application is an authorized presenter.
+            if (!string.IsNullOrEmpty(request.ClientId) && ticket.HasPresenter() &&
+                                                          !ticket.HasPresenter(request.ClientId)) {
+                Logger.LogWarning("The revocation request was rejected because the " +
+                                  "refresh token was issued to a different client.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest
+                });
+            }
+
+            var notification = new HandleRevocationRequestContext(Context, Options, request, ticket);
+            await Options.Provider.HandleRevocationRequest(notification);
+
+            if (notification.HandledResponse) {
+                return true;
+            }
+
+            else if (notification.Skipped) {
+                return false;
+            }
+
+            if (!notification.Revoked) {
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.UnsupportedTokenType,
+                    ErrorDescription = "The token cannot be revoked."
+                });
+            }
+
+            return await SendRevocationResponseAsync(request, new JObject());
+        }
+
+        private Task<bool> SendRevocationResponseAsync(OpenIdConnectMessage request, OpenIdConnectMessage response) {
+            var payload = new JObject();
+
+            foreach (var parameter in response.Parameters) {
+                payload[parameter.Key] = parameter.Value;
+            }
+
+            return SendRevocationResponseAsync(request, payload);
+        }
+
+        private async Task<bool> SendRevocationResponseAsync(OpenIdConnectMessage request, JObject response) {
+            if (request == null) {
+                request = new OpenIdConnectMessage();
+            }
+
+            var notification = new ApplyRevocationResponseContext(Context, Options, request, response);
+            await Options.Provider.ApplyRevocationResponse(notification);
+
+            if (notification.HandledResponse) {
+                return true;
+            }
+
+            else if (notification.Skipped) {
+                return false;
+            }
+
+            return await SendPayloadAsync(response);
+        }
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -39,7 +39,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             // SerializeAccessTokenAsync and SerializeIdentityTokenAsync are responsible of ensuring
             // that subsequent access and identity tokens are correctly filtered.
             var ticket = new AuthenticationTicket(principal, properties, Options.AuthenticationScheme);
-            ticket.SetUsage(OpenIdConnectConstants.Usages.Code);
+            ticket.SetUsage(OpenIdConnectConstants.Usages.AuthorizationCode);
 
             // Associate a random identifier with the authorization code.
             ticket.SetTicketId(Guid.NewGuid().ToString());
@@ -306,7 +306,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
             // Create a new ticket containing the updated properties and the filtered principal.
             var ticket = new AuthenticationTicket(principal, properties, Options.AuthenticationScheme);
-            ticket.SetUsage(OpenIdConnectConstants.Usages.IdToken);
+            ticket.SetUsage(OpenIdConnectConstants.Usages.IdentityToken);
 
             // Associate a random identifier with the identity token.
             ticket.SetTicketId(Guid.NewGuid().ToString());

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -148,26 +148,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 notification.MatchesAuthorizationEndpoint();
             }
 
-            else if (Options.TokenEndpointPath.HasValue &&
-                     Options.TokenEndpointPath == Request.Path) {
-                notification.MatchesTokenEndpoint();
-            }
-
-            else if (Options.IntrospectionEndpointPath.HasValue &&
-                     Options.IntrospectionEndpointPath == Request.Path) {
-                notification.MatchesIntrospectionEndpoint();
-            }
-
-            else if (Options.UserinfoEndpointPath.HasValue &&
-                     Options.UserinfoEndpointPath == Request.Path) {
-                notification.MatchesUserinfoEndpoint();
-            }
-
-            else if (Options.LogoutEndpointPath.HasValue &&
-                     Options.LogoutEndpointPath == Request.Path) {
-                notification.MatchesLogoutEndpoint();
-            }
-
             else if (Options.ConfigurationEndpointPath.HasValue &&
                      Options.ConfigurationEndpointPath == Request.Path) {
                 notification.MatchesConfigurationEndpoint();
@@ -176,6 +156,31 @@ namespace AspNet.Security.OpenIdConnect.Server {
             else if (Options.CryptographyEndpointPath.HasValue &&
                      Options.CryptographyEndpointPath == Request.Path) {
                 notification.MatchesCryptographyEndpoint();
+            }
+
+            else if (Options.IntrospectionEndpointPath.HasValue &&
+                     Options.IntrospectionEndpointPath == Request.Path) {
+                notification.MatchesIntrospectionEndpoint();
+            }
+
+            else if (Options.LogoutEndpointPath.HasValue &&
+                     Options.LogoutEndpointPath == Request.Path) {
+                notification.MatchesLogoutEndpoint();
+            }
+
+            else if (Options.RevocationEndpointPath.HasValue &&
+                     Options.RevocationEndpointPath == Request.Path) {
+                notification.MatchesRevocationEndpoint();
+            }
+
+            else if (Options.TokenEndpointPath.HasValue &&
+                     Options.TokenEndpointPath == Request.Path) {
+                notification.MatchesTokenEndpoint();
+            }
+
+            else if (Options.UserinfoEndpointPath.HasValue &&
+                     Options.UserinfoEndpointPath == Request.Path) {
+                notification.MatchesUserinfoEndpoint();
             }
 
             await Options.Provider.MatchEndpoint(notification);
@@ -203,9 +208,9 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 }
 
                 // Return a JSON error for endpoints that don't involve the user participation.
-                else if (notification.IsTokenEndpoint || notification.IsUserinfoEndpoint ||
-                         notification.IsIntrospectionEndpoint || notification.IsConfigurationEndpoint ||
-                         notification.IsCryptographyEndpoint) {
+                else if (notification.IsConfigurationEndpoint || notification.IsCryptographyEndpoint ||
+                         notification.IsIntrospectionEndpoint || notification.IsRevocationEndpoint ||
+                         notification.IsTokenEndpoint || notification.IsUserinfoEndpoint) {
                     Logger.LogWarning("The current request was rejected because the OpenID Connect server middleware " +
                                       "has been configured to reject HTTP requests. To permanently disable the transport " +
                                       "security requirement, set 'OpenIdConnectServerOptions.AllowInsecureHttp' to 'true'.");
@@ -221,28 +226,32 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 return await InvokeAuthorizationEndpointAsync();
             }
 
-            else if (notification.IsLogoutEndpoint) {
-                return await InvokeLogoutEndpointAsync();
-            }
-
-            else if (notification.IsTokenEndpoint) {
-                return await InvokeTokenEndpointAsync();
-            }
-
-            else if (notification.IsIntrospectionEndpoint) {
-                return await InvokeIntrospectionEndpointAsync();
-            }
-
-            else if (notification.IsUserinfoEndpoint) {
-                return await InvokeUserinfoEndpointAsync();
-            }
-
             else if (notification.IsConfigurationEndpoint) {
                 return await InvokeConfigurationEndpointAsync();
             }
 
             else if (notification.IsCryptographyEndpoint) {
                 return await InvokeCryptographyEndpointAsync();
+            }
+
+            else if (notification.IsIntrospectionEndpoint) {
+                return await InvokeIntrospectionEndpointAsync();
+            }
+
+            else if (notification.IsLogoutEndpoint) {
+                return await InvokeLogoutEndpointAsync();
+            }
+
+            else if (notification.IsRevocationEndpoint) {
+                return await InvokeRevocationEndpointAsync();
+            }
+
+            else if (notification.IsTokenEndpoint) {
+                return await InvokeTokenEndpointAsync();
+            }
+
+            else if (notification.IsUserinfoEndpoint) {
+                return await InvokeUserinfoEndpointAsync();
             }
 
             return false;

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
@@ -66,20 +66,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public PathString CryptographyEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.CryptographyEndpointPath);
 
         /// <summary>
-        /// The request path client applications communicate with directly as part of the OpenID Connect protocol. 
-        /// Must begin with a leading slash, like "/connect/token". If the client is issued a client_secret, it must
-        /// be provided to this endpoint. You can set it to <see cref="PathString.Empty"/> to disable the token endpoint.
-        /// </summary>
-        public PathString TokenEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.TokenEndpointPath);
-
-        /// <summary>
-        /// The request path client applications communicate with to retrieve user information. 
-        /// Must begin with a leading slash, like "/connect/userinfo".
-        /// You can set it to <see cref="PathString.Empty"/> to disable the userinfo endpoint.
-        /// </summary>
-        public PathString UserinfoEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.UserinfoEndpointPath);
-
-        /// <summary>
         /// The request path client applications communicate with to validate an access, identity or refresh token.
         /// Must begin with a leading slash, like "/connect/introspect".
         /// You can set it to <see cref="PathString.Empty"/> to disable the introspection endpoint.
@@ -92,6 +78,27 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// You can set it to <see cref="PathString.Empty"/> to disable the logout endpoint.
         /// </summary>
         public PathString LogoutEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.LogoutEndpointPath);
+
+        /// <summary>
+        /// The request path client applications communicate with to revoke an access or refresh token.
+        /// Must begin with a leading slash, like "/connect/revoke".
+        /// You can set it to <see cref="PathString.Empty"/> to disable the revocation endpoint.
+        /// </summary>
+        public PathString RevocationEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.RevocationEndpointPath);
+
+        /// <summary>
+        /// The request path client applications communicate with directly as part of the OpenID Connect protocol. 
+        /// Must begin with a leading slash, like "/connect/token". If the client is issued a client_secret, it must
+        /// be provided to this endpoint. You can set it to <see cref="PathString.Empty"/> to disable the token endpoint.
+        /// </summary>
+        public PathString TokenEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.TokenEndpointPath);
+
+        /// <summary>
+        /// The request path client applications communicate with to retrieve user information. 
+        /// Must begin with a leading slash, like "/connect/userinfo".
+        /// You can set it to <see cref="PathString.Empty"/> to disable the userinfo endpoint.
+        /// </summary>
+        public PathString UserinfoEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.UserinfoEndpointPath);
 
         /// <summary>
         /// Specifies a <see cref="IOpenIdConnectServerProvider"/> that the <see cref="OpenIdConnectServerMiddleware" /> invokes

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
@@ -46,6 +46,11 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public Func<ValidateIntrospectionRequestContext, Task> OnValidateIntrospectionRequest { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
+        /// Called for each request to the revocation endpoint to determine if the request is valid and should continue.
+        /// </summary>
+        public Func<ValidateRevocationRequestContext, Task> OnValidateRevocationRequest { get; set; } = context => Task.FromResult<object>(null);
+
+        /// <summary>
         /// Called for each request to the logout endpoint to determine if the request is valid and should continue.
         /// </summary>
         public Func<ValidateLogoutRequestContext, Task> OnValidateLogoutRequest { get; set; } = context => Task.FromResult<object>(null);
@@ -155,6 +160,12 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public Func<HandleLogoutRequestContext, Task> OnHandleLogoutRequest { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
+        /// Called by the client applications to revoke an access or refresh token.
+        /// An application may implement this call in order to do any final modification to the revocation response.
+        /// </summary>
+        public Func<HandleRevocationRequestContext, Task> OnHandleRevocationRequest { get; set; } = context => Task.FromResult<object>(null);
+
+        /// <summary>
         /// Called at the final stage of a successful Token endpoint request.
         /// An application may implement this call in order to do any final 
         /// modification of the claims being used to issue access or refresh tokens. 
@@ -208,6 +219,13 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
         public Func<ApplyLogoutResponseContext, Task> OnApplyLogoutResponse { get; set; } = context => Task.FromResult<object>(null);
+
+        /// <summary>
+        /// Called before the authorization server starts emitting the revocation response to the response stream.
+        /// If the web application wishes to produce the token status and metadata directly in this call, it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
+        /// </summary>
+        public Func<ApplyRevocationResponseContext, Task> OnApplyRevocationResponse { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
         /// Called before the TokenEndpoint redirects its response to the caller.
@@ -324,6 +342,13 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
         public virtual Task ValidateLogoutRequest(ValidateLogoutRequestContext context) => OnValidateLogoutRequest(context);
+
+        /// <summary>
+        /// Called for each request to the revocation endpoint to determine if the request is valid and should continue.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task ValidateRevocationRequest(ValidateRevocationRequestContext context) => OnValidateRevocationRequest(context);
 
         /// <summary>
         /// Called for each request to the token endpoint to determine if the request is valid and should continue.
@@ -454,6 +479,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public virtual Task HandleLogoutRequest(HandleLogoutRequestContext context) => OnHandleLogoutRequest(context);
 
         /// <summary>
+        /// Called by the client applications to revoke an access or refresh token.
+        /// An application may implement this call in order to do any final modification to the revocation response.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task HandleRevocationRequest(HandleRevocationRequestContext context) => OnHandleRevocationRequest(context);
+
+        /// <summary>
         /// Called at the final stage of a successful Token endpoint request.
         /// An application may implement this call in order to do any final 
         /// modification of the claims being used to issue access or refresh tokens. 
@@ -521,6 +554,15 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
         public virtual Task ApplyLogoutResponse(ApplyLogoutResponseContext context) => OnApplyLogoutResponse(context);
+
+        /// <summary>
+        /// Called before the authorization server starts emitting the revocation response to the response stream.
+        /// If the web application wishes to produce the token status and metadata directly in this call, it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task ApplyRevocationResponse(ApplyRevocationResponseContext context) => OnApplyRevocationResponse(context);
 
         /// <summary>
         /// Called before the TokenEndpoint redirects its response to the caller.

--- a/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
+++ b/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
@@ -95,6 +95,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             public const string UnauthorizedClient = "unauthorized_client";
             public const string UnsupportedGrantType = "unsupported_grant_type";
             public const string UnsupportedResponseType = "unsupported_response_type";
+            public const string UnsupportedTokenType = "unsupported_token_type";
         }
 
         public static class GrantTypes {
@@ -189,14 +190,20 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             public const string Public = "public";
         }
 
+        public static class TokenTypeHints {
+            public const string AccessToken = "access_token";
+            public const string IdToken = "id_token";
+            public const string RefreshToken = "refresh_token";
+        }
+
         public static class TokenTypes {
             public const string Bearer = "Bearer";
         }
 
         public static class Usages {
             public const string AccessToken = "access_token";
-            public const string Code = "code";
-            public const string IdToken = "id_token";
+            public const string AuthorizationCode = "code";
+            public const string IdentityToken = "id_token";
             public const string RefreshToken = "refresh_token";
         }
     }

--- a/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -919,7 +919,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.Usages.Code, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.Usages.AuthorizationCode, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -957,7 +957,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.Usages.IdToken, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.Usages.IdentityToken, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/Owin.Security.OpenIdConnect.Server/Events/ApplyRevocationResponseContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/ApplyRevocationResponseContext.cs
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.Owin;
+using Microsoft.Owin.Security.Notifications;
+using Newtonsoft.Json.Linq;
+using Owin.Security.OpenIdConnect.Extensions;
+
+namespace Owin.Security.OpenIdConnect.Server {
+    /// <summary>
+    /// An event raised before the authorization server starts
+    /// writing the revocation response to the response stream.
+    /// </summary>
+    public class ApplyRevocationResponseContext : BaseNotification<OpenIdConnectServerOptions> {
+        /// <summary>
+        /// Creates an instance of this context.
+        /// </summary>
+        public ApplyRevocationResponseContext(
+            IOwinContext context,
+            OpenIdConnectServerOptions options,
+            OpenIdConnectMessage request,
+            JObject response)
+            : base(context, options) {
+            Request = request;
+            Response = response;
+        }
+
+        /// <summary>
+        /// Gets the revocation request. 
+        /// </summary>
+        public new OpenIdConnectMessage Request { get; }
+
+        /// <summary>
+        /// Gets the JSON payload returned to the caller.
+        /// </summary>
+        public new JObject Response { get; }
+
+        /// <summary>
+        /// Gets the error code returned to the client application.
+        /// When the response indicates a successful response,
+        /// this property returns <c>null</c>.
+        /// </summary>
+        public string Error => Response[OpenIdConnectConstants.Parameters.Error]?.Value<string>();
+    }
+}

--- a/src/Owin.Security.OpenIdConnect.Server/Events/HandleRevocationRequestContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/HandleRevocationRequestContext.cs
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Notifications;
+
+namespace Owin.Security.OpenIdConnect.Server {
+    /// <summary>
+    /// An event raised before the authorization server handles
+    /// the request made to the token revocation endpoint.
+    /// </summary>
+    public class HandleRevocationRequestContext : BaseNotification<OpenIdConnectServerOptions> {
+        /// <summary>
+        /// Creates an instance of this context.
+        /// </summary>
+        public HandleRevocationRequestContext(
+            IOwinContext context,
+            OpenIdConnectServerOptions options,
+            OpenIdConnectMessage request,
+            AuthenticationTicket ticket)
+            : base(context, options) {
+            Request = request;
+            Ticket = ticket;
+        }
+
+        /// <summary>
+        /// Gets or sets the authentication ticket.
+        /// </summary>
+        public AuthenticationTicket Ticket { get; set; }
+
+        /// <summary>
+        /// Gets the revocation request.
+        /// </summary>
+        public new OpenIdConnectMessage Request { get; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether
+        /// the token was successfully revoked.
+        /// </summary>
+        public bool Revoked { get; set; }
+    }
+}

--- a/src/Owin.Security.OpenIdConnect.Server/Events/MatchEndpointContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/MatchEndpointContext.cs
@@ -42,6 +42,21 @@ namespace Owin.Security.OpenIdConnect.Server {
         public bool IsCryptographyEndpoint { get; private set; }
 
         /// <summary>
+        /// Gets whether or not the endpoint is an introspection endpoint.
+        /// </summary>
+        public bool IsIntrospectionEndpoint { get; private set; }
+
+        /// <summary>
+        /// Gets whether or not the endpoint is a logout endpoint.
+        /// </summary>
+        public bool IsLogoutEndpoint { get; private set; }
+
+        /// <summary>
+        /// Gets whether or not the endpoint is a revocation endpoint.
+        /// </summary>
+        public bool IsRevocationEndpoint { get; private set; }
+
+        /// <summary>
         /// Gets whether or not the endpoint is an
         /// OAuth2/OpenID Connect token endpoint.
         /// </summary>
@@ -53,26 +68,17 @@ namespace Owin.Security.OpenIdConnect.Server {
         public bool IsUserinfoEndpoint { get; private set; }
 
         /// <summary>
-        /// Gets whether or not the endpoint is an introspection endpoint.
-        /// </summary>
-        public bool IsIntrospectionEndpoint { get; private set; }
-
-        /// <summary>
-        /// Gets whether or not the endpoint is a logout endpoint.
-        /// </summary>
-        public bool IsLogoutEndpoint { get; private set; }
-
-        /// <summary>
         /// Sets the endpoint type to the authorization endpoint.
         /// </summary>
         public void MatchesAuthorizationEndpoint() {
             IsAuthorizationEndpoint = true;
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = false;
             IsIntrospectionEndpoint = false;
             IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
         }
 
         /// <summary>
@@ -82,10 +88,11 @@ namespace Owin.Security.OpenIdConnect.Server {
             IsAuthorizationEndpoint = false;
             IsConfigurationEndpoint = true;
             IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = false;
             IsIntrospectionEndpoint = false;
             IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
         }
 
         /// <summary>
@@ -95,36 +102,11 @@ namespace Owin.Security.OpenIdConnect.Server {
             IsAuthorizationEndpoint = false;
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = true;
+            IsIntrospectionEndpoint = false;
+            IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
             IsTokenEndpoint = false;
             IsUserinfoEndpoint = false;
-            IsIntrospectionEndpoint = false;
-            IsLogoutEndpoint = false;
-        }
-
-        /// <summary>
-        /// Sets the endpoint type to token endpoint.
-        /// </summary>
-        public void MatchesTokenEndpoint() {
-            IsAuthorizationEndpoint = false;
-            IsConfigurationEndpoint = false;
-            IsCryptographyEndpoint = false;
-            IsTokenEndpoint = true;
-            IsUserinfoEndpoint = false;
-            IsIntrospectionEndpoint = false;
-            IsLogoutEndpoint = false;
-        }
-
-        /// <summary>
-        /// Sets the endpoint type to userinfo endpoint.
-        /// </summary>
-        public void MatchesUserinfoEndpoint() {
-            IsAuthorizationEndpoint = false;
-            IsConfigurationEndpoint = false;
-            IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = true;
-            IsIntrospectionEndpoint = false;
-            IsLogoutEndpoint = false;
         }
 
         /// <summary>
@@ -134,10 +116,11 @@ namespace Owin.Security.OpenIdConnect.Server {
             IsAuthorizationEndpoint = false;
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = false;
             IsIntrospectionEndpoint = true;
             IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
         }
 
         /// <summary>
@@ -147,10 +130,53 @@ namespace Owin.Security.OpenIdConnect.Server {
             IsAuthorizationEndpoint = false;
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = false;
             IsIntrospectionEndpoint = false;
             IsLogoutEndpoint = true;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
+        }
+
+        /// <summary>
+        /// Sets the endpoint type to revocation endpoint.
+        /// </summary>
+        public void MatchesRevocationEndpoint() {
+            IsAuthorizationEndpoint = false;
+            IsConfigurationEndpoint = false;
+            IsCryptographyEndpoint = false;
+            IsIntrospectionEndpoint = false;
+            IsLogoutEndpoint = false;
+            IsRevocationEndpoint = true;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
+        }
+
+        /// <summary>
+        /// Sets the endpoint type to token endpoint.
+        /// </summary>
+        public void MatchesTokenEndpoint() {
+            IsAuthorizationEndpoint = false;
+            IsConfigurationEndpoint = false;
+            IsCryptographyEndpoint = false;
+            IsIntrospectionEndpoint = false;
+            IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = true;
+            IsUserinfoEndpoint = false;
+        }
+
+        /// <summary>
+        /// Sets the endpoint type to userinfo endpoint.
+        /// </summary>
+        public void MatchesUserinfoEndpoint() {
+            IsAuthorizationEndpoint = false;
+            IsConfigurationEndpoint = false;
+            IsCryptographyEndpoint = false;
+            IsIntrospectionEndpoint = false;
+            IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = true;
         }
 
         /// <summary>
@@ -160,10 +186,11 @@ namespace Owin.Security.OpenIdConnect.Server {
             IsAuthorizationEndpoint = false;
             IsConfigurationEndpoint = false;
             IsCryptographyEndpoint = false;
-            IsTokenEndpoint = false;
-            IsUserinfoEndpoint = false;
             IsIntrospectionEndpoint = false;
             IsLogoutEndpoint = false;
+            IsRevocationEndpoint = false;
+            IsTokenEndpoint = false;
+            IsUserinfoEndpoint = false;
         }
     }
 }

--- a/src/Owin.Security.OpenIdConnect.Server/Events/ValidateRevocationRequestContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/ValidateRevocationRequestContext.cs
@@ -10,16 +10,16 @@ using Owin.Security.OpenIdConnect.Extensions;
 
 namespace Owin.Security.OpenIdConnect.Server {
     /// <summary>
-    /// Provides context information used when validating an introspection request.
+    /// Provides context information used when validating a revocation request.
     /// </summary>
-    public class ValidateIntrospectionRequestContext : BaseValidatingClientContext {
+    public class ValidateRevocationRequestContext : BaseValidatingClientContext {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ValidateIntrospectionRequestContext"/> class.
+        /// Initializes a new instance of the <see cref="ValidateRevocationRequestContext"/> class.
         /// </summary>
         /// <param name="context"></param>
         /// <param name="options"></param>
         /// <param name="request"></param>
-        public ValidateIntrospectionRequestContext(
+        public ValidateRevocationRequestContext(
             IOwinContext context,
             OpenIdConnectServerOptions options,
             OpenIdConnectMessage request)
@@ -28,7 +28,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
         /// <summary>
         /// Gets the optional token_type_hint parameter extracted from the
-        /// introspection request, or <c>null</c> if it cannot be found.
+        /// revocation request, or <c>null</c> if it cannot be found.
         /// </summary>
         public string TokenTypeHint => Request.GetParameter(OpenIdConnectConstants.Parameters.TokenTypeHint);
     }

--- a/src/Owin.Security.OpenIdConnect.Server/IOpenIdConnectServerProvider.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/IOpenIdConnectServerProvider.cs
@@ -53,6 +53,13 @@ namespace Owin.Security.OpenIdConnect.Server {
         Task ValidateIntrospectionRequest(ValidateIntrospectionRequestContext context);
 
         /// <summary>
+        /// Called for each request to the revocation endpoint to determine if the request is valid and should continue.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        Task ValidateRevocationRequest(ValidateRevocationRequestContext context);
+
+        /// <summary>
         /// Called for each request to the logout endpoint to determine if the request is valid and should continue.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -188,6 +195,14 @@ namespace Owin.Security.OpenIdConnect.Server {
         Task HandleLogoutRequest(HandleLogoutRequestContext context);
 
         /// <summary>
+        /// Called by the client applications to revoke an access or refresh token.
+        /// An application may implement this call in order to do any final modification to the revocation response.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        Task HandleRevocationRequest(HandleRevocationRequestContext context);
+
+        /// <summary>
         /// Called at the final stage of a successful Token endpoint request.
         /// An application may implement this call in order to do any final 
         /// modification of the claims being used to issue access or refresh tokens. 
@@ -255,6 +270,15 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
         Task ApplyLogoutResponse(ApplyLogoutResponseContext context);
+
+        /// <summary>
+        /// Called before the authorization server starts emitting the revocation response to the response stream.
+        /// If the web application wishes to produce the token status and metadata directly in this call, it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        Task ApplyRevocationResponse(ApplyRevocationResponseContext context);
 
         /// <summary>
         /// Called before the TokenEndpoint redirects its response to the caller.

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerDefaults.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerDefaults.cs
@@ -32,16 +32,6 @@ namespace Owin.Security.OpenIdConnect.Server {
         public const string CryptographyEndpointPath = "/.well-known/jwks";
 
         /// <summary>
-        /// Default value for <see cref="OpenIdConnectServerOptions.TokenEndpointPath"/>.
-        /// </summary>
-        public const string TokenEndpointPath = "/connect/token";
-
-        /// <summary>
-        /// Default value for <see cref="OpenIdConnectServerOptions.UserinfoEndpointPath"/>.
-        /// </summary>
-        public const string UserinfoEndpointPath = "/connect/userinfo";
-
-        /// <summary>
         /// Default value for <see cref="OpenIdConnectServerOptions.IntrospectionEndpointPath"/>.
         /// </summary>
         public const string IntrospectionEndpointPath = "/connect/introspect";
@@ -50,5 +40,20 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// Default value for <see cref="OpenIdConnectServerOptions.LogoutEndpointPath"/>.
         /// </summary>
         public const string LogoutEndpointPath = "/connect/logout";
+
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.RevocationEndpointPath"/>.
+        /// </summary>
+        public const string RevocationEndpointPath = "/connect/revoke";
+
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.TokenEndpointPath"/>.
+        /// </summary>
+        public const string TokenEndpointPath = "/connect/token";
+
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.UserinfoEndpointPath"/>.
+        /// </summary>
+        public const string UserinfoEndpointPath = "/connect/userinfo";
     }
 }

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -133,16 +133,16 @@ namespace Owin.Security.OpenIdConnect.Server {
             // the type of the token sent by the client application.
             // See https://tools.ietf.org/html/rfc7662#section-2.1
             switch (request.GetTokenTypeHint()) {
-                case OpenIdConnectConstants.Usages.AccessToken:
+                case OpenIdConnectConstants.TokenTypeHints.AccessToken:
                     ticket = await DeserializeAccessTokenAsync(request.Token, request);
                     break;
 
-                case OpenIdConnectConstants.Usages.RefreshToken:
-                    ticket = await DeserializeRefreshTokenAsync(request.Token, request);
+                case OpenIdConnectConstants.TokenTypeHints.IdToken:
+                    ticket = await DeserializeIdentityTokenAsync(request.Token, request);
                     break;
 
-                case OpenIdConnectConstants.Usages.IdToken:
-                    ticket = await DeserializeIdentityTokenAsync(request.Token, request);
+                case OpenIdConnectConstants.TokenTypeHints.RefreshToken:
+                    ticket = await DeserializeRefreshTokenAsync(request.Token, request);
                     break;
             }
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -1,0 +1,224 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Infrastructure;
+using Newtonsoft.Json.Linq;
+using Owin.Security.OpenIdConnect.Extensions;
+
+namespace Owin.Security.OpenIdConnect.Server {
+    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions> {
+        private async Task<bool> InvokeRevocationEndpointAsync() {
+            if (!string.Equals(Request.Method, "POST", StringComparison.OrdinalIgnoreCase)) {
+                Options.Logger.LogError("The revocation request was rejected because an invalid " +
+                                        "HTTP method was received: {Method}.", Request.Method);
+
+                return await SendRevocationResponseAsync(null, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                    ErrorDescription = "A malformed revocation request has been received: " +
+                                       "make sure to use either GET or POST."
+                });
+            }
+
+            // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization
+            if (string.IsNullOrEmpty(Request.ContentType)) {
+                Options.Logger.LogError("The revocation request was rejected because " +
+                                        "the mandatory 'Content-Type' header was missing.");
+
+                return await SendRevocationResponseAsync(null, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                    ErrorDescription = "A malformed revocation request has been received: " +
+                        "the mandatory 'Content-Type' header was missing from the POST request."
+                });
+            }
+
+            // May have media/type; charset=utf-8, allow partial match.
+            if (!Request.ContentType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase)) {
+                Options.Logger.LogError("The revocation request was rejected because an invalid 'Content-Type' " +
+                                        "header was received: {ContentType}.", Request.ContentType);
+
+                return await SendRevocationResponseAsync(null, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                    ErrorDescription = "A malformed revocation request has been received: " +
+                        "the 'Content-Type' header contained an unexcepted value. " +
+                        "Make sure to use 'application/x-www-form-urlencoded'."
+                });
+            }
+
+            var request = new OpenIdConnectMessage(await Request.ReadFormAsync());
+
+            if (string.IsNullOrWhiteSpace(request.Token)) {
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                    ErrorDescription = "A malformed revocation request has been received: " +
+                        "a 'token' parameter with an access or refresh token is required."
+                });
+            }
+
+            // Insert the revocation request in the OWIN context.
+            Context.SetOpenIdConnectRequest(request);
+
+            // When client_id and client_secret are both null, try to extract them from the Authorization header.
+            // See http://tools.ietf.org/html/rfc6749#section-2.3.1 and
+            // http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
+            if (string.IsNullOrEmpty(request.ClientId) && string.IsNullOrEmpty(request.ClientSecret)) {
+                var header = Request.Headers.Get("Authorization");
+                if (!string.IsNullOrEmpty(header) && header.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase)) {
+                    try {
+                        var value = header.Substring("Basic ".Length).Trim();
+                        var data = Encoding.UTF8.GetString(Convert.FromBase64String(value));
+
+                        var index = data.IndexOf(':');
+                        if (index >= 0) {
+                            request.ClientId = data.Substring(0, index);
+                            request.ClientSecret = data.Substring(index + 1);
+                        }
+                    }
+
+                    catch (FormatException) { }
+                    catch (ArgumentException) { }
+                }
+            }
+
+            var context = new ValidateRevocationRequestContext(Context, Options, request);
+            await Options.Provider.ValidateRevocationRequest(context);
+
+            if (context.IsRejected) {
+                Options.Logger.LogInformation("The revocation request was rejected by application code.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = context.Error ?? OpenIdConnectConstants.Errors.InvalidRequest,
+                    ErrorDescription = context.ErrorDescription,
+                    ErrorUri = context.ErrorUri
+                });
+            }
+
+            // Ensure that the client_id has been set from the ValidateRevocationRequest event.
+            else if (context.IsValidated && string.IsNullOrEmpty(request.ClientId)) {
+                Options.Logger.LogError("The revocation request was validated but the client_id was not set.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.ServerError,
+                    ErrorDescription = "An internal server error occurred."
+                });
+            }
+
+            AuthenticationTicket ticket = null;
+
+            // Note: use the "token_type_hint" parameter to determine
+            // the type of the token sent by the client application.
+            // See https://tools.ietf.org/html/rfc7009#section-2.1
+            switch (request.GetTokenTypeHint()) {
+                case OpenIdConnectConstants.TokenTypeHints.AccessToken:
+                    ticket = await DeserializeAccessTokenAsync(request.Token, request);
+                    break;
+
+                case OpenIdConnectConstants.TokenTypeHints.RefreshToken:
+                    ticket = await DeserializeRefreshTokenAsync(request.Token, request);
+                    break;
+            }
+
+            // Note: if the token can't be found using "token_type_hint",
+            // the search must be extended to all supported token types.
+            // See https://tools.ietf.org/html/rfc7009#section-2.1
+            if (ticket == null) {
+                ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                         await DeserializeRefreshTokenAsync(request.Token, request);
+            }
+
+            if (ticket == null) {
+                Options.Logger.LogInformation("The revocation request was ignored because the token was invalid.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage());
+            }
+
+            // If the ticket is already expired, directly return a 200 response.
+            else if (ticket.Properties.ExpiresUtc.HasValue &&
+                     ticket.Properties.ExpiresUtc < Options.SystemClock.UtcNow) {
+                Options.Logger.LogInformation("The revocation request was ignored because the token was already expired.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage());
+            }
+
+            // Note: unlike refresh tokens that can only be revoked by client applications,
+            // access tokens can be revoked by either resource servers or client applications:
+            // in both cases, the caller must be authenticated if the ticket is marked as confidential.
+            if (context.IsSkipped && ticket.IsConfidential()) {
+                Options.Logger.LogWarning("The revocation request was rejected because the caller was not authenticated.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest
+                });
+            }
+
+            // When a client_id can be inferred from the revocation request,
+            // ensure that the client application is an authorized presenter.
+            if (!string.IsNullOrEmpty(request.ClientId) && ticket.HasPresenter() &&
+                                                          !ticket.HasPresenter(request.ClientId)) {
+                Options.Logger.LogWarning("The revocation request was rejected because the " +
+                                          "refresh token was issued to a different client.");
+
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.InvalidRequest
+                });
+            }
+
+            var notification = new HandleRevocationRequestContext(Context, Options, request, ticket);
+            await Options.Provider.HandleRevocationRequest(notification);
+
+            if (notification.HandledResponse) {
+                return true;
+            }
+
+            else if (notification.Skipped) {
+                return false;
+            }
+
+            if (!notification.Revoked) {
+                return await SendRevocationResponseAsync(request, new OpenIdConnectMessage {
+                    Error = OpenIdConnectConstants.Errors.UnsupportedTokenType,
+                    ErrorDescription = "The token cannot be revoked."
+                });
+            }
+
+            return await SendRevocationResponseAsync(request, new JObject());
+        }
+
+        private Task<bool> SendRevocationResponseAsync(OpenIdConnectMessage request, OpenIdConnectMessage response) {
+            var payload = new JObject();
+
+            foreach (var parameter in response.Parameters) {
+                payload[parameter.Key] = parameter.Value;
+            }
+
+            return SendRevocationResponseAsync(request, payload);
+        }
+
+        private async Task<bool> SendRevocationResponseAsync(OpenIdConnectMessage request, JObject response) {
+            if (request == null) {
+                request = new OpenIdConnectMessage();
+            }
+
+            var notification = new ApplyRevocationResponseContext(Context, Options, request, response);
+            await Options.Provider.ApplyRevocationResponse(notification);
+
+            if (notification.HandledResponse) {
+                return true;
+            }
+
+            else if (notification.Skipped) {
+                return false;
+            }
+
+            return await SendPayloadAsync(response);
+        }
+    }
+}

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -40,7 +40,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             // SerializeAccessTokenAsync and SerializeIdentityTokenAsync are responsible of ensuring
             // that subsequent access and identity tokens are correctly filtered.
             var ticket = new AuthenticationTicket(identity, properties);
-            ticket.SetUsage(OpenIdConnectConstants.Usages.Code);
+            ticket.SetUsage(OpenIdConnectConstants.Usages.AuthorizationCode);
 
             // Associate a random identifier with the authorization code.
             ticket.SetTicketId(Guid.NewGuid().ToString());
@@ -308,7 +308,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             // Create a new ticket containing the updated properties and the filtered identity.
             var ticket = new AuthenticationTicket(identity, properties);
-            ticket.SetUsage(OpenIdConnectConstants.Usages.IdToken);
+            ticket.SetUsage(OpenIdConnectConstants.Usages.IdentityToken);
 
             // Associate a random identifier with the identity token.
             ticket.SetTicketId(Guid.NewGuid().ToString());

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -144,26 +144,6 @@ namespace Owin.Security.OpenIdConnect.Server {
                 notification.MatchesAuthorizationEndpoint();
             }
 
-            else if (Options.TokenEndpointPath.HasValue &&
-                     Options.TokenEndpointPath == Request.Path) {
-                notification.MatchesTokenEndpoint();
-            }
-
-            else if (Options.IntrospectionEndpointPath.HasValue &&
-                     Options.IntrospectionEndpointPath == Request.Path) {
-                notification.MatchesIntrospectionEndpoint();
-            }
-
-            else if (Options.UserinfoEndpointPath.HasValue &&
-                     Options.UserinfoEndpointPath == Request.Path) {
-                notification.MatchesUserinfoEndpoint();
-            }
-
-            else if (Options.LogoutEndpointPath.HasValue &&
-                     Options.LogoutEndpointPath == Request.Path) {
-                notification.MatchesLogoutEndpoint();
-            }
-
             else if (Options.ConfigurationEndpointPath.HasValue &&
                      Options.ConfigurationEndpointPath == Request.Path) {
                 notification.MatchesConfigurationEndpoint();
@@ -172,6 +152,31 @@ namespace Owin.Security.OpenIdConnect.Server {
             else if (Options.CryptographyEndpointPath.HasValue &&
                      Options.CryptographyEndpointPath == Request.Path) {
                 notification.MatchesCryptographyEndpoint();
+            }
+
+            else if (Options.IntrospectionEndpointPath.HasValue &&
+                     Options.IntrospectionEndpointPath == Request.Path) {
+                notification.MatchesIntrospectionEndpoint();
+            }
+
+            else if (Options.LogoutEndpointPath.HasValue &&
+                     Options.LogoutEndpointPath == Request.Path) {
+                notification.MatchesLogoutEndpoint();
+            }
+
+            else if (Options.RevocationEndpointPath.HasValue &&
+                     Options.RevocationEndpointPath == Request.Path) {
+                notification.MatchesRevocationEndpoint();
+            }
+
+            else if (Options.TokenEndpointPath.HasValue &&
+                     Options.TokenEndpointPath == Request.Path) {
+                notification.MatchesTokenEndpoint();
+            }
+
+            else if (Options.UserinfoEndpointPath.HasValue &&
+                     Options.UserinfoEndpointPath == Request.Path) {
+                notification.MatchesUserinfoEndpoint();
             }
 
             await Options.Provider.MatchEndpoint(notification);
@@ -199,9 +204,9 @@ namespace Owin.Security.OpenIdConnect.Server {
                 }
 
                 // Return a JSON error for endpoints that don't involve the user participation.
-                else if (notification.IsTokenEndpoint || notification.IsUserinfoEndpoint ||
-                         notification.IsIntrospectionEndpoint || notification.IsConfigurationEndpoint ||
-                         notification.IsCryptographyEndpoint) {
+                else if (notification.IsConfigurationEndpoint || notification.IsCryptographyEndpoint ||
+                         notification.IsIntrospectionEndpoint || notification.IsRevocationEndpoint ||
+                         notification.IsTokenEndpoint || notification.IsUserinfoEndpoint) {
                     Options.Logger.LogWarning("The current request was rejected because the OpenID Connect server middleware " +
                                               "has been configured to reject HTTP requests. To permanently disable the transport " +
                                               "security requirement, set 'OpenIdConnectServerOptions.AllowInsecureHttp' to 'true'.");
@@ -217,28 +222,32 @@ namespace Owin.Security.OpenIdConnect.Server {
                 return await InvokeAuthorizationEndpointAsync();
             }
 
-            else if (notification.IsLogoutEndpoint) {
-                return await InvokeLogoutEndpointAsync();
-            }
-
-            else if (notification.IsTokenEndpoint) {
-                return await InvokeTokenEndpointAsync();
-            }
-
-            else if (notification.IsIntrospectionEndpoint) {
-                return await InvokeIntrospectionEndpointAsync();
-            }
-
-            else if (notification.IsUserinfoEndpoint) {
-                return await InvokeUserinfoEndpointAsync();
-            }
-
             else if (notification.IsConfigurationEndpoint) {
                 return await InvokeConfigurationEndpointAsync();
             }
 
             else if (notification.IsCryptographyEndpoint) {
                 return await InvokeCryptographyEndpointAsync();
+            }
+
+            else if (notification.IsIntrospectionEndpoint) {
+                return await InvokeIntrospectionEndpointAsync();
+            }
+
+            else if (notification.IsLogoutEndpoint) {
+                return await InvokeLogoutEndpointAsync();
+            }
+
+            else if (notification.IsRevocationEndpoint) {
+                return await InvokeRevocationEndpointAsync();
+            }
+
+            else if (notification.IsTokenEndpoint) {
+                return await InvokeTokenEndpointAsync();
+            }
+
+            else if (notification.IsUserinfoEndpoint) {
+                return await InvokeUserinfoEndpointAsync();
             }
 
             return false;

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
@@ -78,20 +78,6 @@ namespace Owin.Security.OpenIdConnect.Server {
         public PathString CryptographyEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.CryptographyEndpointPath);
 
         /// <summary>
-        /// The request path client applications communicate with directly as part of the OpenID Connect protocol. 
-        /// Must begin with a leading slash, like "/connect/token". If the client is issued a client_secret, it must
-        /// be provided to this endpoint. You can set it to <see cref="PathString.Empty"/> to disable the token endpoint.
-        /// </summary>
-        public PathString TokenEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.TokenEndpointPath);
-
-        /// <summary>
-        /// The request path client applications communicate with to retrieve user information. 
-        /// Must begin with a leading slash, like "/connect/userinfo".
-        /// You can set it to <see cref="PathString.Empty"/> to disable the userinfo endpoint.
-        /// </summary>
-        public PathString UserinfoEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.UserinfoEndpointPath);
-
-        /// <summary>
         /// The request path applications communicate with to validate an access, identity or refresh token.
         /// Must begin with a leading slash, like "/connect/introspect".
         /// You can set it to <see cref="PathString.Empty"/> to disable the introspection endpoint.
@@ -104,6 +90,27 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// You can set it to <see cref="PathString.Empty"/> to disable the logout endpoint.
         /// </summary>
         public PathString LogoutEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.LogoutEndpointPath);
+
+        /// <summary>
+        /// The request path applications communicate with to revoke an access or refresh token.
+        /// Must begin with a leading slash, like "/connect/revoke".
+        /// You can set it to <see cref="PathString.Empty"/> to disable the revocation endpoint.
+        /// </summary>
+        public PathString RevocationEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.RevocationEndpointPath);
+
+        /// <summary>
+        /// The request path client applications communicate with directly as part of the OpenID Connect protocol. 
+        /// Must begin with a leading slash, like "/connect/token". If the client is issued a client_secret, it must
+        /// be provided to this endpoint. You can set it to <see cref="PathString.Empty"/> to disable the token endpoint.
+        /// </summary>
+        public PathString TokenEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.TokenEndpointPath);
+
+        /// <summary>
+        /// The request path client applications communicate with to retrieve user information. 
+        /// Must begin with a leading slash, like "/connect/userinfo".
+        /// You can set it to <see cref="PathString.Empty"/> to disable the userinfo endpoint.
+        /// </summary>
+        public PathString UserinfoEndpointPath { get; set; } = new PathString(OpenIdConnectServerDefaults.UserinfoEndpointPath);
 
         /// <summary>
         /// Specifies a <see cref="IOpenIdConnectServerProvider"/> that the <see cref="OpenIdConnectServerMiddleware" /> invokes

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
@@ -51,6 +51,11 @@ namespace Owin.Security.OpenIdConnect.Server {
         public Func<ValidateLogoutRequestContext, Task> OnValidateLogoutRequest { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
+        /// Called for each request to the revocation endpoint to determine if the request is valid and should continue.
+        /// </summary>
+        public Func<ValidateRevocationRequestContext, Task> OnValidateRevocationRequest { get; set; } = context => Task.FromResult<object>(null);
+
+        /// <summary>
         /// Called for each request to the token endpoint to determine if the request is valid and should continue.
         /// </summary>
         public Func<ValidateTokenRequestContext, Task> OnValidateTokenRequest { get; set; } = context => Task.FromResult<object>(null);
@@ -155,6 +160,12 @@ namespace Owin.Security.OpenIdConnect.Server {
         public Func<HandleLogoutRequestContext, Task> OnHandleLogoutRequest { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
+        /// Called by the client applications to revoke an access or refresh token.
+        /// An application may implement this call in order to do any final modification to the revocation response.
+        /// </summary>
+        public Func<HandleRevocationRequestContext, Task> OnHandleRevocationRequest { get; set; } = context => Task.FromResult<object>(null);
+
+        /// <summary>
         /// Called at the final stage of a successful Token endpoint request.
         /// An application may implement this call in order to do any final 
         /// modification of the claims being used to issue access or refresh tokens. 
@@ -208,6 +219,13 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
         public Func<ApplyLogoutResponseContext, Task> OnApplyLogoutResponse { get; set; } = context => Task.FromResult<object>(null);
+
+        /// <summary>
+        /// Called before the authorization server starts emitting the revocation response to the response stream.
+        /// If the web application wishes to produce the token status and metadata directly in this call, it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
+        /// </summary>
+        public Func<ApplyRevocationResponseContext, Task> OnApplyRevocationResponse { get; set; } = context => Task.FromResult<object>(null);
 
         /// <summary>
         /// Called before the TokenEndpoint redirects its response to the caller.
@@ -326,6 +344,13 @@ namespace Owin.Security.OpenIdConnect.Server {
         public virtual Task ValidateLogoutRequest(ValidateLogoutRequestContext context) => OnValidateLogoutRequest(context);
 
         /// <summary>
+        /// Called for each request to the revocation endpoint to determine if the request is valid and should continue.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task ValidateRevocationRequest(ValidateRevocationRequestContext context) => OnValidateRevocationRequest(context);
+
+        /// <summary>
         /// Called for each request to the token endpoint to determine if the request is valid and should continue.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
@@ -418,16 +443,29 @@ namespace Owin.Security.OpenIdConnect.Server {
         public virtual Task HandleAuthorizationRequest(HandleAuthorizationRequestContext context) => OnHandleAuthorizationRequest(context);
 
         /// <summary>
-        /// Called before the AuthorizationEndpoint redirects its response to the caller.
-        /// The response could contain an access token when using implicit flow or
-        /// an authorization code when using the authorization code flow.
-        /// If the web application wishes to produce the authorization response directly in the AuthorizationEndpoint call it may write to the 
-        /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
-        /// This call may also be used to add additional response parameters to the authorization response.
+        /// Called by the client applications to retrieve the OpenID Connect configuration associated with this instance.
+        /// An application may implement this call in order to do any final modification to the configuration metadata.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
-        public virtual Task ApplyAuthorizationResponse(ApplyAuthorizationResponseContext context) => OnApplyAuthorizationResponse(context);
+        public virtual Task HandleConfigurationRequest(HandleConfigurationRequestContext context) => OnHandleConfigurationRequest(context);
+
+        /// <summary>
+        /// Called by the client applications to retrieve the OpenID Connect JSON Web Key set associated with this instance.
+        /// An application may implement this call in order to do any final modification to the keys set.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task HandleCryptographyRequest(HandleCryptographyRequestContext context) => OnHandleCryptographyRequest(context);
+
+        /// <summary>
+        /// Called by applications to determine the status and metadata for a token.
+        /// Validation conforms to the OAuth 2.0 Token Introspection specification with some additions. See documentation for details.
+        /// An application may implement this call in order to do any final modification to the status and metadata.
+        /// </summary>`
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task HandleIntrospectionRequest(HandleIntrospectionRequestContext context) => OnHandleIntrospectionRequest(context);
 
         /// <summary>
         /// Called at the final stage of an incoming logout endpoint request before the execution continues on to the web application component 
@@ -441,14 +479,21 @@ namespace Owin.Security.OpenIdConnect.Server {
         public virtual Task HandleLogoutRequest(HandleLogoutRequestContext context) => OnHandleLogoutRequest(context);
 
         /// <summary>
-        /// Called before the LogoutEndpoint endpoint redirects its response to the caller.
-        /// If the web application wishes to produce the authorization response directly in the LogoutEndpoint call it may write to the 
-        /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
-        /// This call may also be used to add additional response parameters to the authorization response.
+        /// Called by the client applications to revoke an access or refresh token.
+        /// An application may implement this call in order to do any final modification to the revocation response.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
-        public virtual Task ApplyLogoutResponse(ApplyLogoutResponseContext context) => OnApplyLogoutResponse(context);
+        public virtual Task HandleRevocationRequest(HandleRevocationRequestContext context) => OnHandleRevocationRequest(context);
+
+        /// <summary>
+        /// Called at the final stage of a successful Token endpoint request.
+        /// An application may implement this call in order to do any final 
+        /// modification of the claims being used to issue access or refresh tokens. 
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task HandleTokenRequest(HandleTokenRequestContext context) => OnHandleTokenRequest(context);
 
         /// <summary>
         /// Called at the final stage of an incoming userinfo endpoint request before the execution continues on to the web application component 
@@ -461,22 +506,16 @@ namespace Owin.Security.OpenIdConnect.Server {
         public virtual Task HandleUserinfoRequest(HandleUserinfoRequestContext context) => OnHandleUserinfoRequest(context);
 
         /// <summary>
-        /// Called before the UserinfoEndpoint endpoint starts writing to the response stream.
-        /// If the web application wishes to produce the userinfo response directly in the UserinfoEndpoint call it may write to the 
+        /// Called before the AuthorizationEndpoint redirects its response to the caller.
+        /// The response could contain an access token when using implicit flow or
+        /// an authorization code when using the authorization code flow.
+        /// If the web application wishes to produce the authorization response directly in the AuthorizationEndpoint call it may write to the 
         /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
         /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
-        public virtual Task ApplyUserinfoResponse(ApplyUserinfoResponseContext context) => OnApplyUserinfoResponse(context);
-
-        /// <summary>
-        /// Called by the client applications to retrieve the OpenID Connect configuration associated with this instance.
-        /// An application may implement this call in order to do any final modification to the configuration metadata.
-        /// </summary>
-        /// <param name="context">The context of the event carries information in and results out.</param>
-        /// <returns>Task to enable asynchronous execution</returns>
-        public virtual Task HandleConfigurationRequest(HandleConfigurationRequestContext context) => OnHandleConfigurationRequest(context);
+        public virtual Task ApplyAuthorizationResponse(ApplyAuthorizationResponseContext context) => OnApplyAuthorizationResponse(context);
 
         /// <summary>
         /// Called before the authorization server starts emitting the OpenID Connect configuration associated with this instance.
@@ -488,14 +527,6 @@ namespace Owin.Security.OpenIdConnect.Server {
         public virtual Task ApplyConfigurationResponse(ApplyConfigurationResponseContext context) => OnApplyConfigurationResponse(context);
 
         /// <summary>
-        /// Called by the client applications to retrieve the OpenID Connect JSON Web Key set associated with this instance.
-        /// An application may implement this call in order to do any final modification to the keys set.
-        /// </summary>
-        /// <param name="context">The context of the event carries information in and results out.</param>
-        /// <returns>Task to enable asynchronous execution</returns>
-        public virtual Task HandleCryptographyRequest(HandleCryptographyRequestContext context) => OnHandleCryptographyRequest(context);
-
-        /// <summary>
         /// Called before the authorization server starts emitting the OpenID Connect JSON Web Key set associated with this instance.
         /// If the web application wishes to produce the JSON Web Key set directly in this call, it may write to the 
         /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
@@ -505,13 +536,33 @@ namespace Owin.Security.OpenIdConnect.Server {
         public virtual Task ApplyCryptographyResponse(ApplyCryptographyResponseContext context) => OnApplyCryptographyResponse(context);
 
         /// <summary>
-        /// Called at the final stage of a successful Token endpoint request.
-        /// An application may implement this call in order to do any final 
-        /// modification of the claims being used to issue access or refresh tokens. 
+        /// Called before the authorization server starts emitting the status and metadata associated with the token received.
+        /// Validation conforms to the OAuth 2.0 Token Introspection specification with some additions. See documentation for details.
+        /// If the web application wishes to produce the status and metadata directly in this call, it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
-        public virtual Task HandleTokenRequest(HandleTokenRequestContext context) => OnHandleTokenRequest(context);
+        public virtual Task ApplyIntrospectionResponse(ApplyIntrospectionResponseContext context) => OnApplyIntrospectionResponse(context);
+
+        /// <summary>
+        /// Called before the LogoutEndpoint endpoint redirects its response to the caller.
+        /// If the web application wishes to produce the authorization response directly in the LogoutEndpoint call it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
+        /// This call may also be used to add additional response parameters to the authorization response.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task ApplyLogoutResponse(ApplyLogoutResponseContext context) => OnApplyLogoutResponse(context);
+
+        /// <summary>
+        /// Called before the authorization server starts emitting the revocation response to the response stream.
+        /// If the web application wishes to produce the token status and metadata directly in this call, it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
+        /// </summary>
+        /// <param name="context">The context of the event carries information in and results out.</param>
+        /// <returns>Task to enable asynchronous execution</returns>
+        public virtual Task ApplyRevocationResponse(ApplyRevocationResponseContext context) => OnApplyRevocationResponse(context);
 
         /// <summary>
         /// Called before the TokenEndpoint redirects its response to the caller.
@@ -523,23 +574,14 @@ namespace Owin.Security.OpenIdConnect.Server {
         public virtual Task ApplyTokenResponse(ApplyTokenResponseContext context) => OnApplyTokenResponse(context);
 
         /// <summary>
-        /// Called by applications to determine the status and metadata for a token.
-        /// Validation conforms to the OAuth 2.0 Token Introspection specification with some additions. See documentation for details.
-        /// An application may implement this call in order to do any final modification to the status and metadata.
-        /// </summary>`
-        /// <param name="context">The context of the event carries information in and results out.</param>
-        /// <returns>Task to enable asynchronous execution</returns>
-        public virtual Task HandleIntrospectionRequest(HandleIntrospectionRequestContext context) => OnHandleIntrospectionRequest(context);
-
-        /// <summary>
-        /// Called before the authorization server starts emitting the status and metadata associated with the token received.
-        /// Validation conforms to the OAuth 2.0 Token Introspection specification with some additions. See documentation for details.
-        /// If the web application wishes to produce the status and metadata directly in this call, it may write to the 
-        /// context.Response directly and should call context.RequestCompleted to stop the default behavior from executing.
+        /// Called before the UserinfoEndpoint endpoint starts writing to the response stream.
+        /// If the web application wishes to produce the userinfo response directly in the UserinfoEndpoint call it may write to the 
+        /// context.Response directly and should call context.RequestCompleted to stop other handlers from executing.
+        /// This call may also be used to add additional response parameters to the authorization response.
         /// </summary>
         /// <param name="context">The context of the event carries information in and results out.</param>
         /// <returns>Task to enable asynchronous execution</returns>
-        public virtual Task ApplyIntrospectionResponse(ApplyIntrospectionResponseContext context) => OnApplyIntrospectionResponse(context);
+        public virtual Task ApplyUserinfoResponse(ApplyUserinfoResponseContext context) => OnApplyUserinfoResponse(context);
 
         /// <summary>
         /// Called to create a new authorization code. An application may use this context


### PR DESCRIPTION
Closes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/181.

The new revocation endpoint is heavily inspired from the introspection endpoint, except it doesn't support identity tokens, uses a different security policy (only the client apps listed as authorized presenters are allowed to revoke a token), and must be "implemented" by the final developer, who's responsible of storing the tokens he/she wants to revoke and adding the "token removal" logic in the `HandleRevocationRequest` event.