### PR TITLE
Avoid rejecting authorization requests that specify a custom response_type/response_mode

### DIFF
--- a/samples/Mvc/Mvc.Server/Providers/AuthorizationProvider.cs
+++ b/samples/Mvc/Mvc.Server/Providers/AuthorizationProvider.cs
@@ -34,6 +34,19 @@ namespace Mvc.Server.Providers {
                 return;
             }
 
+            // Note: to support custom response modes, the OpenID Connect server middleware doesn't
+            // reject unknown modes before the ApplyAuthorizationResponse event is invoked.
+            // To ensure invalid modes are rejected early enough, a check is made here.
+            if (!string.IsNullOrEmpty(context.Request.ResponseMode) && !context.Request.IsFormPostResponseMode() &&
+                                                                       !context.Request.IsFragmentResponseMode() &&
+                                                                       !context.Request.IsQueryResponseMode()) {
+                context.Reject(
+                    error: OpenIdConnectConstants.Errors.InvalidRequest,
+                    description: "The specified response_mode is unsupported.");
+
+                return;
+            }
+
             var database = context.HttpContext.RequestServices.GetRequiredService<ApplicationContext>();
 
             // Retrieve the application details corresponding to the requested client_id.

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -215,29 +215,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 });
             }
 
-            // Reject requests whose response_type parameter is unsupported.
-            else if (!request.IsNoneFlow() && !request.IsAuthorizationCodeFlow() &&
-                     !request.IsImplicitFlow() && !request.IsHybridFlow()) {
-                Logger.LogError("The authorization request was rejected because the 'response_type' " +
-                                "parameter was invalid: {ResponseType}.", request.ResponseType);
-
-                return await SendAuthorizationResponseAsync(request, new OpenIdConnectMessage {
-                    Error = OpenIdConnectConstants.Errors.UnsupportedResponseType,
-                    ErrorDescription = "response_type unsupported"
-                });
-            }
-
-            // Reject requests whose response_mode is unsupported.
-            else if (!request.IsFormPostResponseMode() && !request.IsFragmentResponseMode() && !request.IsQueryResponseMode()) {
-                Logger.LogError("The authorization request was rejected because the 'response_mode' " +
-                                "parameter was invalid: {ResponseMode}.", request.ResponseMode);
-
-                return await SendAuthorizationResponseAsync(request, new OpenIdConnectMessage {
-                    Error = OpenIdConnectConstants.Errors.InvalidRequest,
-                    ErrorDescription = "response_mode unsupported"
-                });
-            }
-
             // response_mode=query (explicit or not) and a response_type containing id_token
             // or token are not considered as a safe combination and MUST be rejected.
             // See http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#Security
@@ -266,7 +243,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 });
             }
 
-            // Reject requests containing the id_token response_mode if no openid scope has been received.
+            // Reject requests containing the id_token response_type if no openid scope has been received.
             else if (request.HasResponseType(OpenIdConnectConstants.ResponseTypes.IdToken) &&
                     !request.HasScope(OpenIdConnectConstants.Scopes.OpenId)) {
                 Logger.LogError("The authorization request was rejected because the 'openid' scope was missing.");
@@ -643,7 +620,13 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 return true;
             }
 
-            return await SendNativePageAsync(response);
+            Logger.LogError("The authorization request was rejected because the 'response_mode' " +
+                            "parameter was invalid: {ResponseMode}.", request.ResponseMode);
+
+            return await SendNativePageAsync(new OpenIdConnectMessage {
+                Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                ErrorDescription = "response_mode unsupported"
+            });
         }
     }
 }

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -211,29 +211,6 @@ namespace Owin.Security.OpenIdConnect.Server {
                 });
             }
 
-            // Reject requests whose response_type parameter is unsupported.
-            else if (!request.IsNoneFlow() && !request.IsAuthorizationCodeFlow() &&
-                     !request.IsImplicitFlow() && !request.IsHybridFlow()) {
-                Options.Logger.LogError("The authorization request was rejected because the 'response_type' " +
-                                        "parameter was invalid: {ResponseType}.", request.ResponseType);
-
-                return await SendAuthorizationResponseAsync(request, new OpenIdConnectMessage {
-                    Error = OpenIdConnectConstants.Errors.UnsupportedResponseType,
-                    ErrorDescription = "response_type unsupported"
-                });
-            }
-
-            // Reject requests whose response_mode is unsupported.
-            else if (!request.IsFormPostResponseMode() && !request.IsFragmentResponseMode() && !request.IsQueryResponseMode()) {
-                Options.Logger.LogError("The authorization request was rejected because the 'response_mode' " +
-                                        "parameter was invalid: {ResponseMode}.", request.ResponseMode);
-
-                return await SendAuthorizationResponseAsync(request, new OpenIdConnectMessage {
-                    Error = OpenIdConnectConstants.Errors.InvalidRequest,
-                    ErrorDescription = "response_mode unsupported"
-                });
-            }
-
             // response_mode=query (explicit or not) and a response_type containing id_token
             // or token are not considered as a safe combination and MUST be rejected.
             // See http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#Security
@@ -263,7 +240,7 @@ namespace Owin.Security.OpenIdConnect.Server {
                 });
             }
 
-            // Reject requests containing the id_token response_mode if no openid scope has been received.
+            // Reject requests containing the id_token response_type if no openid scope has been received.
             else if (request.HasResponseType(OpenIdConnectConstants.ResponseTypes.IdToken) &&
                     !request.HasScope(OpenIdConnectConstants.Scopes.OpenId)) {
                 Options.Logger.LogError("The authorization request was rejected because the 'openid' scope was missing.");
@@ -632,7 +609,13 @@ namespace Owin.Security.OpenIdConnect.Server {
                 return true;
             }
 
-            return await SendNativePageAsync(response);
+            Options.Logger.LogError("The authorization request was rejected because the 'response_mode' " +
+                                    "parameter was invalid: {ResponseMode}.", request.ResponseMode);
+
+            return await SendNativePageAsync(new OpenIdConnectMessage {
+                Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                ErrorDescription = "response_mode unsupported"
+            });
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/288.