### PR TITLE
Avoid rejecting authorization requests that specify a request or request_uri parameter

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -162,30 +162,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 }
             }
 
-            // Reject requests using the unsupported request parameter.
-            if (!string.IsNullOrEmpty(request.GetParameter(OpenIdConnectConstants.Parameters.Request))) {
-                Logger.LogError("The authorization request was rejected because it contained " +
-                                "an unsupported parameter: {Parameter}.", "request");
-
-                return await SendAuthorizationResponseAsync(request, new OpenIdConnectMessage {
-                    Error = OpenIdConnectConstants.Errors.RequestNotSupported,
-                    ErrorDescription = "The request parameter is not supported."
-                });
-            }
-
-            // Reject requests using the unsupported request_uri parameter.
-            else if (!string.IsNullOrEmpty(request.RequestUri)) {
-                Logger.LogError("The authorization request was rejected because it contained " +
-                                "an unsupported parameter: {Parameter}.", "request_uri");
-
-                return await SendAuthorizationResponseAsync(request, new OpenIdConnectMessage {
-                    Error = OpenIdConnectConstants.Errors.RequestUriNotSupported,
-                    ErrorDescription = "The request_uri parameter is not supported."
-                });
-            }
-
             // Reject requests missing the mandatory response_type parameter.
-            else if (string.IsNullOrEmpty(request.ResponseType)) {
+            if (string.IsNullOrEmpty(request.ResponseType)) {
                 Logger.LogError("The authorization request was rejected because " +
                                 "the mandatory 'response_type' parameter was missing.");
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -158,30 +158,8 @@ namespace Owin.Security.OpenIdConnect.Server {
                 }
             }
 
-            // Reject requests using the unsupported request parameter.
-            if (!string.IsNullOrEmpty(request.GetParameter(OpenIdConnectConstants.Parameters.Request))) {
-                Options.Logger.LogError("The authorization request was rejected because it contained " +
-                                        "an unsupported parameter: {Parameter}.", "request");
-
-                return await SendAuthorizationResponseAsync(request, new OpenIdConnectMessage {
-                    Error = OpenIdConnectConstants.Errors.RequestNotSupported,
-                    ErrorDescription = "The request parameter is not supported."
-                });
-            }
-
-            // Reject requests using the unsupported request_uri parameter.
-            else if (!string.IsNullOrEmpty(request.RequestUri)) {
-                Options.Logger.LogError("The authorization request was rejected because it contained " +
-                                        "an unsupported parameter: {Parameter}.", "request_uri");
-
-                return await SendAuthorizationResponseAsync(request, new OpenIdConnectMessage {
-                    Error = OpenIdConnectConstants.Errors.RequestUriNotSupported,
-                    ErrorDescription = "The request_uri parameter is not supported."
-                });
-            }
-
             // Reject requests missing the mandatory response_type parameter.
-            else if (string.IsNullOrEmpty(request.ResponseType)) {
+            if (string.IsNullOrEmpty(request.ResponseType)) {
                 Options.Logger.LogError("The authorization request was rejected because " +
                                         "the mandatory 'response_type' parameter was missing.");
 


### PR DESCRIPTION
With the introduction of the `ExtractAuthorizationRequest` event, `request`/`request_uri` support can now be implemented from user code. Unfortunately, authorization rejects that specify one of these parameters are automatically rejected by ASOS, unless they are explicitly removed after invoking the `ExtractAuthorizationRequest`.

This PR aims at removing the unwanted checks.