### PR TITLE
Expose the revocation endpoint in the discovery metadata

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
+++ b/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
@@ -111,6 +111,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             public const string ResponseTypesSupported = "response_types_supported";
             public const string ScopesSupported = "scopes_supported";
             public const string SubjectTypesSupported = "subject_types_supported";
+            public const string RevocationEndpoint = "revocation_endpoint";
             public const string TokenEndpoint = "token_endpoint";
             public const string UserinfoEndpoint = "userinfo_endpoint";
         }

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
@@ -47,14 +47,19 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public string CryptographyEndpoint { get; set; }
 
         /// <summary>
-        /// Gets or sets the userinfo endpoint address.
-        /// </summary>
-        public string UserinfoEndpoint { get; set; }
-
-        /// <summary>
         /// Gets or sets the introspection endpoint address.
         /// </summary>
         public string IntrospectionEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the logout endpoint address.
+        /// </summary>
+        public string LogoutEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the revocation endpoint address.
+        /// </summary>
+        public string RevocationEndpoint { get; set; }
 
         /// <summary>
         /// Gets or sets the token endpoint address.
@@ -62,9 +67,9 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public string TokenEndpoint { get; set; }
 
         /// <summary>
-        /// Gets or sets the logout endpoint address.
+        /// Gets or sets the userinfo endpoint address.
         /// </summary>
-        public string LogoutEndpoint { get; set; }
+        public string UserinfoEndpoint { get; set; }
 
         /// <summary>
         /// Gets or sets the issuer address.

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -56,20 +56,24 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 notification.CryptographyEndpoint = notification.Issuer.AddPath(Options.CryptographyEndpointPath);
             }
 
-            if (Options.UserinfoEndpointPath.HasValue) {
-                notification.UserinfoEndpoint = notification.Issuer.AddPath(Options.UserinfoEndpointPath);
-            }
-
             if (Options.IntrospectionEndpointPath.HasValue) {
                 notification.IntrospectionEndpoint = notification.Issuer.AddPath(Options.IntrospectionEndpointPath);
+            }
+
+            if (Options.LogoutEndpointPath.HasValue) {
+                notification.LogoutEndpoint = notification.Issuer.AddPath(Options.LogoutEndpointPath);
+            }
+
+            if (Options.RevocationEndpointPath.HasValue) {
+                notification.RevocationEndpoint = notification.Issuer.AddPath(Options.RevocationEndpointPath);
             }
 
             if (Options.TokenEndpointPath.HasValue) {
                 notification.TokenEndpoint = notification.Issuer.AddPath(Options.TokenEndpointPath);
             }
 
-            if (Options.LogoutEndpointPath.HasValue) {
-                notification.LogoutEndpoint = notification.Issuer.AddPath(Options.LogoutEndpointPath);
+            if (Options.UserinfoEndpointPath.HasValue) {
+                notification.UserinfoEndpoint = notification.Issuer.AddPath(Options.UserinfoEndpointPath);
             }
 
             if (Options.AuthorizationEndpointPath.HasValue) {
@@ -153,24 +157,28 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 response.Add(OpenIdConnectConstants.Metadata.AuthorizationEndpoint, notification.AuthorizationEndpoint);
             }
 
-            if (!string.IsNullOrEmpty(notification.UserinfoEndpoint)) {
-                response.Add(OpenIdConnectConstants.Metadata.UserinfoEndpoint, notification.UserinfoEndpoint);
+            if (!string.IsNullOrEmpty(notification.CryptographyEndpoint)) {
+                response.Add(OpenIdConnectConstants.Metadata.JwksUri, notification.CryptographyEndpoint);
             }
 
             if (!string.IsNullOrEmpty(notification.IntrospectionEndpoint)) {
                 response.Add(OpenIdConnectConstants.Metadata.IntrospectionEndpoint, notification.IntrospectionEndpoint);
             }
 
-            if (!string.IsNullOrEmpty(notification.TokenEndpoint)) {
-                response.Add(OpenIdConnectConstants.Metadata.TokenEndpoint, notification.TokenEndpoint);
-            }
-
             if (!string.IsNullOrEmpty(notification.LogoutEndpoint)) {
                 response.Add(OpenIdConnectConstants.Metadata.EndSessionEndpoint, notification.LogoutEndpoint);
             }
 
-            if (!string.IsNullOrEmpty(notification.CryptographyEndpoint)) {
-                response.Add(OpenIdConnectConstants.Metadata.JwksUri, notification.CryptographyEndpoint);
+            if (!string.IsNullOrEmpty(notification.RevocationEndpoint)) {
+                response.Add(OpenIdConnectConstants.Metadata.RevocationEndpoint, notification.RevocationEndpoint);
+            }
+
+            if (!string.IsNullOrEmpty(notification.TokenEndpoint)) {
+                response.Add(OpenIdConnectConstants.Metadata.TokenEndpoint, notification.TokenEndpoint);
+            }
+
+            if (!string.IsNullOrEmpty(notification.UserinfoEndpoint)) {
+                response.Add(OpenIdConnectConstants.Metadata.UserinfoEndpoint, notification.UserinfoEndpoint);
             }
 
             response.Add(OpenIdConnectConstants.Metadata.GrantTypesSupported,

--- a/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
+++ b/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
@@ -118,6 +118,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             public const string ResponseTypesSupported = "response_types_supported";
             public const string ScopesSupported = "scopes_supported";
             public const string SubjectTypesSupported = "subject_types_supported";
+            public const string RevocationEndpoint = "revocation_endpoint";
             public const string TokenEndpoint = "token_endpoint";
             public const string UserinfoEndpoint = "userinfo_endpoint";
         }

--- a/src/Owin.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
@@ -42,14 +42,19 @@ namespace Owin.Security.OpenIdConnect.Server {
         public string CryptographyEndpoint { get; set; }
 
         /// <summary>
-        /// Gets or sets the userinfo endpoint address.
-        /// </summary>
-        public string UserinfoEndpoint { get; set; }
-
-        /// <summary>
         /// Gets or sets the introspection endpoint address.
         /// </summary>
         public string IntrospectionEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the logout endpoint address.
+        /// </summary>
+        public string LogoutEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the revocation endpoint address.
+        /// </summary>
+        public string RevocationEndpoint { get; set; }
 
         /// <summary>
         /// Gets or sets the token endpoint address.
@@ -57,9 +62,9 @@ namespace Owin.Security.OpenIdConnect.Server {
         public string TokenEndpoint { get; set; }
 
         /// <summary>
-        /// Gets or sets the logout endpoint address.
+        /// Gets or sets the userinfo endpoint address.
         /// </summary>
-        public string LogoutEndpoint { get; set; }
+        public string UserinfoEndpoint { get; set; }
 
         /// <summary>
         /// Gets or sets the issuer address.

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -61,20 +61,24 @@ namespace Owin.Security.OpenIdConnect.Server {
                 notification.CryptographyEndpoint = notification.Issuer.AddPath(Options.CryptographyEndpointPath);
             }
 
-            if (Options.UserinfoEndpointPath.HasValue) {
-                notification.UserinfoEndpoint = notification.Issuer.AddPath(Options.UserinfoEndpointPath);
-            }
-
             if (Options.IntrospectionEndpointPath.HasValue) {
                 notification.IntrospectionEndpoint = notification.Issuer.AddPath(Options.IntrospectionEndpointPath);
+            }
+
+            if (Options.LogoutEndpointPath.HasValue) {
+                notification.LogoutEndpoint = notification.Issuer.AddPath(Options.LogoutEndpointPath);
+            }
+
+            if (Options.RevocationEndpointPath.HasValue) {
+                notification.RevocationEndpoint = notification.Issuer.AddPath(Options.RevocationEndpointPath);
             }
 
             if (Options.TokenEndpointPath.HasValue) {
                 notification.TokenEndpoint = notification.Issuer.AddPath(Options.TokenEndpointPath);
             }
 
-            if (Options.LogoutEndpointPath.HasValue) {
-                notification.LogoutEndpoint = notification.Issuer.AddPath(Options.LogoutEndpointPath);
+            if (Options.UserinfoEndpointPath.HasValue) {
+                notification.UserinfoEndpoint = notification.Issuer.AddPath(Options.UserinfoEndpointPath);
             }
 
             if (Options.AuthorizationEndpointPath.HasValue) {
@@ -158,24 +162,28 @@ namespace Owin.Security.OpenIdConnect.Server {
                 response.Add(OpenIdConnectConstants.Metadata.AuthorizationEndpoint, notification.AuthorizationEndpoint);
             }
 
-            if (!string.IsNullOrEmpty(notification.UserinfoEndpoint)) {
-                response.Add(OpenIdConnectConstants.Metadata.UserinfoEndpoint, notification.UserinfoEndpoint);
+            if (!string.IsNullOrEmpty(notification.CryptographyEndpoint)) {
+                response.Add(OpenIdConnectConstants.Metadata.JwksUri, notification.CryptographyEndpoint);
             }
 
             if (!string.IsNullOrEmpty(notification.IntrospectionEndpoint)) {
                 response.Add(OpenIdConnectConstants.Metadata.IntrospectionEndpoint, notification.IntrospectionEndpoint);
             }
 
-            if (!string.IsNullOrEmpty(notification.TokenEndpoint)) {
-                response.Add(OpenIdConnectConstants.Metadata.TokenEndpoint, notification.TokenEndpoint);
-            }
-
             if (!string.IsNullOrEmpty(notification.LogoutEndpoint)) {
                 response.Add(OpenIdConnectConstants.Metadata.EndSessionEndpoint, notification.LogoutEndpoint);
             }
 
-            if (!string.IsNullOrEmpty(notification.CryptographyEndpoint)) {
-                response.Add(OpenIdConnectConstants.Metadata.JwksUri, notification.CryptographyEndpoint);
+            if (!string.IsNullOrEmpty(notification.RevocationEndpoint)) {
+                response.Add(OpenIdConnectConstants.Metadata.RevocationEndpoint, notification.RevocationEndpoint);
+            }
+
+            if (!string.IsNullOrEmpty(notification.TokenEndpoint)) {
+                response.Add(OpenIdConnectConstants.Metadata.TokenEndpoint, notification.TokenEndpoint);
+            }
+
+            if (!string.IsNullOrEmpty(notification.UserinfoEndpoint)) {
+                response.Add(OpenIdConnectConstants.Metadata.UserinfoEndpoint, notification.UserinfoEndpoint);
             }
 
             response.Add(OpenIdConnectConstants.Metadata.GrantTypesSupported,


### PR DESCRIPTION
This PR adds a new `revocation_endpoint` value in the provider configuration document.

Note: the OpenID Connect discovery spec doesn't have any dedicated entry for the revocation endpoint, but the whole new OAuth2 discovery draft does: https://tools.ietf.org/html/draft-ietf-oauth-discovery-02#section-2. 