### PR TITLE
Specify StringSplitOptions.RemoveEmptyEntries to avoid returning empty audiences/presenters/resources/scopes

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
+++ b/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
@@ -223,6 +223,10 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             public const string Token = "token";
         }
 
+        public static class Separators {
+            public static readonly char[] Space = { ' ' };
+        }
+
         public static class Scopes {
             public const string Address = "address";
             public const string Email = "email";

--- a/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -27,7 +27,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return request.Resource?.Split(' ')
+            return request.Resource?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                                    ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -41,7 +41,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return request.Scope?.Split(' ')
+            return request.Scope?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                                 ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -55,7 +55,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(response));
             }
 
-            return response.Resource?.Split(' ')
+            return response.Resource?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                                     ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -69,7 +69,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(response));
             }
 
-            return response.Scope?.Split(' ')
+            return response.Scope?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                                  ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -410,7 +410,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             string destinations;
             claim.Properties.TryGetValue(OpenIdConnectConstants.Properties.Destinations, out destinations);
 
-            return destinations?.Split(' ')
+            return destinations?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                                ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -714,7 +714,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             }
 
             return ticket.GetProperty(OpenIdConnectConstants.Properties.Audiences)
-                        ?.Split(' ')
+                        ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                         ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -731,7 +731,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             }
 
             return ticket.GetProperty(OpenIdConnectConstants.Properties.Presenters)
-                        ?.Split(' ')
+                        ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                         ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -761,7 +761,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             }
 
             return ticket.GetProperty(OpenIdConnectConstants.Properties.Resources)
-                        ?.Split(' ')
+                        ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                         ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -778,7 +778,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             }
 
             return ticket.GetProperty(OpenIdConnectConstants.Properties.Scopes)
-                        ?.Split(' ')
+                        ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                         ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -870,7 +870,9 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(ticket));
             }
 
-            var audiences = ticket.GetProperty(OpenIdConnectConstants.Properties.Audiences)?.Split(' ');
+            var audiences = ticket.GetProperty(OpenIdConnectConstants.Properties.Audiences)
+                                 ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries);
+
             if (audiences == null) {
                 return false;
             }
@@ -902,7 +904,9 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(ticket));
             }
 
-            var presenters = ticket.GetProperty(OpenIdConnectConstants.Properties.Presenters)?.Split(' ');
+            var presenters = ticket.GetProperty(OpenIdConnectConstants.Properties.Presenters)
+                                  ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries);
+
             if (presenters == null) {
                 return false;
             }
@@ -934,7 +938,9 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(ticket));
             }
 
-            var resources = ticket.GetProperty(OpenIdConnectConstants.Properties.Resources)?.Split(' ');
+            var resources = ticket.GetProperty(OpenIdConnectConstants.Properties.Resources)
+                                 ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries);
+
             if (resources == null) {
                 return false;
             }
@@ -966,7 +972,9 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(ticket));
             }
 
-            var scopes = ticket.GetProperty(OpenIdConnectConstants.Properties.Scopes)?.Split(' ');
+            var scopes = ticket.GetProperty(OpenIdConnectConstants.Properties.Scopes)
+                              ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries);
+
             if (scopes == null) {
                 return false;
             }
@@ -1328,7 +1336,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 return false;
             }
 
-            return (from component in source.Split(' ')
+            return (from component in source.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                     where string.Equals(component, value, StringComparison.Ordinal)
                     select component).Any();
         }
@@ -1343,7 +1351,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             }
 
             var set = new HashSet<string>(
-                collection: source.Split(' '),
+                collection: source.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries),
                 comparer: StringComparer.Ordinal);
 
             return set.SetEquals(components);

--- a/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -1092,7 +1092,7 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
             }
 
             if (string.IsNullOrEmpty(property)) {
-                throw new ArgumentException($"{nameof(property)} cannot be null or empty.", nameof(property));
+                throw new ArgumentException("The property name cannot be null or empty.", nameof(property));
             }
 
             if (string.IsNullOrEmpty(value)) {
@@ -1141,8 +1141,8 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 return ticket;
             }
 
-            if (audiences.Any(audience => audience.Contains(" "))) {
-                throw new ArgumentException("The audiences cannot contain spaces.", nameof(audiences));
+            if (audiences.Any(audience => string.IsNullOrEmpty(audience) || audience.Contains(" "))) {
+                throw new ArgumentException("The audiences cannot be null, empty or contain spaces.", nameof(audiences));
             }
 
             ticket.Properties.Items[OpenIdConnectConstants.Properties.Audiences] =
@@ -1182,8 +1182,8 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 return ticket;
             }
 
-            if (presenters.Any(presenter => presenter.Contains(" "))) {
-                throw new ArgumentException("The presenters cannot contain spaces.", nameof(presenters));
+            if (presenters.Any(presenter => string.IsNullOrEmpty(presenter) || presenter.Contains(" "))) {
+                throw new ArgumentException("The presenters cannot be null, empty or contain spaces.", nameof(presenters));
             }
 
             ticket.Properties.Items[OpenIdConnectConstants.Properties.Presenters] =
@@ -1223,8 +1223,8 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 return ticket;
             }
 
-            if (resources.Any(resource => resource.Contains(" "))) {
-                throw new ArgumentException("The resources cannot contain spaces.", nameof(resources));
+            if (resources.Any(resource => string.IsNullOrEmpty(resource) || resource.Contains(" "))) {
+                throw new ArgumentException("The resources cannot be null, empty or contain spaces.", nameof(resources));
             }
 
             ticket.Properties.Items[OpenIdConnectConstants.Properties.Resources] =
@@ -1264,8 +1264,8 @@ namespace AspNet.Security.OpenIdConnect.Extensions {
                 return ticket;
             }
 
-            if (scopes.Any(scope => scope.Contains(" "))) {
-                throw new ArgumentException("The scopes cannot contain spaces.", nameof(scopes));
+            if (scopes.Any(scope => string.IsNullOrEmpty(scope) || scope.Contains(" "))) {
+                throw new ArgumentException("The scopes cannot be null, empty or contain spaces.", nameof(scopes));
             }
 
             ticket.Properties.Items[OpenIdConnectConstants.Properties.Scopes] =

--- a/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
+++ b/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectConstants.cs
@@ -228,6 +228,10 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             public const string Token = "token";
         }
 
+        public static class Separators {
+            public static readonly char[] Space = { ' ' };
+        }
+
         public static class Scopes {
             public const string Address = "address";
             public const string Email = "email";

--- a/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -26,7 +26,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return request.Resource?.Split(' ')
+            return request.Resource?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                                    ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -40,7 +40,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return request.Scope?.Split(' ')
+            return request.Scope?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                                 ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -54,7 +54,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(response));
             }
 
-            return response.Resource?.Split(' ')
+            return response.Resource?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                                     ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -68,7 +68,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(response));
             }
 
-            return response.Scope?.Split(' ')
+            return response.Scope?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                                  ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -409,7 +409,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             string destinations;
             claim.Properties.TryGetValue(OpenIdConnectConstants.Properties.Destinations, out destinations);
 
-            return destinations?.Split(' ')
+            return destinations?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                                ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -713,7 +713,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             }
 
             return ticket.GetProperty(OpenIdConnectConstants.Properties.Audiences)
-                        ?.Split(' ')
+                        ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                         ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -730,7 +730,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             }
 
             return ticket.GetProperty(OpenIdConnectConstants.Properties.Presenters)
-                        ?.Split(' ')
+                        ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                         ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -760,7 +760,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             }
 
             return ticket.GetProperty(OpenIdConnectConstants.Properties.Resources)
-                        ?.Split(' ')
+                        ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                         ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -777,7 +777,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             }
 
             return ticket.GetProperty(OpenIdConnectConstants.Properties.Scopes)
-                        ?.Split(' ')
+                        ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                         ?.Distinct(StringComparer.Ordinal)
                    ?? Enumerable.Empty<string>();
         }
@@ -869,7 +869,9 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(ticket));
             }
 
-            var audiences = ticket.GetProperty(OpenIdConnectConstants.Properties.Audiences)?.Split(' ');
+            var audiences = ticket.GetProperty(OpenIdConnectConstants.Properties.Audiences)
+                                 ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries);
+
             if (audiences == null) {
                 return false;
             }
@@ -901,7 +903,9 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(ticket));
             }
 
-            var presenters = ticket.GetProperty(OpenIdConnectConstants.Properties.Presenters)?.Split(' ');
+            var presenters = ticket.GetProperty(OpenIdConnectConstants.Properties.Presenters)
+                                  ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries);
+
             if (presenters == null) {
                 return false;
             }
@@ -933,7 +937,9 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(ticket));
             }
 
-            var resources = ticket.GetProperty(OpenIdConnectConstants.Properties.Resources)?.Split(' ');
+            var resources = ticket.GetProperty(OpenIdConnectConstants.Properties.Resources)
+                                 ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries);
+
             if (resources == null) {
                 return false;
             }
@@ -965,7 +971,9 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 throw new ArgumentNullException(nameof(ticket));
             }
 
-            var scopes = ticket.GetProperty(OpenIdConnectConstants.Properties.Scopes)?.Split(' ');
+            var scopes = ticket.GetProperty(OpenIdConnectConstants.Properties.Scopes)
+                              ?.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries);
+
             if (scopes == null) {
                 return false;
             }
@@ -1327,7 +1335,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 return false;
             }
 
-            return (from component in source.Split(' ')
+            return (from component in source.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries)
                     where string.Equals(component, value, StringComparison.Ordinal)
                     select component).Any();
         }
@@ -1342,7 +1350,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             }
 
             var set = new HashSet<string>(
-                collection: source.Split(' '),
+                collection: source.Split(OpenIdConnectConstants.Separators.Space, StringSplitOptions.RemoveEmptyEntries),
                 comparer: StringComparer.Ordinal);
 
             return set.SetEquals(components);

--- a/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
+++ b/src/Owin.Security.OpenIdConnect.Extensions/OpenIdConnectExtensions.cs
@@ -1091,7 +1091,7 @@ namespace Owin.Security.OpenIdConnect.Extensions {
             }
 
             if (string.IsNullOrEmpty(property)) {
-                throw new ArgumentException($"{nameof(property)} cannot be null or empty.", nameof(property));
+                throw new ArgumentException("The property name cannot be null or empty.", nameof(property));
             }
 
             if (string.IsNullOrEmpty(value)) {
@@ -1140,8 +1140,8 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 return ticket;
             }
 
-            if (audiences.Any(audience => audience.Contains(" "))) {
-                throw new ArgumentException("The audiences cannot contain spaces.", nameof(audiences));
+            if (audiences.Any(audience => string.IsNullOrEmpty(audience) || audience.Contains(" "))) {
+                throw new ArgumentException("The audiences cannot be null, empty or contain spaces.", nameof(audiences));
             }
 
             ticket.Properties.Dictionary[OpenIdConnectConstants.Properties.Audiences] =
@@ -1181,8 +1181,8 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 return ticket;
             }
 
-            if (presenters.Any(presenter => presenter.Contains(" "))) {
-                throw new ArgumentException("The presenters cannot contain spaces.", nameof(presenters));
+            if (presenters.Any(presenter => string.IsNullOrEmpty(presenter) || presenter.Contains(" "))) {
+                throw new ArgumentException("The presenters cannot be null, empty or contain spaces.", nameof(presenters));
             }
 
             ticket.Properties.Dictionary[OpenIdConnectConstants.Properties.Presenters] =
@@ -1222,8 +1222,8 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 return ticket;
             }
 
-            if (resources.Any(resource => resource.Contains(" "))) {
-                throw new ArgumentException("The resources cannot contain spaces.", nameof(resources));
+            if (resources.Any(resource => string.IsNullOrEmpty(resource) || resource.Contains(" "))) {
+                throw new ArgumentException("The resources cannot be null, empty or contain spaces.", nameof(resources));
             }
 
             ticket.Properties.Dictionary[OpenIdConnectConstants.Properties.Resources] =
@@ -1263,8 +1263,8 @@ namespace Owin.Security.OpenIdConnect.Extensions {
                 return ticket;
             }
 
-            if (scopes.Any(scope => scope.Contains(" "))) {
-                throw new ArgumentException("The scopes cannot contain spaces.", nameof(scopes));
+            if (scopes.Any(scope => string.IsNullOrEmpty(scope) || scope.Contains(" "))) {
+                throw new ArgumentException("The scopes cannot be null, empty or contain spaces.", nameof(scopes));
             }
 
             ticket.Properties.Dictionary[OpenIdConnectConstants.Properties.Scopes] =


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/Orchard2/issues/247.