### PR TITLE
Stop storing authorization codes in the distributed cache

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
@@ -204,7 +204,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public bool AllowInsecureHttp { get; set; }
 
         /// <summary>
-        /// The cache instance used to store short-lived data like authentication requests or authorization codes.
+        /// The cache instance used to store short-lived data like authentication/authorization requests.
         /// You can replace the default instance by a distributed implementation to support Web farm environments.
         /// When this property is not explicitly set, the global cache defined in Startup.cs is used instead.
         /// </summary>

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -7,14 +7,12 @@
 using System;
 using System.IdentityModel.Protocols.WSTrust;
 using System.IdentityModel.Tokens;
-using System.IO;
 using System.Linq;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
-using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.Owin.Security;
@@ -69,25 +67,7 @@ namespace Owin.Security.OpenIdConnect.Server {
                 return null;
             }
 
-            // Note: make sure to use a secure generated string having
-            // enough entropy to prevent cryptanalytic attacks.
-            var key = Options.RandomNumberGenerator.GenerateKey(length: 256 / 8);
-
-            using (var stream = new MemoryStream())
-            using (var writter = new StreamWriter(stream)) {
-                writter.Write(notification.DataFormat.Protect(ticket));
-                writter.Flush();
-
-                // Serialize the authorization code.
-                var bytes = stream.ToArray();
-
-                // Store the authorization code in the distributed cache.
-                await Options.Cache.SetAsync($"asos-authorization-code:{key}", bytes, new DistributedCacheEntryOptions {
-                    AbsoluteExpiration = ticket.Properties.ExpiresUtc
-                });
-            }
-
-            return key;
+            return notification.DataFormat.Protect(ticket);
         }
 
         private async Task<string> SerializeAccessTokenAsync(
@@ -515,31 +495,19 @@ namespace Owin.Security.OpenIdConnect.Server {
                 return null;
             }
 
-            var buffer = await Options.Cache.GetAsync($"asos-authorization-code:{code}");
-            if (buffer == null) {
+            var ticket = notification.DataFormat?.Unprotect(code);
+            if (ticket == null) {
                 return null;
             }
 
-            using (var stream = new MemoryStream(buffer))
-            using (var reader = new StreamReader(stream)) {
-                // Because authorization codes are guaranteed to be unique, make sure
-                // to remove the current code from the global store before using it.
-                await Options.Cache.RemoveAsync($"asos-authorization-code:{code}");
+            // Ensure the received ticket is an authorization code.
+            if (!ticket.IsAuthorizationCode()) {
+                Options.Logger.LogDebug("The received token was not an authorization code: {Code}.", code);
 
-                var ticket = notification.DataFormat?.Unprotect(await reader.ReadToEndAsync());
-                if (ticket == null) {
-                    return null;
-                }
-
-                // Ensure the received ticket is an authorization code.
-                if (!ticket.IsAuthorizationCode()) {
-                    Options.Logger.LogDebug("The received token was not an authorization code: {Code}.", code);
-
-                    return null;
-                }
-
-                return ticket;
+                return null;
             }
+
+            return ticket;
         }
 
         private async Task<AuthenticationTicket> DeserializeAccessTokenAsync(string token, OpenIdConnectMessage request) {

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
@@ -221,7 +221,7 @@ namespace Owin.Security.OpenIdConnect.Server {
         public bool AllowInsecureHttp { get; set; }
 
         /// <summary>
-        /// The cache instance used to store short-lived data like authentication requests or authorization codes.
+        /// The cache instance used to store short-lived data like authentication/authorization requests.
         /// You can replace the default instance by a distributed implementation to support Web farm environments.
         /// When this property is not explicitly set, a default in-memory implementation is used instead.
         /// </summary>


### PR DESCRIPTION
With OpenID Connect, supporting authorization code revocation to prevent token reuse is no longer mandatory:

  - http://openid.net/specs/openid-connect-core-1_0.html#TokenReuse
  - http://openid.net/specs/openid-connect-core-1_0.html#TokenRequestValidation

This PR removes the built-in caching support and aligns the authorization code handling with the refresh token logic, which is the first step of removing the entire caching story in ASOS (the next step being getting rid of the automatic authorization request storage).

Implementations that want/need to support single-use authorization code can store the token identifier in a database from `SerializeAuthorizationCode` and ensure it is still valid from `HandleTokenRequest`/`GrantRefreshToken`.