### PR TITLE
 Revamp OpenIdConnectMessage and introduce OpenIdConnectParameter/OpenIdConnectConverter

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Client/OpenIdConnectClient.cs
+++ b/src/AspNet.Security.OpenIdConnect.Client/OpenIdConnectClient.cs
@@ -216,12 +216,12 @@ namespace AspNet.Security.OpenIdConnect.Client {
             var parameters = new Dictionary<string, string>();
 
             foreach (var parameter in request.GetParameters()) {
-                var value = parameter.Value as JValue;
-                if (value == null) {
+                var value = (string) parameter.Value;
+                if (string.IsNullOrEmpty(value)) {
                     continue;
                 }
 
-                parameters.Add(parameter.Key, (string) parameter.Value);
+                parameters.Add(parameter.Key, value);
             }
 
             if (method == HttpMethod.Get && parameters.Count != 0) {
@@ -291,7 +291,7 @@ namespace AspNet.Security.OpenIdConnect.Client {
                             continue;
                         }
 
-                        result.SetParameter(
+                        result.AddParameter(
                             Uri.UnescapeDataString(name.Replace('+', ' ')),
                             Uri.UnescapeDataString(value.Replace('+', ' ')));
                     }
@@ -303,12 +303,9 @@ namespace AspNet.Security.OpenIdConnect.Client {
             else if (string.Equals(response.Content?.Headers?.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase)) {
                 using (var stream = await response.Content.ReadAsStreamAsync())
                 using (var reader = new JsonTextReader(new StreamReader(stream))) {
-                    var payload = JToken.ReadFrom(reader) as JObject;
-                    if (payload == null) {
-                        throw new InvalidOperationException("The JSON payload returned by the server was invalid.");
-                    }
+                    var serializer = JsonSerializer.CreateDefault();
 
-                    return new OpenIdConnectResponse(payload);
+                    return serializer.Deserialize<OpenIdConnectResponse>(reader);
                 }
             }
 
@@ -329,7 +326,7 @@ namespace AspNet.Security.OpenIdConnect.Client {
                             continue;
                         }
 
-                        result.SetParameter(name, value);
+                        result.AddParameter(name, value);
                     }
 
                     return result;
@@ -347,7 +344,7 @@ namespace AspNet.Security.OpenIdConnect.Client {
                             continue;
                         }
 
-                        result.SetParameter(line.Substring(0, index), line.Substring(index + 1));
+                        result.AddParameter(line.Substring(0, index), line.Substring(index + 1));
                     }
 
                     return result;

--- a/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConverter.cs
+++ b/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConverter.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Reflection;
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace AspNet.Security.OpenIdConnect.Primitives {
+    /// <summary>
+    /// Represents a JSON.NET converter able to convert <see cref="OpenIdConnectRequest"/>
+    /// and <see cref="OpenIdConnectResponse"/> instances.
+    /// </summary>
+    public class OpenIdConnectConverter : JsonConverter {
+        /// <summary>
+        /// Determines whether the specified type is supported by this converter.
+        /// </summary>
+        /// <param name="type">The type to convert.</param>
+        /// <returns><c>true</c> if the type is supported, <c>false</c> otherwise.</returns>
+        public override bool CanConvert([NotNull] Type type) {
+            if (type == null) {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            return typeof(OpenIdConnectMessage).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo());
+        }
+
+        /// <summary>
+        /// Deserializes an <see cref="OpenIdConnectMessage"/> instance.
+        /// </summary>
+        /// <param name="reader">The JSON reader.</param>
+        /// <param name="type">The type of the deserialized instance.</param>
+        /// <param name="value">The existing <see cref="OpenIdConnectMessage"/>, if applicable.</param>
+        /// <param name="serializer">The JSON serializer.</param>
+        /// <returns>The deserialized <see cref="OpenIdConnectMessage"/> instance.</returns>
+        public override object ReadJson(
+            [NotNull] JsonReader reader, [NotNull] Type type,
+            [CanBeNull] object value, [CanBeNull] JsonSerializer serializer) {
+            if (reader == null) {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            if (type == null) {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            // Note: OpenID Connect messages are always represented as JSON objects.
+            var payload = JToken.Load(reader) as JObject;
+            if (payload == null) {
+                throw new JsonSerializationException("An error occurred while reading the JSON payload.");
+            }
+
+            // If no existing value was specified, instantiate a
+            // new request/response depending on the requested type.
+            var message = value as OpenIdConnectMessage;
+            if (message == null) {
+                if (type == typeof(OpenIdConnectRequest)) {
+                    message = new OpenIdConnectRequest();
+                }
+
+                else if (type == typeof(OpenIdConnectResponse)) {
+                    message = new OpenIdConnectResponse();
+                }
+            }
+
+            if (message == null) {
+                throw new ArgumentException("The specified type is not supported.", nameof(type));
+            }
+
+            foreach (var parameter in payload.Properties()) {
+                message.AddParameter(parameter.Name, parameter.Value);
+            }
+
+            return message;
+        }
+
+        /// <summary>
+        /// Serializes an <see cref="OpenIdConnectMessage"/>.
+        /// </summary>
+        /// <param name="writer">The JSON writer.</param>
+        /// <param name="value">The <see cref="OpenIdConnectMessage"/> instance.</param>
+        /// <param name="serializer">The JSON serializer.</param>
+        public override void WriteJson([NotNull] JsonWriter writer,
+            [NotNull] object value, [CanBeNull] JsonSerializer serializer) {
+            if (writer == null) {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            if (value == null) {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var message = value as OpenIdConnectMessage;
+            if (message == null) {
+                throw new ArgumentException("The specified object is not supported.", nameof(value));
+            }
+
+            writer.WriteStartObject();
+
+            foreach (var parameter in message.GetParameters()) {
+                writer.WritePropertyName(parameter.Key);
+
+                var token = (JToken) parameter.Value;
+                if (token == null) {
+                    continue;
+                }
+
+                token.WriteTo(writer);
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectExtensions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectExtensions.cs
@@ -81,7 +81,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var value = request.GetProperty(OpenIdConnectConstants.Properties.MessageType);
+            var value = request.GetProperty<string>(OpenIdConnectConstants.Properties.MessageType);
             if (string.IsNullOrEmpty(value)) {
                 return false;
             }
@@ -100,7 +100,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var value = request.GetProperty(OpenIdConnectConstants.Properties.ConfidentialityLevel);
+            var value = request.GetProperty<string>(OpenIdConnectConstants.Properties.ConfidentialityLevel);
             if (string.IsNullOrEmpty(value)) {
                 return false;
             }
@@ -118,7 +118,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var value = request.GetProperty(OpenIdConnectConstants.Properties.MessageType);
+            var value = request.GetProperty<string>(OpenIdConnectConstants.Properties.MessageType);
             if (string.IsNullOrEmpty(value)) {
                 return false;
             }
@@ -136,7 +136,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var value = request.GetProperty(OpenIdConnectConstants.Properties.MessageType);
+            var value = request.GetProperty<string>(OpenIdConnectConstants.Properties.MessageType);
             if (string.IsNullOrEmpty(value)) {
                 return false;
             }
@@ -154,7 +154,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var value = request.GetProperty(OpenIdConnectConstants.Properties.MessageType);
+            var value = request.GetProperty<string>(OpenIdConnectConstants.Properties.MessageType);
             if (string.IsNullOrEmpty(value)) {
                 return false;
             }
@@ -172,7 +172,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var value = request.GetProperty(OpenIdConnectConstants.Properties.MessageType);
+            var value = request.GetProperty<string>(OpenIdConnectConstants.Properties.MessageType);
             if (string.IsNullOrEmpty(value)) {
                 return false;
             }
@@ -190,7 +190,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var value = request.GetProperty(OpenIdConnectConstants.Properties.MessageType);
+            var value = request.GetProperty<string>(OpenIdConnectConstants.Properties.MessageType);
             if (string.IsNullOrEmpty(value)) {
                 return false;
             }
@@ -208,7 +208,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var value = request.GetProperty(OpenIdConnectConstants.Properties.MessageType);
+            var value = request.GetProperty<string>(OpenIdConnectConstants.Properties.MessageType);
             if (string.IsNullOrEmpty(value)) {
                 return false;
             }
@@ -226,7 +226,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var value = request.GetProperty(OpenIdConnectConstants.Properties.MessageType);
+            var value = request.GetProperty<string>(OpenIdConnectConstants.Properties.MessageType);
             if (string.IsNullOrEmpty(value)) {
                 return false;
             }

--- a/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectParameter.cs
+++ b/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectParameter.cs
@@ -1,0 +1,447 @@
+﻿using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace AspNet.Security.OpenIdConnect.Primitives {
+    /// <summary>
+    /// Represents an OpenID Connect parameter value, that can be either
+    /// a primitive value or a complex JSON representation containing child nodes.
+    /// </summary>
+    public struct OpenIdConnectParameter : IEquatable<OpenIdConnectParameter> {
+        /// <summary>
+        /// Initializes a new OpenID Connect
+        /// parameter using the specified value.
+        /// </summary>
+        /// <param name="value">The parameter value.</param>
+        public OpenIdConnectParameter(bool value) {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new OpenID Connect
+        /// parameter using the specified value.
+        /// </summary>
+        /// <param name="value">The parameter value.</param>
+        public OpenIdConnectParameter(bool? value) {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new OpenID Connect
+        /// parameter using the specified value.
+        /// </summary>
+        /// <param name="value">The parameter value.</param>
+        public OpenIdConnectParameter(JToken value) {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new OpenID Connect
+        /// parameter using the specified value.
+        /// </summary>
+        /// <param name="value">The parameter value.</param>
+        public OpenIdConnectParameter(long value) {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new OpenID Connect
+        /// parameter using the specified value.
+        /// </summary>
+        /// <param name="value">The parameter value.</param>
+        public OpenIdConnectParameter(long? value) {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Initializes a new OpenID Connect
+        /// parameter using the specified value.
+        /// </summary>
+        /// <param name="value">The parameter value.</param>
+        public OpenIdConnectParameter(string value) {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Gets the child item corresponding to the specified index.
+        /// </summary>
+        /// <param name="index">The index of the child item.</param>
+        /// <returns>An <see cref="OpenIdConnectParameter"/> instance containing the item value.</returns>
+        public OpenIdConnectParameter? this[int index] => GetParameter(index);
+
+        /// <summary>
+        /// Gets the child item corresponding to the specified name.
+        /// </summary>
+        /// <param name="name">The name of the child item.</param>
+        /// <returns>An <see cref="OpenIdConnectParameter"/> instance containing the item value.</returns>
+        public OpenIdConnectParameter? this[string name] => GetParameter(name);
+
+        /// <summary>
+        /// Gets the associated value, that can be either a primitive
+        /// CLR type (e.g bool, string, long) or a complex JSON object.
+        /// </summary>
+        public object Value { get; }
+
+        /// <summary>
+        /// Determines whether the current <see cref="OpenIdConnectParameter"/>
+        /// instance is equal to the specified <see cref="OpenIdConnectParameter"/>.
+        /// </summary>
+        /// <param name="parameter">The other object to which to compare this instance.</param>
+        /// <returns><c>true</c> if the two instances are equal, <c>false</c> otherwise.</returns>
+        public bool Equals(OpenIdConnectParameter parameter) {
+            // If the two parameters reference the same instance, return true.
+            // Note: true will also be returned if the two parameters are null.
+            if (ReferenceEquals(Value, parameter.Value)) {
+                return true;
+            }
+
+            // If one of the two parameters is null, return false.
+            if (Value == null || parameter.Value == null) {
+                return false;
+            }
+
+            // If the two parameters are JSON values, use JToken.DeepEquals.
+            if (Value is JToken && parameter.Value is JToken) {
+                return JToken.DeepEquals((JToken) Value, ((JToken) parameter.Value));
+            }
+
+            // If the current instance is a JValue, compare the
+            // underlying value to the other parameter value.
+            if (Value is JValue) {
+                return ((JValue) Value).Value.Equals(parameter.Value);
+            }
+
+            // If the other parameter is a JValue, compare the
+            // underlying value to the current parameter value.
+            if (parameter.Value is JValue) {
+                return ((JValue) parameter.Value).Value.Equals(Value);
+            }
+
+            return Value.Equals(parameter.Value);
+        }
+
+        /// <summary>
+        /// Determines whether the current <see cref="OpenIdConnectParameter"/>
+        /// instance is equal to the specified <see cref="object"/>.
+        /// </summary>
+        /// <param name="value">The other object to which to compare this instance.</param>
+        /// <returns><c>true</c> if the two instances are equal, <c>false</c> otherwise.</returns>
+        public override bool Equals(object value) {
+            if (value is OpenIdConnectParameter) {
+                return Equals((OpenIdConnectParameter) value);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the hash code of the current <see cref="OpenIdConnectParameter"/> instance.
+        /// </summary>
+        /// <returns>The hash code for the current instance.</returns>
+        public override int GetHashCode() {
+            if (Value == null) {
+                return 0;
+            }
+
+            // Note: if the value is a JValue, JSON.NET will automatically
+            // return the hash code corresponding to the underlying value.
+            return Value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Gets the child item corresponding to the specified index.
+        /// </summary>
+        /// <param name="index">The index of the child item.</param>
+        /// <returns>An <see cref="OpenIdConnectParameter"/> instance containing the item value.</returns>
+        public OpenIdConnectParameter? GetParameter(int index) {
+            if (index < 0) {
+                throw new ArgumentOutOfRangeException(nameof(index), "The item index cannot be negative.");
+            }
+
+            // If the value is not an array, return null.
+            var array = Value as JArray;
+            if (array == null) {
+                return null;
+            }
+
+            // If the specified index goes beyond the
+            // number of items in the array, return null.
+            if (index >= array.Count) {
+                return null;
+            }
+
+            // If the item doesn't exist, return a null parameter.
+            var value = array[index];
+            if (value == null) {
+                return null;
+            }
+
+            return new OpenIdConnectParameter(value);
+        }
+
+        /// <summary>
+        /// Gets the child item corresponding to the specified name.
+        /// </summary>
+        /// <param name="name">The name of the child item.</param>
+        /// <returns>An <see cref="OpenIdConnectParameter"/> instance containing the item value.</returns>
+        public OpenIdConnectParameter? GetParameter([NotNull] string name) {
+            if (string.IsNullOrEmpty(name)) {
+                throw new ArgumentException("The item name cannot be null or empty.");
+            }
+
+            // If the parameter is not a JSON.NET object, return null.
+            var container = Value as JObject;
+            if (container == null) {
+                return null;
+            }
+
+            // If the item doesn't exist, return a null parameter.
+            var value = container[name];
+            if (value == null) {
+                return null;
+            }
+
+            return new OpenIdConnectParameter(value);
+        }
+
+        /// <summary>
+        /// Gets the child items associated with the current parameter.
+        /// </summary>
+        /// <returns>An enumeration of all the parameters associated with the current instance.</returns>
+        public IEnumerable<KeyValuePair<string, OpenIdConnectParameter>> GetParameters() {
+            var token = Value as JToken;
+            if (token == null) {
+                yield break;
+            }
+
+            foreach (var parameter in token.Children()) {
+                var property = parameter as JProperty;
+                if (property == null) {
+                    yield return new KeyValuePair<string, OpenIdConnectParameter>(null, parameter);
+
+                    continue;
+                }
+
+                yield return new KeyValuePair<string, OpenIdConnectParameter>(property.Name, property.Value);
+            }
+
+            yield break;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="string"/> representation of the current instance.
+        /// </summary>
+        /// <returns>The <see cref="string"/> representation associated with the parameter value.</returns>
+        public override string ToString() {
+            if (Value == null) {
+                return string.Empty;
+            }
+
+            var token = Value as JToken;
+            if (token == null) {
+                return Value.ToString();
+            }
+
+            var value = token as JValue;
+            if (value == null) {
+                return token.ToString(Formatting.None);
+            }
+
+            return value.Value.ToString();
+        }
+
+        /// <summary>
+        /// Determines whether two <see cref="OpenIdConnectParameter"/> instances are equal.
+        /// </summary>
+        /// <param name="left">The first instance.</param>
+        /// <param name="right">The second instance.</param>
+        /// <returns><c>true</c> if the two instances are equal, <c>false</c> otherwise.</returns>
+        public static bool operator ==(OpenIdConnectParameter left, OpenIdConnectParameter right) => left.Equals(right);
+
+        /// <summary>
+        /// Determines whether two <see cref="OpenIdConnectParameter"/> instances are not equal.
+        /// </summary>
+        /// <param name="left">The first instance.</param>
+        /// <param name="right">The second instance.</param>
+        /// <returns><c>true</c> if the two instances are not equal, <c>false</c> otherwise.</returns>
+        public static bool operator !=(OpenIdConnectParameter left, OpenIdConnectParameter right) => !left.Equals(right);
+
+        /// <summary>
+        /// Converts an <see cref="OpenIdConnectParameter"/> instance to a boolean.
+        /// </summary>
+        /// <param name="parameter">The parameter to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static explicit operator bool(OpenIdConnectParameter? parameter) => Convert<bool>(parameter);
+
+        /// <summary>
+        /// Converts an <see cref="OpenIdConnectParameter"/> instance to a nullable boolean.
+        /// </summary>
+        /// <param name="parameter">The parameter to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static explicit operator bool?(OpenIdConnectParameter? parameter) => Convert<bool?>(parameter);
+
+        /// <summary>
+        /// Converts an <see cref="OpenIdConnectParameter"/> instance to a <see cref="JArray"/>.
+        /// </summary>
+        /// <param name="parameter">The parameter to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static explicit operator JArray(OpenIdConnectParameter? parameter) => Convert<JArray>(parameter);
+
+        /// <summary>
+        /// Converts an <see cref="OpenIdConnectParameter"/> instance to a <see cref="JObject"/>.
+        /// </summary>
+        /// <param name="parameter">The parameter to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static explicit operator JObject(OpenIdConnectParameter? parameter) => Convert<JObject>(parameter);
+
+        /// <summary>
+        /// Converts an <see cref="OpenIdConnectParameter"/> instance to a <see cref="JToken"/>.
+        /// </summary>
+        /// <param name="parameter">The parameter to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static explicit operator JToken(OpenIdConnectParameter? parameter) => Convert<JToken>(parameter);
+
+        /// <summary>
+        /// Converts an <see cref="OpenIdConnectParameter"/> instance to a <see cref="JValue"/>.
+        /// </summary>
+        /// <param name="parameter">The parameter to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static explicit operator JValue(OpenIdConnectParameter? parameter) => Convert<JValue>(parameter);
+
+        /// <summary>
+        /// Converts an <see cref="OpenIdConnectParameter"/> instance to a long integer.
+        /// </summary>
+        /// <param name="parameter">The parameter to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static explicit operator long(OpenIdConnectParameter? parameter) => Convert<long>(parameter);
+
+        /// <summary>
+        /// Converts an <see cref="OpenIdConnectParameter"/> instance to a nullable long integer.
+        /// </summary>
+        /// <param name="parameter">The parameter to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static explicit operator long?(OpenIdConnectParameter? parameter) => Convert<long?>(parameter);
+
+        /// <summary>
+        /// Converts an <see cref="OpenIdConnectParameter"/> instance to a string.
+        /// </summary>
+        /// <param name="parameter">The parameter to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static explicit operator string(OpenIdConnectParameter? parameter) => Convert<string>(parameter);
+
+        /// <summary>
+        /// Converts a boolean to an <see cref="OpenIdConnectParameter"/> instance.
+        /// </summary>
+        /// <param name="value">The value to convert</param>
+        /// <returns>An <see cref="OpenIdConnectParameter"/> instance.</returns>
+        public static implicit operator OpenIdConnectParameter(bool value) => new OpenIdConnectParameter(value);
+
+        /// <summary>
+        /// Converts a nullable boolean to an <see cref="OpenIdConnectParameter"/> instance.
+        /// </summary>
+        /// <param name="value">The value to convert</param>
+        /// <returns>An <see cref="OpenIdConnectParameter"/> instance.</returns>
+        public static implicit operator OpenIdConnectParameter(bool? value) => new OpenIdConnectParameter(value);
+
+        /// <summary>
+        /// Converts a <see cref="JToken"/> to an <see cref="OpenIdConnectParameter"/> instance.
+        /// </summary>
+        /// <param name="value">The value to convert</param>
+        /// <returns>An <see cref="OpenIdConnectParameter"/> instance.</returns>
+        public static implicit operator OpenIdConnectParameter(JToken value) => new OpenIdConnectParameter(value);
+
+        /// <summary>
+        /// Converts a long integer to an <see cref="OpenIdConnectParameter"/> instance.
+        /// </summary>
+        /// <param name="value">The value to convert</param>
+        /// <returns>An <see cref="OpenIdConnectParameter"/> instance.</returns>
+        public static implicit operator OpenIdConnectParameter(long value) => new OpenIdConnectParameter(value);
+
+        /// <summary>
+        /// Converts a nullable long integer to an <see cref="OpenIdConnectParameter"/> instance.
+        /// </summary>
+        /// <param name="value">The value to convert</param>
+        /// <returns>An <see cref="OpenIdConnectParameter"/> instance.</returns>
+        public static implicit operator OpenIdConnectParameter(long? value) => new OpenIdConnectParameter(value);
+
+        /// <summary>
+        /// Converts a string to an <see cref="OpenIdConnectParameter"/> instance.
+        /// </summary>
+        /// <param name="value">The value to convert</param>
+        /// <returns>An <see cref="OpenIdConnectParameter"/> instance.</returns>
+        public static implicit operator OpenIdConnectParameter(string value) => new OpenIdConnectParameter(value);
+
+        /// <summary>
+        /// Converts the parameter to the specified generic type.
+        /// </summary>
+        /// <typeparam name="T">The type the parameter will be converted to.</typeparam>
+        /// <param name="parameter">The <see cref="OpenIdConnectParameter"/> instance.</param>
+        /// <returns>The converted parameter.</returns>
+        private static T Convert<T>(OpenIdConnectParameter? parameter) {
+            if (parameter == null) {
+                return default(T);
+            }
+
+            var value = parameter.Value.Value;
+            if (value == null) {
+                return default(T);
+            }
+
+            if (value is T) {
+                return (T) value;
+            }
+
+            // Note: the value is either a JSON object or a
+            // primitive type that can be used with JValue.
+            var token = value as JToken;
+            if (token == null) {
+                token = new JValue(value);
+            }
+
+            try {
+                return token.ToObject<T>();
+            }
+
+            // Swallow the argument/format/invalid cast exceptions.
+            catch (Exception exception) when (exception is ArgumentException ||
+                                              exception is FormatException ||
+                                              exception is InvalidCastException) {
+                return default(T);
+            }
+
+            // Other exceptions will be automatically re-thrown.
+        }
+
+        /// <summary>
+        /// Determines whether an OpenID Connect parameter is null or empty.
+        /// </summary>
+        /// <param name="parameter">The OpenID Connect parameter.</param>
+        /// <returns><c>true</c> if the parameter is null or empty, <c>false</c> otherwise.</returns>
+        internal static bool IsNullOrEmpty(OpenIdConnectParameter? parameter) {
+            if (parameter == null) {
+                return true;
+            }
+
+            var value = parameter.Value.Value;
+            if (value == null) {
+                return true;
+            }
+
+            if (value is string) {
+                return string.IsNullOrEmpty((string) value);
+            }
+
+            var token = value as JToken;
+            if (token == null) {
+                return false;
+            }
+
+            return (token.Type == JTokenType.Array && !token.HasValues) ||
+                   (token.Type == JTokenType.Object && !token.HasValues) ||
+                   (token.Type == JTokenType.String && string.IsNullOrEmpty((string) token)) ||
+                   (token.Type == JTokenType.Null);
+        }
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectRequest.cs
+++ b/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectRequest.cs
@@ -16,7 +16,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
     /// Represents a generic OpenID Connect request.
     /// </summary>
     [DebuggerDisplay("Parameters: {Parameters.Count}")]
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+    [JsonConverter(typeof(OpenIdConnectConverter))]
     public class OpenIdConnectRequest : OpenIdConnectMessage {
         /// <summary>
         /// Initializes a new OpenID Connect request.
@@ -27,22 +27,22 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// <summary>
         /// Initializes a new OpenID Connect request.
         /// </summary>
-        /// <param name="payload">The request payload.</param>
-        public OpenIdConnectRequest([NotNull] JObject payload)
-            : base(payload) { }
-
-        /// <summary>
-        /// Initializes a new OpenID Connect request.
-        /// </summary>
         /// <param name="parameters">The request parameters.</param>
-        public OpenIdConnectRequest([NotNull] IDictionary<string, string> parameters)
+        public OpenIdConnectRequest([NotNull] IEnumerable<KeyValuePair<string, JToken>> parameters)
             : base(parameters) { }
 
         /// <summary>
         /// Initializes a new OpenID Connect request.
         /// </summary>
         /// <param name="parameters">The request parameters.</param>
-        public OpenIdConnectRequest([NotNull] IDictionary<string, JToken> parameters)
+        public OpenIdConnectRequest([NotNull] IEnumerable<KeyValuePair<string, OpenIdConnectParameter>> parameters)
+            : base(parameters) { }
+
+        /// <summary>
+        /// Initializes a new OpenID Connect request.
+        /// </summary>
+        /// <param name="parameters">The request parameters.</param>
+        public OpenIdConnectRequest([NotNull] IEnumerable<KeyValuePair<string, string>> parameters)
             : base(parameters) { }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "access_token" parameter.
         /// </summary>
         public string AccessToken {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.AccessToken); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.AccessToken); }
             set { SetParameter(OpenIdConnectConstants.Parameters.AccessToken, value); }
         }
 
@@ -71,7 +71,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "assertion" parameter.
         /// </summary>
         public string Assertion {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Assertion); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Assertion); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Assertion, value); }
         }
 
@@ -79,7 +79,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "client_assertion" parameter.
         /// </summary>
         public string ClientAssertion {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.ClientAssertion); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.ClientAssertion); }
             set { SetParameter(OpenIdConnectConstants.Parameters.ClientAssertion, value); }
         }
 
@@ -87,7 +87,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "client_assertion_type" parameter.
         /// </summary>
         public string ClientAssertionType {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.ClientAssertionType); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.ClientAssertionType); }
             set { SetParameter(OpenIdConnectConstants.Parameters.ClientAssertionType, value); }
         }
 
@@ -95,7 +95,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "client_id" parameter.
         /// </summary>
         public string ClientId {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.ClientId); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.ClientId); }
             set { SetParameter(OpenIdConnectConstants.Parameters.ClientId, value); }
         }
 
@@ -103,7 +103,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "client_secret" parameter.
         /// </summary>
         public string ClientSecret {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.ClientSecret); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.ClientSecret); }
             set { SetParameter(OpenIdConnectConstants.Parameters.ClientSecret, value); }
         }
 
@@ -111,7 +111,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "code" parameter.
         /// </summary>
         public string Code {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Code); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Code); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Code, value); }
         }
 
@@ -119,7 +119,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "code_challenge" parameter.
         /// </summary>
         public string CodeChallenge {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.CodeChallenge); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.CodeChallenge); }
             set { SetParameter(OpenIdConnectConstants.Parameters.CodeChallenge, value); }
         }
 
@@ -127,7 +127,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "code_challenge_method" parameter.
         /// </summary>
         public string CodeChallengeMethod {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.CodeChallengeMethod); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.CodeChallengeMethod); }
             set { SetParameter(OpenIdConnectConstants.Parameters.CodeChallengeMethod, value); }
         }
 
@@ -135,7 +135,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "code_verifier" parameter.
         /// </summary>
         public string CodeVerifier {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.CodeVerifier); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.CodeVerifier); }
             set { SetParameter(OpenIdConnectConstants.Parameters.CodeVerifier, value); }
         }
 
@@ -143,7 +143,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "grant_type" parameter.
         /// </summary>
         public string GrantType {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.GrantType); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.GrantType); }
             set { SetParameter(OpenIdConnectConstants.Parameters.GrantType, value); }
         }
 
@@ -151,7 +151,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "id_token_hint" parameter.
         /// </summary>
         public string IdTokenHint {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.IdTokenHint); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.IdTokenHint); }
             set { SetParameter(OpenIdConnectConstants.Parameters.IdTokenHint, value); }
         }
 
@@ -159,7 +159,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "nonce" parameter.
         /// </summary>
         public string Nonce {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Nonce); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Nonce); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Nonce, value); }
         }
 
@@ -167,7 +167,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "password" parameter.
         /// </summary>
         public string Password {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Password); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Password); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Password, value); }
         }
 
@@ -175,7 +175,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "post_logout_redirect_uri" parameter.
         /// </summary>
         public string PostLogoutRedirectUri {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.PostLogoutRedirectUri); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.PostLogoutRedirectUri); }
             set { SetParameter(OpenIdConnectConstants.Parameters.PostLogoutRedirectUri, value); }
         }
 
@@ -183,7 +183,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "prompt" parameter.
         /// </summary>
         public string Prompt {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Prompt); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Prompt); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Prompt, value); }
         }
 
@@ -191,7 +191,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "redirect_uri" parameter.
         /// </summary>
         public string RedirectUri {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.RedirectUri); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.RedirectUri); }
             set { SetParameter(OpenIdConnectConstants.Parameters.RedirectUri, value); }
         }
 
@@ -199,7 +199,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "refresh_token" parameter.
         /// </summary>
         public string RefreshToken {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.RefreshToken); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.RefreshToken); }
             set { SetParameter(OpenIdConnectConstants.Parameters.RefreshToken, value); }
         }
 
@@ -207,7 +207,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "request" parameter.
         /// </summary>
         public string Request {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Request); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Request); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Request, value); }
         }
 
@@ -215,7 +215,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "request_id" parameter.
         /// </summary>
         public string RequestId {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.RequestId); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.RequestId); }
             set { SetParameter(OpenIdConnectConstants.Parameters.RequestId, value); }
         }
 
@@ -223,7 +223,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "request_uri" parameter.
         /// </summary>
         public string RequestUri {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.RequestUri); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.RequestUri); }
             set { SetParameter(OpenIdConnectConstants.Parameters.RequestUri, value); }
         }
 
@@ -231,7 +231,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "resource" parameter.
         /// </summary>
         public string Resource {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Resource); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Resource); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Resource, value); }
         }
 
@@ -239,7 +239,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "response_mode" parameter.
         /// </summary>
         public string ResponseMode {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.ResponseMode); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.ResponseMode); }
             set { SetParameter(OpenIdConnectConstants.Parameters.ResponseMode, value); }
         }
 
@@ -247,7 +247,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "response_type" parameter.
         /// </summary>
         public string ResponseType {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.ResponseType); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.ResponseType); }
             set { SetParameter(OpenIdConnectConstants.Parameters.ResponseType, value); }
         }
 
@@ -255,7 +255,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "scope" parameter.
         /// </summary>
         public string Scope {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Scope); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Scope); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Scope, value); }
         }
 
@@ -263,7 +263,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "state" parameter.
         /// </summary>
         public string State {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.State); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.State); }
             set { SetParameter(OpenIdConnectConstants.Parameters.State, value); }
         }
 
@@ -271,7 +271,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "token" parameter.
         /// </summary>
         public string Token {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Token); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Token); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Token, value); }
         }
 
@@ -279,7 +279,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "token_type_hint" parameter.
         /// </summary>
         public string TokenTypeHint {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.TokenTypeHint); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.TokenTypeHint); }
             set { SetParameter(OpenIdConnectConstants.Parameters.TokenTypeHint, value); }
         }
 
@@ -287,7 +287,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "username" parameter.
         /// </summary>
         public string Username {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Username); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Username); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Username, value); }
         }
     }

--- a/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectResponse.cs
+++ b/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectResponse.cs
@@ -16,7 +16,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
     /// Represents a generic OpenID Connect response.
     /// </summary>
     [DebuggerDisplay("Parameters: {Parameters.Count}")]
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+    [JsonConverter(typeof(OpenIdConnectConverter))]
     public class OpenIdConnectResponse : OpenIdConnectMessage {
         /// <summary>
         /// Initializes a new OpenID Connect response.
@@ -27,22 +27,22 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// <summary>
         /// Initializes a new OpenID Connect response.
         /// </summary>
-        /// <param name="payload">The response payload.</param>
-        public OpenIdConnectResponse([NotNull] JObject payload)
-            : base(payload) { }
-
-        /// <summary>
-        /// Initializes a new OpenID Connect response.
-        /// </summary>
         /// <param name="parameters">The response parameters.</param>
-        public OpenIdConnectResponse([NotNull] IDictionary<string, string> parameters)
+        public OpenIdConnectResponse([NotNull] IEnumerable<KeyValuePair<string, JToken>> parameters)
             : base(parameters) { }
 
         /// <summary>
         /// Initializes a new OpenID Connect response.
         /// </summary>
         /// <param name="parameters">The response parameters.</param>
-        public OpenIdConnectResponse([NotNull] IDictionary<string, JToken> parameters)
+        public OpenIdConnectResponse([NotNull] IEnumerable<KeyValuePair<string, OpenIdConnectParameter>> parameters)
+            : base(parameters) { }
+
+        /// <summary>
+        /// Initializes a new OpenID Connect response.
+        /// </summary>
+        /// <param name="parameters">The response parameters.</param>
+        public OpenIdConnectResponse([NotNull] IEnumerable<KeyValuePair<string, string>> parameters)
             : base(parameters) { }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "access_token" parameter.
         /// </summary>
         public string AccessToken {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.AccessToken); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.AccessToken); }
             set { SetParameter(OpenIdConnectConstants.Parameters.AccessToken, value); }
         }
 
@@ -71,7 +71,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "code" parameter.
         /// </summary>
         public string Code {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Code); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Code); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Code, value); }
         }
 
@@ -79,7 +79,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "error" parameter.
         /// </summary>
         public string Error {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Error); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Error); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Error, value); }
         }
 
@@ -87,7 +87,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "error_description" parameter.
         /// </summary>
         public string ErrorDescription {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.ErrorDescription); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.ErrorDescription); }
             set { SetParameter(OpenIdConnectConstants.Parameters.ErrorDescription, value); }
         }
 
@@ -95,7 +95,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "error_uri" parameter.
         /// </summary>
         public string ErrorUri {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.ErrorUri); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.ErrorUri); }
             set { SetParameter(OpenIdConnectConstants.Parameters.ErrorUri, value); }
         }
 
@@ -103,7 +103,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "expires_in" parameter.
         /// </summary>
         public long? ExpiresIn {
-            get { return GetParameter<long?>(OpenIdConnectConstants.Parameters.ExpiresIn); }
+            get { return (long?) GetParameter(OpenIdConnectConstants.Parameters.ExpiresIn); }
             set { SetParameter(OpenIdConnectConstants.Parameters.ExpiresIn, value); }
         }
 
@@ -111,7 +111,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "id_token" parameter.
         /// </summary>
         public string IdToken {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.IdToken); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.IdToken); }
             set { SetParameter(OpenIdConnectConstants.Parameters.IdToken, value); }
         }
 
@@ -119,7 +119,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "post_logout_redirect_uri" parameter.
         /// </summary>
         public string PostLogoutRedirectUri {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.PostLogoutRedirectUri); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.PostLogoutRedirectUri); }
             set { SetParameter(OpenIdConnectConstants.Parameters.PostLogoutRedirectUri, value); }
         }
 
@@ -127,7 +127,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "redirect_uri" parameter.
         /// </summary>
         public string RedirectUri {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.RedirectUri); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.RedirectUri); }
             set { SetParameter(OpenIdConnectConstants.Parameters.RedirectUri, value); }
         }
 
@@ -135,7 +135,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "refresh_token" parameter.
         /// </summary>
         public string RefreshToken {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.RefreshToken); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.RefreshToken); }
             set { SetParameter(OpenIdConnectConstants.Parameters.RefreshToken, value); }
         }
 
@@ -143,7 +143,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "resource" parameter.
         /// </summary>
         public string Resource {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Resource); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Resource); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Resource, value); }
         }
 
@@ -151,7 +151,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "scope" parameter.
         /// </summary>
         public string Scope {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.Scope); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.Scope); }
             set { SetParameter(OpenIdConnectConstants.Parameters.Scope, value); }
         }
 
@@ -159,7 +159,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "state" parameter.
         /// </summary>
         public string State {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.State); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.State); }
             set { SetParameter(OpenIdConnectConstants.Parameters.State, value); }
         }
 
@@ -167,7 +167,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         /// Gets or sets the "token_type" parameter.
         /// </summary>
         public string TokenType {
-            get { return GetParameter<string>(OpenIdConnectConstants.Parameters.TokenType); }
+            get { return (string) GetParameter(OpenIdConnectConstants.Parameters.TokenType); }
             set { SetParameter(OpenIdConnectConstants.Parameters.TokenType, value); }
         }
     }

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
@@ -28,10 +27,10 @@ namespace AspNet.Security.OpenIdConnect.Server {
         }
 
         /// <summary>
-        /// Gets the additional claims returned to the client application.
+        /// Gets the additional parameters returned to the client application.
         /// </summary>
-        public IDictionary<string, JToken> Claims { get; } =
-            new Dictionary<string, JToken>(StringComparer.Ordinal);
+        public IDictionary<string, OpenIdConnectParameter> Metadata { get; } =
+            new Dictionary<string, OpenIdConnectParameter>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the authorization endpoint address.

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/HandleIntrospectionRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/HandleIntrospectionRequestContext.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OpenIdConnect.Server {
     /// <summary>
@@ -33,8 +32,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <summary>
         /// Gets the additional claims returned to the caller.
         /// </summary>
-        public IDictionary<string, JToken> Claims { get; } =
-            new Dictionary<string, JToken>(StringComparer.Ordinal);
+        public IDictionary<string, OpenIdConnectParameter> Claims { get; } =
+            new Dictionary<string, OpenIdConnectParameter>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the flag indicating

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/HandleUserinfoRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/HandleUserinfoRequestContext.cs
@@ -33,8 +33,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
         /// <summary>
         /// Gets the additional claims returned to the client application.
         /// </summary>
-        public IDictionary<string, JToken> Claims { get; } =
-            new Dictionary<string, JToken>(StringComparer.Ordinal);
+        public IDictionary<string, OpenIdConnectParameter> Claims { get; } =
+            new Dictionary<string, OpenIdConnectParameter>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the value used for the "address" claim.

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -352,15 +352,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
                     continue;
                 }
 
-                var value = parameter.Value as JValue;
-                if (value == null) {
-                    Logger.LogWarning("A parameter whose type was incompatible was ignored and excluded "+
-                                      "from the authorization response: '{Parameter}'.", parameter.Key);
-
+                // Ignore null or empty parameters, including JSON
+                // objects that can't be represented as strings.
+                var value = (string) parameter.Value;
+                if (string.IsNullOrEmpty(value)) {
                     continue;
                 }
 
-                parameters.Add(parameter.Key, (string) value);
+                parameters.Add(parameter.Key, value);
             }
 
             // Note: at this stage, the redirect_uri parameter MUST be trusted.

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Primitives;
@@ -214,28 +213,23 @@ namespace AspNet.Security.OpenIdConnect.Server {
             var response = new OpenIdConnectResponse {
                 [OpenIdConnectConstants.Metadata.Issuer] = notification.Issuer,
                 [OpenIdConnectConstants.Metadata.AuthorizationEndpoint] = notification.AuthorizationEndpoint,
-                [OpenIdConnectConstants.Metadata.JwksUri] = notification.CryptographyEndpoint,
+                [OpenIdConnectConstants.Metadata.TokenEndpoint] = notification.TokenEndpoint,
                 [OpenIdConnectConstants.Metadata.IntrospectionEndpoint] = notification.IntrospectionEndpoint,
                 [OpenIdConnectConstants.Metadata.EndSessionEndpoint] = notification.LogoutEndpoint,
                 [OpenIdConnectConstants.Metadata.RevocationEndpoint] = notification.RevocationEndpoint,
-                [OpenIdConnectConstants.Metadata.TokenEndpoint] = notification.TokenEndpoint,
                 [OpenIdConnectConstants.Metadata.UserinfoEndpoint] = notification.UserinfoEndpoint,
-                [OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported] = new JArray(notification.CodeChallengeMethods),
+                [OpenIdConnectConstants.Metadata.JwksUri] = notification.CryptographyEndpoint,
                 [OpenIdConnectConstants.Metadata.GrantTypesSupported] = new JArray(notification.GrantTypes),
-                [OpenIdConnectConstants.Metadata.ResponseModesSupported] = new JArray(notification.ResponseModes),
                 [OpenIdConnectConstants.Metadata.ResponseTypesSupported] = new JArray(notification.ResponseTypes),
-                [OpenIdConnectConstants.Metadata.SubjectTypesSupported] = new JArray(notification.SubjectTypes),
+                [OpenIdConnectConstants.Metadata.ResponseModesSupported] = new JArray(notification.ResponseModes),
                 [OpenIdConnectConstants.Metadata.ScopesSupported] = new JArray(notification.Scopes),
-                [OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported] = new JArray(notification.SigningAlgorithms)
+                [OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported] = new JArray(notification.SigningAlgorithms),
+                [OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported] = new JArray(notification.CodeChallengeMethods),
+                [OpenIdConnectConstants.Metadata.SubjectTypesSupported] = new JArray(notification.SubjectTypes)
             };
 
-            foreach (var claim in notification.Claims) {
-                // Ignore claims whose value is null.
-                if (claim.Value == null) {
-                    continue;
-                }
-
-                response.SetParameter(claim.Key, claim.Value);
+            foreach (var metadata in notification.Metadata) {
+                response.AddParameter(metadata.Key, metadata.Value);
             }
 
             return await SendConfigurationResponseAsync(response);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -349,7 +349,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
                         // When multiple claims with the same name exist, convert the existing entry
                         // to a new JArray to allow returning multiple claim values to the caller.
-                        var array = notification.Claims[type] as JArray;
+                        var array = notification.Claims[type].Value as JArray;
                         if (array == null) {
                             array = new JArray();
 
@@ -402,17 +402,17 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 response[OpenIdConnectConstants.Claims.JwtId] = notification.TokenId;
                 response[OpenIdConnectConstants.Claims.TokenType] = notification.TokenType;
 
-                if (notification.IssuedAt.HasValue) {
+                if (notification.IssuedAt != null) {
                     response[OpenIdConnectConstants.Claims.IssuedAt] =
                         EpochTime.GetIntDate(notification.IssuedAt.Value.UtcDateTime);
                 }
 
-                if (notification.NotBefore.HasValue) {
+                if (notification.NotBefore != null) {
                     response[OpenIdConnectConstants.Claims.NotBefore] =
                         EpochTime.GetIntDate(notification.NotBefore.Value.UtcDateTime);
                 }
 
-                if (notification.ExpiresAt.HasValue) {
+                if (notification.ExpiresAt != null) {
                     response[OpenIdConnectConstants.Claims.ExpiresAt] =
                         EpochTime.GetIntDate(notification.ExpiresAt.Value.UtcDateTime);
                 }
@@ -430,12 +430,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 }
 
                 foreach (var claim in notification.Claims) {
-                    // Ignore claims whose value is null.
-                    if (claim.Value == null) {
-                        continue;
-                    }
-
-                    response.SetParameter(claim.Key, claim.Value);
+                    response.AddParameter(claim.Key, claim.Value);
                 }
             }
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
@@ -188,15 +188,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
                     continue;
                 }
 
-                var value = parameter.Value as JValue;
-                if (value == null) {
-                    Logger.LogWarning("A parameter whose type was incompatible was ignored and excluded " +
-                                      "from the logout response: '{Parameter}'.", parameter.Key);
-
+                // Ignore null or empty parameters, including JSON
+                // objects that can't be represented as strings.
+                var value = (string) parameter.Value;
+                if (string.IsNullOrEmpty(value)) {
                     continue;
                 }
 
-                parameters.Add(parameter.Key, (string) value);
+                parameters.Add(parameter.Key, value);
             }
 
             var location = QueryHelpers.AddQueryString(response.PostLogoutRedirectUri, parameters);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -289,12 +289,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             }
 
             foreach (var claim in notification.Claims) {
-                // Ignore claims whose value is null.
-                if (claim.Value == null) {
-                    continue;
-                }
-
-                response.SetParameter(claim.Key, claim.Value);
+                response.AddParameter(claim.Key, claim.Value);
             }
 
             return await SendUserinfoResponseAsync(response);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -249,7 +249,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
             // Copy the confidentiality level associated with the request to the authentication ticket.
             if (!ticket.HasProperty(OpenIdConnectConstants.Properties.ConfidentialityLevel)) {
                 ticket.SetProperty(OpenIdConnectConstants.Properties.ConfidentialityLevel,
-                    request.GetProperty(OpenIdConnectConstants.Properties.ConfidentialityLevel));
+                    request.GetProperty<string>(OpenIdConnectConstants.Properties.ConfidentialityLevel));
             }
 
             // Always include the "openid" scope when the developer doesn't explicitly call SetScopes.
@@ -435,15 +435,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
             using (var buffer = new MemoryStream())
             using (var writer = new StreamWriter(buffer)) {
                 foreach (var parameter in response.GetParameters()) {
-                    var value = parameter.Value as JValue;
-                    if (value == null) {
-                        Logger.LogWarning("A parameter whose type was incompatible was ignored " +
-                                          "and excluded from the response: '{Parameter}'.", parameter.Key);
-
+                    // Ignore null or empty parameters, including JSON
+                    // objects that can't be represented as strings.
+                    var value = (string) parameter.Value;
+                    if (string.IsNullOrEmpty(value)) {
                         continue;
                     }
 
-                    writer.WriteLine("{0}:{1}", parameter.Key, (string) value);
+                    writer.WriteLine("{0}:{1}", parameter.Key, value);
                 }
 
                 writer.Flush();

--- a/src/Owin.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.Owin;
-using Newtonsoft.Json.Linq;
 
 namespace Owin.Security.OpenIdConnect.Server {
     /// <summary>
@@ -28,10 +27,10 @@ namespace Owin.Security.OpenIdConnect.Server {
         }
 
         /// <summary>
-        /// Gets the additional claims returned to the client application.
+        /// Gets the additional parameters returned to the client application.
         /// </summary>
-        public IDictionary<string, JToken> Claims { get; } =
-            new Dictionary<string, JToken>(StringComparer.Ordinal);
+        public IDictionary<string, OpenIdConnectParameter> Metadata { get; } =
+            new Dictionary<string, OpenIdConnectParameter>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the authorization endpoint address.

--- a/src/Owin.Security.OpenIdConnect.Server/Events/HandleIntrospectionRequestContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/HandleIntrospectionRequestContext.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.Owin;
 using Microsoft.Owin.Security;
-using Newtonsoft.Json.Linq;
 
 namespace Owin.Security.OpenIdConnect.Server {
     /// <summary>
@@ -38,8 +37,8 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// <summary>
         /// Gets the additional claims returned to the caller.
         /// </summary>
-        public IDictionary<string, JToken> Claims { get; } =
-            new Dictionary<string, JToken>(StringComparer.Ordinal);
+        public IDictionary<string, OpenIdConnectParameter> Claims { get; } =
+            new Dictionary<string, OpenIdConnectParameter>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the flag indicating

--- a/src/Owin.Security.OpenIdConnect.Server/Events/HandleUserinfoRequestContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/HandleUserinfoRequestContext.cs
@@ -38,8 +38,8 @@ namespace Owin.Security.OpenIdConnect.Server {
         /// <summary>
         /// Gets the additional claims returned to the client application.
         /// </summary>
-        public IDictionary<string, JToken> Claims { get; } =
-            new Dictionary<string, JToken>(StringComparer.Ordinal);
+        public IDictionary<string, OpenIdConnectParameter> Claims { get; } =
+            new Dictionary<string, OpenIdConnectParameter>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the value used for the "address" claim.

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -355,15 +355,14 @@ namespace Owin.Security.OpenIdConnect.Server {
                     continue;
                 }
 
-                var value = parameter.Value as JValue;
-                if (value == null) {
-                    Options.Logger.LogWarning("A parameter whose type was incompatible was ignored and excluded " +
-                                              "from the authorization response: '{Parameter}'.", parameter.Key);
-
+                // Ignore null or empty parameters, including JSON
+                // objects that can't be represented as strings.
+                var value = (string) parameter.Value;
+                if (string.IsNullOrEmpty(value)) {
                     continue;
                 }
 
-                parameters.Add(parameter.Key, (string) value);
+                parameters.Add(parameter.Key, value);
             }
 
             // Note: at this stage, the redirect_uri parameter MUST be trusted.

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IdentityModel.Tokens;
-using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -216,28 +215,23 @@ namespace Owin.Security.OpenIdConnect.Server {
             var response = new OpenIdConnectResponse {
                 [OpenIdConnectConstants.Metadata.Issuer] = notification.Issuer,
                 [OpenIdConnectConstants.Metadata.AuthorizationEndpoint] = notification.AuthorizationEndpoint,
-                [OpenIdConnectConstants.Metadata.JwksUri] = notification.CryptographyEndpoint,
+                [OpenIdConnectConstants.Metadata.TokenEndpoint] = notification.TokenEndpoint,
                 [OpenIdConnectConstants.Metadata.IntrospectionEndpoint] = notification.IntrospectionEndpoint,
                 [OpenIdConnectConstants.Metadata.EndSessionEndpoint] = notification.LogoutEndpoint,
                 [OpenIdConnectConstants.Metadata.RevocationEndpoint] = notification.RevocationEndpoint,
-                [OpenIdConnectConstants.Metadata.TokenEndpoint] = notification.TokenEndpoint,
                 [OpenIdConnectConstants.Metadata.UserinfoEndpoint] = notification.UserinfoEndpoint,
-                [OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported] = new JArray(notification.CodeChallengeMethods),
+                [OpenIdConnectConstants.Metadata.JwksUri] = notification.CryptographyEndpoint,
                 [OpenIdConnectConstants.Metadata.GrantTypesSupported] = new JArray(notification.GrantTypes),
-                [OpenIdConnectConstants.Metadata.ResponseModesSupported] = new JArray(notification.ResponseModes),
                 [OpenIdConnectConstants.Metadata.ResponseTypesSupported] = new JArray(notification.ResponseTypes),
-                [OpenIdConnectConstants.Metadata.SubjectTypesSupported] = new JArray(notification.SubjectTypes),
+                [OpenIdConnectConstants.Metadata.ResponseModesSupported] = new JArray(notification.ResponseModes),
                 [OpenIdConnectConstants.Metadata.ScopesSupported] = new JArray(notification.Scopes),
-                [OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported] = new JArray(notification.SigningAlgorithms)
+                [OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported] = new JArray(notification.SigningAlgorithms),
+                [OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported] = new JArray(notification.CodeChallengeMethods),
+                [OpenIdConnectConstants.Metadata.SubjectTypesSupported] = new JArray(notification.SubjectTypes)
             };
 
-            foreach (var claim in notification.Claims) {
-                // Ignore claims whose value is null.
-                if (claim.Value == null) {
-                    continue;
-                }
-
-                response.SetParameter(claim.Key, claim.Value);
+            foreach (var metadata in notification.Metadata) {
+                response.AddParameter(metadata.Key, metadata.Value);
             }
 
             return await SendConfigurationResponseAsync(response);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -347,7 +347,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
                         // When multiple claims with the same name exist, convert the existing entry
                         // to a new JArray to allow returning multiple claim values to the caller.
-                        var array = notification.Claims[type] as JArray;
+                        var array = notification.Claims[type].Value as JArray;
                         if (array == null) {
                             array = new JArray();
 
@@ -400,17 +400,17 @@ namespace Owin.Security.OpenIdConnect.Server {
                 response[OpenIdConnectConstants.Claims.JwtId] = notification.TokenId;
                 response[OpenIdConnectConstants.Claims.TokenType] = notification.TokenType;
 
-                if (notification.IssuedAt.HasValue) {
+                if (notification.IssuedAt != null) {
                     response[OpenIdConnectConstants.Claims.IssuedAt] =
                         EpochTime.GetIntDate(notification.IssuedAt.Value.UtcDateTime);
                 }
 
-                if (notification.NotBefore.HasValue) {
+                if (notification.NotBefore != null) {
                     response[OpenIdConnectConstants.Claims.NotBefore] =
                         EpochTime.GetIntDate(notification.NotBefore.Value.UtcDateTime);
                 }
 
-                if (notification.ExpiresAt.HasValue) {
+                if (notification.ExpiresAt != null) {
                     response[OpenIdConnectConstants.Claims.ExpiresAt] =
                         EpochTime.GetIntDate(notification.ExpiresAt.Value.UtcDateTime);
                 }
@@ -428,12 +428,7 @@ namespace Owin.Security.OpenIdConnect.Server {
                 }
 
                 foreach (var claim in notification.Claims) {
-                    // Ignore claims whose value is null.
-                    if (claim.Value == null) {
-                        continue;
-                    }
-
-                    response.SetParameter(claim.Key, claim.Value);
+                    response.AddParameter(claim.Key, claim.Value);
                 }
             }
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
@@ -187,15 +187,14 @@ namespace Owin.Security.OpenIdConnect.Server {
                     continue;
                 }
 
-                var value = parameter.Value as JValue;
-                if (value == null) {
-                    Options.Logger.LogWarning("A parameter whose type was incompatible was ignored and excluded " +
-                                              "from the logout response: '{Parameter}'.", parameter.Key);
-
+                // Ignore null or empty parameters, including JSON
+                // objects that can't be represented as strings.
+                var value = (string) parameter.Value;
+                if (string.IsNullOrEmpty(value)) {
                     continue;
                 }
 
-                parameters.Add(parameter.Key, (string) value);
+                parameters.Add(parameter.Key, value);
             }
 
             var location = WebUtilities.AddQueryString(response.PostLogoutRedirectUri, parameters);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -287,12 +287,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             }
 
             foreach (var claim in notification.Claims) {
-                // Ignore claims whose value is null.
-                if (claim.Value == null) {
-                    continue;
-                }
-
-                response.SetParameter(claim.Key, claim.Value);
+                response.AddParameter(claim.Key, claim.Value);
             }
 
             return await SendUserinfoResponseAsync(response);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -276,7 +276,7 @@ namespace Owin.Security.OpenIdConnect.Server {
             // Copy the confidentiality level associated with the request to the authentication ticket.
             if (!ticket.HasProperty(OpenIdConnectConstants.Properties.ConfidentialityLevel)) {
                 ticket.SetProperty(OpenIdConnectConstants.Properties.ConfidentialityLevel,
-                    request.GetProperty(OpenIdConnectConstants.Properties.ConfidentialityLevel));
+                    request.GetProperty<string>(OpenIdConnectConstants.Properties.ConfidentialityLevel));
             }
 
             // Always include the "openid" scope when the developer doesn't explicitly call SetScopes.
@@ -457,15 +457,14 @@ namespace Owin.Security.OpenIdConnect.Server {
             using (var buffer = new MemoryStream())
             using (var writer = new StreamWriter(buffer)) {
                 foreach (var parameter in response.GetParameters()) {
-                    var value = parameter.Value as JValue;
-                    if (value == null) {
-                        Options.Logger.LogWarning("A parameter whose type was incompatible was ignored " +
-                                                  "and excluded from the response: '{Parameter}'.", parameter.Key);
-
+                    // Ignore null or empty parameters, including JSON
+                    // objects that can't be represented as strings.
+                    var value = (string) parameter.Value;
+                    if (string.IsNullOrEmpty(value)) {
                         continue;
                     }
 
-                    writer.WriteLine("{0}:{1}", parameter.Key, (string) value);
+                    writer.WriteLine("{0}:{1}", parameter.Key, value);
                 }
 
                 writer.Flush();

--- a/test/AspNet.Security.OpenIdConnect.Primitives.Tests/OpenIdConnectConverterTests.cs
+++ b/test/AspNet.Security.OpenIdConnect.Primitives.Tests/OpenIdConnectConverterTests.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.IO;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
+    public class OpenIdConnectConverterTests {
+        [Fact]
+        public void CanConvert_ThrowsAnExceptionForNullType() {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+
+            // Act and assert
+            var exception = Assert.Throws<ArgumentNullException>(delegate {
+                converter.CanConvert(type: null);
+            });
+
+            Assert.Equal("type", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(typeof(OpenIdConnectMessage), true)]
+        [InlineData(typeof(OpenIdConnectRequest), true)]
+        [InlineData(typeof(OpenIdConnectResponse), true)]
+        [InlineData(typeof(OpenIdConnectMessage[]), false)]
+        [InlineData(typeof(OpenIdConnectRequest[]), false)]
+        [InlineData(typeof(OpenIdConnectResponse[]), false)]
+        [InlineData(typeof(OpenIdConnectParameter), false)]
+        [InlineData(typeof(OpenIdConnectParameter?), false)]
+        [InlineData(typeof(OpenIdConnectParameter[]), false)]
+        [InlineData(typeof(OpenIdConnectParameter?[]), false)]
+        [InlineData(typeof(object), false)]
+        [InlineData(typeof(long), false)]
+        public void CanConvert_ReturnsExpectedResult(Type type, bool result) {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+
+            // Act and assert
+            Assert.Equal(result, converter.CanConvert(type));
+        }
+
+        [Fact]
+        public void ReadJson_ThrowsAnExceptionForNullReader() {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+
+            // Act and assert
+            var exception = Assert.Throws<ArgumentNullException>(delegate {
+                converter.ReadJson(reader: null, type: null, value: null, serializer: null);
+            });
+
+            Assert.Equal("reader", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReadJson_ThrowsAnExceptionForNullType() {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+
+            // Act and assert
+            var exception = Assert.Throws<ArgumentNullException>(delegate {
+                converter.ReadJson(reader: new JsonTextReader(TextReader.Null),
+                                   type: null, value: null, serializer: null);
+            });
+
+            Assert.Equal("type", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReadJson_ThrowsAnExceptionForUnexpectedJsonToken() {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+            var reader = new JsonTextReader(new StringReader("[0,1,2,3]"));
+
+            // Act and assert
+            var exception = Assert.Throws<JsonSerializationException>(delegate {
+                converter.ReadJson(reader: reader, type: typeof(OpenIdConnectRequest),
+                                   value: null, serializer: null);
+            });
+
+            Assert.Equal("An error occurred while reading the JSON payload.", exception.Message);
+        }
+
+        [Theory]
+        [InlineData(typeof(OpenIdConnectMessage))]
+        [InlineData(typeof(OpenIdConnectMessage[]))]
+        [InlineData(typeof(OpenIdConnectRequest[]))]
+        [InlineData(typeof(OpenIdConnectResponse[]))]
+        [InlineData(typeof(OpenIdConnectParameter))]
+        [InlineData(typeof(OpenIdConnectParameter?))]
+        [InlineData(typeof(OpenIdConnectParameter[]))]
+        [InlineData(typeof(OpenIdConnectParameter?[]))]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(long))]
+        public void ReadJson_ThrowsAnExceptionForUnsupportedType(Type type) {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+            var reader = new JsonTextReader(new StringReader(@"{""name"":""value""}"));
+
+            // Act and assert
+            var exception = Assert.Throws<ArgumentException>(delegate {
+                converter.ReadJson(reader, type, value: null, serializer: null);
+            });
+
+            Assert.StartsWith("The specified type is not supported.", exception.Message);
+            Assert.Equal("type", exception.ParamName);
+        }
+
+        [Fact]
+        public void ReadJson_PopulatesExistingInstance() {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+            var reader = new JsonTextReader(new StringReader(@"{""name"":""value""}"));
+
+            var message = Mock.Of<OpenIdConnectMessage>();
+            Mock.Get(message).CallBase = true;
+
+            // Act
+            var result = converter.ReadJson(reader: reader, type: typeof(OpenIdConnectMessage),
+                                            value: message, serializer: null);
+
+            // Assert
+            Assert.Same(message, result);
+            Assert.Equal("value", message.GetParameter("name"));
+        }
+
+        [Theory]
+        [InlineData(typeof(OpenIdConnectRequest))]
+        [InlineData(typeof(OpenIdConnectResponse))]
+        public void ReadJson_ReturnsRequestedType(Type type) {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+            var reader = new JsonTextReader(new StringReader(@"{""name"":""value""}"));
+
+            // Act
+            var result = (OpenIdConnectMessage) converter.ReadJson(reader, type, value: null, serializer: null);
+
+            // Assert
+            Assert.IsType(type, result);
+            Assert.Equal("value", result.GetParameter("name"));
+        }
+
+        [Fact]
+        public void WriteJson_ThrowsAnExceptionForNullWriter() {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+
+            // Act and assert
+            var exception = Assert.Throws<ArgumentNullException>(delegate {
+                converter.WriteJson(writer: null, value: null, serializer: null);
+            });
+
+            Assert.Equal("writer", exception.ParamName);
+        }
+
+        [Fact]
+        public void WriteJson_ThrowsAnExceptionForNullValue() {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+
+            // Act and assert
+            var exception = Assert.Throws<ArgumentNullException>(delegate {
+                converter.WriteJson(writer: new JsonTextWriter(TextWriter.Null), value: null, serializer: null);
+            });
+
+            Assert.Equal("value", exception.ParamName);
+        }
+
+        [Fact]
+        public void WriteJson_ThrowsAnExceptionForInvalidValue() {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+
+            // Act and assert
+            var exception = Assert.Throws<ArgumentException>(delegate {
+                converter.WriteJson(writer: new JsonTextWriter(TextWriter.Null), value: new object(), serializer: null);
+            });
+
+            Assert.StartsWith("The specified object is not supported.", exception.Message);
+            Assert.Equal("value", exception.ParamName);
+        }
+
+        [Fact]
+        public void WriteJson_WritesEmptyPayloadForEmptyMessages() {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+            var writer = new StringWriter();
+
+            var message = Mock.Of<OpenIdConnectMessage>();
+            Mock.Get(message).CallBase = true;
+
+            // Act
+            converter.WriteJson(writer: new JsonTextWriter(writer), value: message, serializer: null);
+
+            Assert.Equal("{}", writer.ToString());
+        }
+
+        [Fact]
+        public void WriteJson_WritesExpectedPayload() {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+            var writer = new StringWriter();
+
+            var message = Mock.Of<OpenIdConnectMessage>();
+            Mock.Get(message).CallBase = true;
+
+            message.SetParameter("string", "value");
+            message.SetParameter("array", new JArray("value"));
+
+            // Act
+            converter.WriteJson(writer: new JsonTextWriter(writer), value: message, serializer: null);
+
+            // Assert
+            Assert.Equal(@"{""string"":""value"",""array"":[""value""]}", writer.ToString());
+        }
+
+        [Fact]
+        public void WriteJson_IgnoresNullParameters() {
+            // Arrange
+            var converter = new OpenIdConnectConverter();
+            var writer = new StringWriter();
+
+            var message = Mock.Of<OpenIdConnectMessage>();
+            Mock.Get(message).CallBase = true;
+
+            message.SetParameter("string", new OpenIdConnectParameter((string) null));
+            message.SetParameter("array", new OpenIdConnectParameter((JArray) null));
+            message.SetParameter("object", new OpenIdConnectParameter((JObject) null));
+
+            // Act
+            converter.WriteJson(writer: new JsonTextWriter(writer), value: message, serializer: null);
+
+            // Assert
+            Assert.Equal(@"{}", writer.ToString());
+        }
+    }
+}

--- a/test/AspNet.Security.OpenIdConnect.Primitives.Tests/OpenIdConnectParameterTests.cs
+++ b/test/AspNet.Security.OpenIdConnect.Primitives.Tests/OpenIdConnectParameterTests.cs
@@ -1,0 +1,622 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
+    public class OpenIdConnectParameterTests {
+        [Fact]
+        public void Equals_ReturnsTrueWhenBothParametersAreNull() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter();
+
+            // Act and assert
+            Assert.True(parameter.Equals(new OpenIdConnectParameter()));
+        }
+
+        [Fact]
+        public void Equals_ReturnsTrueWhenReferencesAreIdentical() {
+            // Arrange
+            var value = new JObject();
+            var parameter = new OpenIdConnectParameter(value);
+
+            // Act and assert
+            Assert.True(parameter.Equals(new OpenIdConnectParameter(value)));
+        }
+
+        [Fact]
+        public void Equals_ReturnsFalseWhenCurrentValueIsNull() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter();
+
+            // Act and assert
+            Assert.False(parameter.Equals(new OpenIdConnectParameter(42)));
+        }
+
+        [Fact]
+        public void Equals_ReturnsFalseWhenOtherValueIsNull() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(42);
+
+            // Act and assert
+            Assert.False(parameter.Equals(new OpenIdConnectParameter()));
+        }
+
+        [Fact]
+        public void Equals_ReturnsFalseForDifferentTypes() {
+            // Arrange, act and assert
+            Assert.False(new OpenIdConnectParameter(true).Equals(new OpenIdConnectParameter("true")));
+            Assert.False(new OpenIdConnectParameter("true").Equals(new OpenIdConnectParameter(true)));
+
+            Assert.False(new OpenIdConnectParameter("42").Equals(new OpenIdConnectParameter(42)));
+            Assert.False(new OpenIdConnectParameter(42).Equals(new OpenIdConnectParameter("42")));
+
+            Assert.False(new OpenIdConnectParameter(new JObject()).Equals(new OpenIdConnectParameter(new JArray())));
+            Assert.False(new OpenIdConnectParameter(new JArray()).Equals(new OpenIdConnectParameter(new JObject())));
+        }
+
+        [Fact]
+        public void Equals_UsesDeepEqualsForJsonArrays() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JArray(new[] { 0, 1, 2, 3 }));
+
+            // Act and assert
+            Assert.True(parameter.Equals(new JArray(new[] { 0, 1, 2, 3 })));
+        }
+
+        [Fact]
+        public void Equals_UsesDeepEqualsForJsonObjects() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JObject {
+                ["field"] = new JArray(new[] { 0, 1, 2, 3 })
+            });
+
+            // Act and assert
+            Assert.True(parameter.Equals(new JObject {
+                ["field"] = new JArray(new[] { 0, 1, 2, 3 })
+            }));
+        }
+
+        [Fact]
+        public void Equals_ComparesUnderlyingValuesForJsonValues() {
+            // Arrange
+            var value = new JValue(42);
+            var parameter = new OpenIdConnectParameter(value);
+
+            // Act and assert
+            Assert.True(parameter.Equals(new OpenIdConnectParameter(42)));
+            Assert.False(parameter.Equals(new OpenIdConnectParameter(100)));
+        }
+
+        [Fact]
+        public void Equals_SupportsJsonValues() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(42);
+
+            // Act and assert
+            Assert.True(parameter.Equals(new OpenIdConnectParameter(new JValue(42))));
+            Assert.False(parameter.Equals(new OpenIdConnectParameter(new JValue(100))));
+        }
+
+        [Fact]
+        public void Equals_ReturnsFalseForNonParameters() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter();
+
+            // Act and assert
+            Assert.False(parameter.Equals(new object()));
+        }
+
+        [Fact]
+        public void GetHashCode_ReturnsZeroForNullValues() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter();
+
+            // Act and assert
+            Assert.Equal(0, parameter.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_ReturnsHashCodeValue() {
+            // Arrange
+            var value = "Fabrikam";
+            var parameter = new OpenIdConnectParameter(value);
+
+            // Act and assert
+            Assert.Equal(value.GetHashCode(), parameter.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_ReturnsUnderlyingJsonValueHashCode() {
+            // Arrange
+            var value = "Fabrikam";
+            var parameter = new OpenIdConnectParameter(new JValue(value));
+
+            // Act and assert
+            Assert.Equal(value.GetHashCode(), parameter.GetHashCode());
+        }
+
+        [Fact]
+        public void GetParameter_ThrowsAnExceptionForNegativeIndex() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter();
+
+            // Act
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(delegate {
+                parameter.GetParameter(-1);
+            });
+
+            // Assert
+            Assert.Equal("index", exception.ParamName);
+            Assert.StartsWith("The item index cannot be negative.", exception.Message);
+        }
+
+        [Fact]
+        public void GetParameter_ReturnsNullForPrimitiveValues() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(42);
+
+            // Act and assert
+            Assert.Null(parameter.GetParameter(0));
+            Assert.Null(parameter.GetParameter("parameter"));
+        }
+
+        [Fact]
+        public void GetParameter_ReturnsNullForOutOfRangeIndex() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JArray {
+                "Fabrikam",
+                "Contoso",
+            });
+
+            // Act and assert
+            Assert.Null(parameter.GetParameter(2));
+        }
+
+        [Fact]
+        public void GetParameter_ReturnsNullForNonexistentItem() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JObject());
+
+            // Act and assert
+            Assert.Null(parameter.GetParameter("parameter"));
+        }
+
+        [Fact]
+        public void GetParameter_ReturnsNullForJsonArrays() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JArray {
+                "Fabrikam",
+                "Contoso",
+            });
+
+            // Act and assert
+            Assert.Null(parameter.GetParameter("Fabrikam"));
+        }
+
+        [Fact]
+        public void GetParameter_ReturnsNullForJsonObjects() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JObject {
+                ["parameter"] = new JValue("value")
+            });
+
+            // Act and assert
+            Assert.Null(parameter.GetParameter(0));
+        }
+
+        [Fact]
+        public void GetParameter_ReturnsNullForNullJsonObjects() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JObject {
+                ["property"] = null
+            });
+
+            // Act and assert
+            Assert.Null(parameter.GetParameter(0));
+            Assert.Null(parameter.GetParameter("parameter"));
+        }
+
+        [Fact]
+        public void GetParameter_ReturnsExpectedParameter() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JObject {
+                ["parameter"] = new JValue("value")
+            });
+
+            // Act and assert
+            Assert.Equal("value", (string) parameter.GetParameter("parameter"));
+        }
+
+        [Fact]
+        public void GetParameter_ReturnsExpectedNode() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JArray {
+                "Fabrikam",
+                "Contoso",
+            });
+
+            // Act and assert
+            Assert.Equal("Fabrikam", (string) parameter.GetParameter(0));
+        }
+
+        [Fact]
+        public void GetParameters_ReturnsEmptyEnumerationForPrimitiveValues() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(42);
+
+            // Act and assert
+            Assert.Empty(parameter.GetParameters());
+        }
+
+        [Fact]
+        public void GetParameters_ReturnsEmptyEnumerationForJsonValues() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JValue(42));
+
+            // Act and assert
+            Assert.Empty(parameter.GetParameters());
+        }
+
+        [Fact]
+        public void GetParameters_ReturnsNullKeysForJsonArrays() {
+            // Arrange
+            var parameters = new[] {
+                "Fabrikam",
+                "Contoso",
+            };
+
+            var parameter = new OpenIdConnectParameter(new JArray(parameters));
+
+            // Act and assert
+            Assert.All(from element in parameter.GetParameters()
+                       select element.Key, key => Assert.Null(key));
+        }
+
+        [Fact]
+        public void GetParameters_ReturnsExpectedParametersForJsonArrays() {
+            // Arrange
+            var parameters = new[] {
+                "Fabrikam",
+                "Contoso",
+            };
+
+            var parameter = new OpenIdConnectParameter(new JArray(parameters));
+
+            // Act and assert
+            Assert.Equal(parameters, from element in parameter.GetParameters()
+                                     select (string) element.Value);
+        }
+
+        [Fact]
+        public void GetParameters_ReturnsExpectedParametersForJsonObjects() {
+            // Arrange
+            var parameters = new Dictionary<string, string> {
+                ["parameter"] = "value"
+            };
+
+            var parameter = new OpenIdConnectParameter(JObject.FromObject(parameters));
+
+            // Act and assert
+            Assert.Equal(parameters, parameter.GetParameters().ToDictionary(pair => pair.Key, pair => (string) pair.Value));
+        }
+
+        [Fact]
+        public void ToString_ReturnsEmptyStringForNullValues() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter();
+
+            // Act and assert
+            Assert.Empty(parameter.ToString());
+        }
+
+        [Fact]
+        public void ToString_ReturnsStringValue() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter("Fabrikam");
+
+            // Act and assert
+            Assert.Equal("Fabrikam", parameter.ToString());
+        }
+
+        [Fact]
+        public void ToString_ReturnsJsonRepresentation() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JObject {
+                ["parameter"] = new JValue("value")
+            });
+
+            // Act and assert
+            Assert.Equal(@"{""parameter"":""value""}", parameter.ToString());
+        }
+
+        [Fact]
+        public void ToString_ReturnsUnderlyingJsonValue() {
+            // Arrange
+            var parameter = new OpenIdConnectParameter(new JValue("Fabrikam"));
+
+            // Act and assert
+            Assert.Equal("Fabrikam", parameter.ToString());
+        }
+
+        [Fact]
+        public void BoolConverter_CanCreateParameterFromBooleanValue() {
+            // Arrange, act and assert
+            Assert.True((bool) new OpenIdConnectParameter(true).Value);
+            Assert.True((bool) new OpenIdConnectParameter((bool?) true).Value);
+
+            Assert.False((bool) new OpenIdConnectParameter(false).Value);
+            Assert.False((bool) new OpenIdConnectParameter((bool?) false).Value);
+        }
+
+        [Fact]
+        public void BoolConverter_ReturnsDefaultValueForNullValues() {
+            // Arrange, act and assert
+            Assert.False((bool) new OpenIdConnectParameter());
+            Assert.False((bool) (OpenIdConnectParameter?) null);
+
+            Assert.Null((bool?) new OpenIdConnectParameter());
+            Assert.Null((bool?) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void BoolConverter_ReturnsDefaultValueForUnsupportedPrimitiveValues() {
+            // Arrange, act and assert
+            Assert.False((bool) new OpenIdConnectParameter("Fabrikam"));
+            Assert.False((bool) (OpenIdConnectParameter?) null);
+
+            Assert.Null((bool?) new OpenIdConnectParameter("Fabrikam"));
+            Assert.Null((bool?) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void BoolConverter_ReturnsDefaultValueForUnsupportedJsonValues() {
+            // Arrange, act and assert
+            Assert.False((bool) new OpenIdConnectParameter(new JArray()));
+            Assert.False((bool) (OpenIdConnectParameter?) null);
+
+            Assert.Null((bool?) new OpenIdConnectParameter(new JArray()));
+            Assert.Null((bool?) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void BoolConverter_CanConvertFromPrimitiveValues() {
+            // Arrange, act and assert
+            Assert.True((bool) new OpenIdConnectParameter(true));
+            Assert.True((bool?) new OpenIdConnectParameter(true));
+            Assert.True((bool) new OpenIdConnectParameter("true"));
+            Assert.True((bool?) new OpenIdConnectParameter("true"));
+
+            Assert.False((bool) new OpenIdConnectParameter(false));
+            Assert.False((bool?) new OpenIdConnectParameter(false));
+            Assert.False((bool) new OpenIdConnectParameter("false"));
+            Assert.False((bool?) new OpenIdConnectParameter("false"));
+        }
+
+        [Fact]
+        public void BoolConverter_CanConvertFromJsonValues() {
+            // Arrange, act and assert
+            Assert.True((bool) new OpenIdConnectParameter(new JValue(true)));
+            Assert.True((bool?) new OpenIdConnectParameter(new JValue(true)));
+            Assert.True((bool) new OpenIdConnectParameter(new JValue("true")));
+            Assert.True((bool?) new OpenIdConnectParameter(new JValue("true")));
+
+            Assert.False((bool) new OpenIdConnectParameter(new JValue(false)));
+            Assert.False((bool?) new OpenIdConnectParameter(new JValue(false)));
+            Assert.False((bool) new OpenIdConnectParameter(new JValue("false")));
+            Assert.False((bool?) new OpenIdConnectParameter(new JValue("false")));
+        }
+
+        [Fact]
+        public void JArrayConverter_CanCreateParameterFromJArrayValue() {
+            // Arrange
+            var array = new JArray("Fabrikam", "Contoso");
+
+            // Act
+            var parameter = new OpenIdConnectParameter(array);
+
+            // Assert
+            Assert.Same(array, parameter.Value);
+        }
+
+        [Fact]
+        public void JArrayConverter_ReturnsDefaultValueForNullValues() {
+            // Arrange, act and assert
+            Assert.Null((JArray) new OpenIdConnectParameter());
+            Assert.Null((JArray) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void JArrayConverter_ReturnsDefaultValueForUnsupportedPrimitiveValues() {
+            // Arrange, act and assert
+            Assert.Null((JArray) new OpenIdConnectParameter("Fabrikam"));
+            Assert.Null((JArray) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void JArrayConverter_ReturnsDefaultValueForUnsupportedJsonValues() {
+            // Arrange, act and assert
+            Assert.Null((JArray) new OpenIdConnectParameter(new JObject()));
+            Assert.Null((JArray) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void JArrayConverter_CanConvertFromJsonValues() {
+            // Arrange, act and assert
+            Assert.Equal(new JArray("Contoso", "Fabrikam"), (JArray) new OpenIdConnectParameter(new JArray("Contoso", "Fabrikam")));
+        }
+
+        [Fact]
+        public void JObjectConverter_CanCreateParameterFromJObjectValue() {
+            // Arrange
+            var value = JObject.FromObject(new { Property = "value" });
+
+            // Act
+            var parameter = new OpenIdConnectParameter(value);
+
+            // Assert
+            Assert.Same(value, parameter.Value);
+        }
+
+        [Fact]
+        public void JObjectConverter_ReturnsDefaultValueForNullValues() {
+            // Arrange, act and assert
+            Assert.Null((JObject) new OpenIdConnectParameter());
+            Assert.Null((JObject) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void JObjectConverter_ReturnsDefaultValueForUnsupportedPrimitiveValues() {
+            // Arrange, act and assert
+            Assert.Null((JObject) new OpenIdConnectParameter("Fabrikam"));
+            Assert.Null((JObject) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void JObjectConverter_ReturnsDefaultValueForUnsupportedJsonValues() {
+            // Arrange, act and assert
+            Assert.Null((JObject) new OpenIdConnectParameter(new JArray()));
+            Assert.Null((JObject) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void JObjectConverter_CanConvertFromJsonValues() {
+            // Arrange, act and assert
+            Assert.Equal(JObject.FromObject(new { Property = "value" }), (JObject) new OpenIdConnectParameter(JObject.FromObject(new { Property = "value" })));
+        }
+
+        [Fact]
+        public void JValueConverter_CanCreateParameterFromJValueValue() {
+            // Arrange
+            var value = new JValue("Fabrikam");
+
+            // Act
+            var parameter = new OpenIdConnectParameter(value);
+
+            // Assert
+            Assert.Same(value, parameter.Value);
+        }
+
+        [Fact]
+        public void JValueConverter_ReturnsDefaultValueForNullValues() {
+            // Arrange, act and assert
+            Assert.Null((JValue) new OpenIdConnectParameter());
+            Assert.Null((JValue) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void JValueConverter_ReturnsDefaultValueForUnsupportedJsonValues() {
+            // Arrange, act and assert
+            Assert.Null((JValue) new OpenIdConnectParameter(new JArray()));
+            Assert.Null((JValue) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void JValueConverter_CanConvertFromJsonValues() {
+            // Arrange, act and assert
+            Assert.Equal(new JValue(true), (JValue) new OpenIdConnectParameter(new JValue(true)));
+            Assert.Equal(new JValue(42), (JValue) new OpenIdConnectParameter(new JValue(42)));
+            Assert.Equal(new JValue("Fabrikam"), (JValue) new OpenIdConnectParameter(new JValue("Fabrikam")));
+        }
+
+        [Fact]
+        public void LongConverter_CanCreateParameterFromLongValue() {
+            // Arrange, act and assert
+            Assert.Equal(42, (long) new OpenIdConnectParameter(42).Value);
+            Assert.Equal(42, (long) new OpenIdConnectParameter((long?) 42).Value);
+        }
+
+        [Fact]
+        public void LongConverter_ReturnsDefaultValueForNullValues() {
+            // Arrange, act and assert
+            Assert.Equal(0, (long) new OpenIdConnectParameter());
+            Assert.Equal(0, (long) (OpenIdConnectParameter?) null);
+
+            Assert.Null((long?) new OpenIdConnectParameter());
+            Assert.Null((long?) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void LongConverter_ReturnsDefaultValueForUnsupportedPrimitiveValues() {
+            // Arrange, act and assert
+            Assert.Equal(0, (long) new OpenIdConnectParameter("Fabrikam"));
+            Assert.Equal(0, (long) (OpenIdConnectParameter?) null);
+
+            Assert.Null((long?) new OpenIdConnectParameter("Fabrikam"));
+            Assert.Null((long?) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void LongConverter_ReturnsDefaultValueForUnsupportedJsonValues() {
+            // Arrange, act and assert
+            Assert.Equal(0, (long) new OpenIdConnectParameter(new JArray()));
+            Assert.Equal(0, (long) (OpenIdConnectParameter?) null);
+
+            Assert.Null((long?) new OpenIdConnectParameter(new JArray()));
+            Assert.Null((long?) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void LongConverter_CanConvertFromPrimitiveValues() {
+            // Arrange, act and assert
+            Assert.Equal(42, (long) new OpenIdConnectParameter(42));
+            Assert.Equal(42, (long?) new OpenIdConnectParameter(42));
+            Assert.Equal(42, (long) new OpenIdConnectParameter(42));
+            Assert.Equal(42, (long?) new OpenIdConnectParameter(42));
+        }
+
+        [Fact]
+        public void LongConverter_CanConvertFromJsonValues() {
+            // Arrange, act and assert
+            Assert.Equal(42, (long) new OpenIdConnectParameter(new JValue(42)));
+            Assert.Equal(42, (long?) new OpenIdConnectParameter(new JValue(42)));
+            Assert.Equal(42, (long) new OpenIdConnectParameter(new JValue(42)));
+            Assert.Equal(42, (long?) new OpenIdConnectParameter(new JValue(42)));
+            Assert.Equal(42, (long) new OpenIdConnectParameter(new JValue(42f)));
+            Assert.Equal(42, (long?) new OpenIdConnectParameter(new JValue(42f)));
+            Assert.Equal(42, (long) new OpenIdConnectParameter(new JValue(42f)));
+            Assert.Equal(42, (long?) new OpenIdConnectParameter(new JValue(42f)));
+            Assert.Equal(42, (long) new OpenIdConnectParameter(new JValue(42m)));
+            Assert.Equal(42, (long?) new OpenIdConnectParameter(new JValue(42m)));
+            Assert.Equal(42, (long) new OpenIdConnectParameter(new JValue(42m)));
+            Assert.Equal(42, (long?) new OpenIdConnectParameter(new JValue(42m)));
+        }
+
+        [Fact]
+        public void StringConverter_CanCreateParameterFromStringValue() {
+            // Arrange, act and assert
+            Assert.Equal("Fabrikam", (string) new OpenIdConnectParameter("Fabrikam").Value);
+        }
+
+        [Fact]
+        public void StringConverter_ReturnsDefaultValueForNullValues() {
+            // Arrange, act and assert
+            Assert.Null((string) new OpenIdConnectParameter());
+            Assert.Null((string) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void StringConverter_ReturnsDefaultValueForUnsupportedJsonValues() {
+            // Arrange, act and assert
+            Assert.Null((string) new OpenIdConnectParameter(new JArray()));
+            Assert.Null((string) (OpenIdConnectParameter?) null);
+        }
+
+        [Fact]
+        public void StringConverter_CanConvertFromPrimitiveValues() {
+            // Arrange, act and assert
+            Assert.Equal("Fabrikam", (string) new OpenIdConnectParameter("Fabrikam"));
+            Assert.Equal("False", (string) new OpenIdConnectParameter(false));
+            Assert.Equal("42", (string) new OpenIdConnectParameter(42));
+        }
+
+        [Fact]
+        public void StringConverter_CanConvertFromJsonValues() {
+            // Arrange, act and assert
+            Assert.Equal("Fabrikam", (string) new OpenIdConnectParameter(new JValue("Fabrikam")));
+            Assert.Equal("False", (string) new OpenIdConnectParameter(new JValue(false)));
+            Assert.Equal("42", (string) new OpenIdConnectParameter(new JValue(42)));
+        }
+    }
+}

--- a/test/AspNet.Security.OpenIdConnect.Primitives.Tests/OpenIdConnectRequestTests.cs
+++ b/test/AspNet.Security.OpenIdConnect.Primitives.Tests/OpenIdConnectRequestTests.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Generic;
 using System.Reflection;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
@@ -16,201 +15,201 @@ namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.AccessToken),
                     /* name: */ OpenIdConnectConstants.Parameters.AccessToken,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.Assertion),
                     /* name: */ OpenIdConnectConstants.Parameters.Assertion,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.ClientAssertion),
                     /* name: */ OpenIdConnectConstants.Parameters.ClientAssertion,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.ClientAssertionType),
                     /* name: */ OpenIdConnectConstants.Parameters.ClientAssertionType,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.ClientId),
                     /* name: */ OpenIdConnectConstants.Parameters.ClientId,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.ClientSecret),
                     /* name: */ OpenIdConnectConstants.Parameters.ClientSecret,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.Code),
                     /* name: */ OpenIdConnectConstants.Parameters.Code,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.CodeChallenge),
                     /* name: */ OpenIdConnectConstants.Parameters.CodeChallenge,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.CodeChallengeMethod),
                     /* name: */ OpenIdConnectConstants.Parameters.CodeChallengeMethod,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.CodeVerifier),
                     /* name: */ OpenIdConnectConstants.Parameters.CodeVerifier,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.GrantType),
                     /* name: */ OpenIdConnectConstants.Parameters.GrantType,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.IdTokenHint),
                     /* name: */ OpenIdConnectConstants.Parameters.IdTokenHint,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.Nonce),
                     /* name: */ OpenIdConnectConstants.Parameters.Nonce,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.Password),
                     /* name: */ OpenIdConnectConstants.Parameters.Password,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.PostLogoutRedirectUri),
                     /* name: */ OpenIdConnectConstants.Parameters.PostLogoutRedirectUri,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.Prompt),
                     /* name: */ OpenIdConnectConstants.Parameters.Prompt,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.RedirectUri),
                     /* name: */ OpenIdConnectConstants.Parameters.RedirectUri,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.RefreshToken),
                     /* name: */ OpenIdConnectConstants.Parameters.RefreshToken,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.Request),
                     /* name: */ OpenIdConnectConstants.Parameters.Request,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.RequestId),
                     /* name: */ OpenIdConnectConstants.Parameters.RequestId,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.RequestUri),
                     /* name: */ OpenIdConnectConstants.Parameters.RequestUri,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.Resource),
                     /* name: */ OpenIdConnectConstants.Parameters.Resource,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.ResponseMode),
                     /* name: */ OpenIdConnectConstants.Parameters.ResponseMode,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.ResponseType),
                     /* name: */ OpenIdConnectConstants.Parameters.ResponseType,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.Scope),
                     /* name: */ OpenIdConnectConstants.Parameters.Scope,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.State),
                     /* name: */ OpenIdConnectConstants.Parameters.State,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.Token),
                     /* name: */ OpenIdConnectConstants.Parameters.Token,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.TokenTypeHint),
                     /* name: */ OpenIdConnectConstants.Parameters.TokenTypeHint,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectRequest.Username),
                     /* name: */ OpenIdConnectConstants.Parameters.Username,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
             }
         }
 
         [Theory]
         [MemberData(nameof(Properties))]
-        public void PropertyGetter_ReturnsExpectedParameter(string property, string name, object value) {
+        public void PropertyGetter_ReturnsExpectedParameter(string property, string name, OpenIdConnectParameter value) {
             // Arrange
             var request = new OpenIdConnectRequest();
-            request.SetParameter(name, JToken.FromObject(value));
+            request.SetParameter(name, value);
 
             // Act and assert
-            Assert.Equal(value, typeof(OpenIdConnectRequest).GetProperty(property).GetValue(request));
+            Assert.Equal(value.Value, typeof(OpenIdConnectRequest).GetProperty(property).GetValue(request));
         }
 
         [Theory]
         [MemberData(nameof(Properties))]
-        public void PropertySetter_AddsExpectedParameter(string property, string name, object value) {
+        public void PropertySetter_AddsExpectedParameter(string property, string name, OpenIdConnectParameter value) {
             // Arrange
             var request = new OpenIdConnectRequest();
 
             // Act
-            typeof(OpenIdConnectRequest).GetProperty(property).SetValue(request, value);
+            typeof(OpenIdConnectRequest).GetProperty(property).SetValue(request, value.Value);
 
             // Assert
-            Assert.Equal(JToken.FromObject(value), request.GetParameter(name));
+            Assert.Equal(value, request.GetParameter(name));
         }
     }
 }

--- a/test/AspNet.Security.OpenIdConnect.Primitives.Tests/OpenIdConnectResponseTests.cs
+++ b/test/AspNet.Security.OpenIdConnect.Primitives.Tests/OpenIdConnectResponseTests.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Generic;
 using System.Reflection;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
@@ -16,111 +15,111 @@ namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.AccessToken),
                     /* name: */ OpenIdConnectConstants.Parameters.AccessToken,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.Code),
                     /* name: */ OpenIdConnectConstants.Parameters.Code,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.Error),
                     /* name: */ OpenIdConnectConstants.Parameters.Error,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.ErrorDescription),
                     /* name: */ OpenIdConnectConstants.Parameters.ErrorDescription,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.ErrorUri),
                     /* name: */ OpenIdConnectConstants.Parameters.ErrorUri,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.ExpiresIn),
                     /* name: */ OpenIdConnectConstants.Parameters.ExpiresIn,
-                    /* value: */ (long?) 42
+                    /* value: */ new OpenIdConnectParameter((long?) 42)
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.IdToken),
                     /* name: */ OpenIdConnectConstants.Parameters.IdToken,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.PostLogoutRedirectUri),
                     /* name: */ OpenIdConnectConstants.Parameters.PostLogoutRedirectUri,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.RedirectUri),
                     /* name: */ OpenIdConnectConstants.Parameters.RedirectUri,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.RefreshToken),
                     /* name: */ OpenIdConnectConstants.Parameters.RefreshToken,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.Resource),
                     /* name: */ OpenIdConnectConstants.Parameters.Resource,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.Scope),
                     /* name: */ OpenIdConnectConstants.Parameters.Scope,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.State),
                     /* name: */ OpenIdConnectConstants.Parameters.State,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
 
                 yield return new object[] {
                     /* property: */ nameof(OpenIdConnectResponse.TokenType),
                     /* name: */ OpenIdConnectConstants.Parameters.TokenType,
-                    /* value: */ "802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4"
+                    /* value: */ new OpenIdConnectParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
                 };
             }
         }
 
         [Theory]
         [MemberData(nameof(Properties))]
-        public void PropertyGetter_ReturnsExpectedParameter(string property, string name, object value) {
+        public void PropertyGetter_ReturnsExpectedParameter(string property, string name, OpenIdConnectParameter value) {
             // Arrange
             var response = new OpenIdConnectResponse();
-            response.SetParameter(name, JToken.FromObject(value));
+            response.SetParameter(name, value);
 
             // Act and assert
-            Assert.Equal(value, typeof(OpenIdConnectResponse).GetProperty(property).GetValue(response));
+            Assert.Equal(value.Value, typeof(OpenIdConnectResponse).GetProperty(property).GetValue(response));
         }
 
         [Theory]
         [MemberData(nameof(Properties))]
-        public void PropertySetter_AddsExpectedParameter(string property, string name, object value) {
+        public void PropertySetter_AddsExpectedParameter(string property, string name, OpenIdConnectParameter value) {
             // Arrange
             var response = new OpenIdConnectResponse();
 
             // Act
-            typeof(OpenIdConnectResponse).GetProperty(property).SetValue(response, value);
+            typeof(OpenIdConnectResponse).GetProperty(property).SetValue(response, value.Value);
 
             // Assert
-            Assert.Equal(JToken.FromObject(value), response.GetParameter(name));
+            Assert.Equal(value, response.GetParameter(name));
         }
     }
 }

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
@@ -17,6 +17,7 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
 using Moq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using static System.Net.Http.HttpMethod;
 
@@ -268,7 +269,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var types = response[OpenIdConnectConstants.Metadata.GrantTypesSupported].Values<string>();
+            var types = ((JArray) response[OpenIdConnectConstants.Metadata.GrantTypesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.GrantTypes.Implicit, types);
@@ -283,7 +284,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var types = response[OpenIdConnectConstants.Metadata.GrantTypesSupported].Values<string>();
+            var types = ((JArray) response[OpenIdConnectConstants.Metadata.GrantTypesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.GrantTypes.ClientCredentials, types);
@@ -300,7 +301,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var modes = response[OpenIdConnectConstants.Metadata.ResponseModesSupported].Values<string>();
+            var modes = ((JArray) response[OpenIdConnectConstants.Metadata.ResponseModesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.ResponseModes.FormPost, modes);
@@ -317,7 +318,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var types = response[OpenIdConnectConstants.Metadata.ResponseTypesSupported].Values<string>();
+            var types = ((JArray) response[OpenIdConnectConstants.Metadata.ResponseTypesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.ResponseTypes.Token, types);
@@ -335,7 +336,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var types = response[OpenIdConnectConstants.Metadata.ResponseTypesSupported].Values<string>();
+            var types = ((JArray) response[OpenIdConnectConstants.Metadata.ResponseTypesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(
@@ -361,7 +362,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var scopes = response[OpenIdConnectConstants.Metadata.ScopesSupported].Values<string>();
+            var scopes = ((JArray) response[OpenIdConnectConstants.Metadata.ScopesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.Scopes.OpenId, scopes);
@@ -376,7 +377,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var types = response[OpenIdConnectConstants.Metadata.SubjectTypesSupported].Values<string>();
+            var types = ((JArray) response[OpenIdConnectConstants.Metadata.SubjectTypesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.SubjectTypes.Public, types);
@@ -388,18 +389,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
         [InlineData(OpenIdConnectConstants.Algorithms.RsaSha512)]
         public async Task InvokeConfigurationEndpointAsync_SigningAlgorithmsAreCorrectlyReturned(string algorithm) {
             // Arrange
-            var parameters = new RSAParameters {
-                D = Convert.FromBase64String("Uj6NrYBnyddhlJefYEP2nleCntAKlWyIttJC4cJnNxNN+OT2fQXhpTXRwW4R5YIS3HDqK/Fg2yoYm+OTVntAAgRFKveRx/WKwFo6UpnJc5u3lElhFa7IfosO9qXjErpX9ruAVqipekDLwQ++KmVVdgH4PK/o//nEx5zklGCdlEJURZYJPs9/7g1cx3UwvPp8jM7LgZL5OZRNyI3Jz4efrwiI2/vd8P28lAbpv/Ao4NwUDq/WKEnZ8JYSjLEKnZCfbX1ZEwf0Ic48jEKHmi1WEwpru1fMPoYfakrsY/VEfatPiDs8a5HABP/KaXcM4AZsr7HbzqAaNycV2xgdZimGcQ=="),
-                DP = Convert.FromBase64String("hi1e+0eQ/iYrfT4zpZVbx3dyfA7Ch/aujMt6nGMF+1LGaut86vDHM2JI0Gc2BKc+uPEu2bNAorhSmuSyGpfGYl0MYFQoVF/jyiGpzYPmhYpL5yLuN9jWAqNwjfstuRDLU9zTEfZnr3OSN85rZcgT7NUxlY8im1Y2TWYxGiEXw9E="),
-                DQ = Convert.FromBase64String("laVNkWIbnSuGo7nAxyUSdL2sXU3GZWwItwzTG0IK/0woFjArtCxGgNXW+V+GhxT7iHGAVJJSBvJ65TXrUYuBmoWj2CsoUs2mzK8ax4zg3CXrU61esCsGUoS2owR4FXlhYPmoVnglGu89bH72eXKixZsuF7vKW19nG703BXYEaEU="),
-                Exponent = Convert.FromBase64String("AQAB"),
-                InverseQ = Convert.FromBase64String("dhzLDS4F5WYHX+vH4+uL3Ei/K5lxw2A/dBHGtbS2X54gm7vARl+FrptOFFwIjjmsLuTjttAq9K1EP/XZIq8bjW6dXJ/IytnobIPSFkclEeQlMi4/2VDMG5915J0DwnKO9M+B8F3JViUyMv0pvb+ub+HHDVFkIr7zooCmY25i77Q="),
-                Modulus = Convert.FromBase64String("kXv7Pxf6mSf7mu6mPAOAoKAXl5kU7Q3h9zevC5i4Mm5bMk17XCh7ZvVxDzGA+1JmyxOX6sw3gMUl31FtIFlDhis8VnXKAPn8i1zrmebq+7QKzpE2GpoIpXjXbkPaHG/DbC67M1bux7/dE7lSUSifHRRLsbMUC2D4UahJ6miH2iPFNFyoa6CLtwosD8tIJKwmZ9r9zfqc9BrVGu24lZySjTSRttpLaTkgkBjxHmYhinKNEtj9wUfi1S1wPJUvf+roc6o+7jeBBV3EXJCsb6XCCXI7/e3umWp19odeRShXLQNQbNuuVC7yre4iidUDrWJ1jiaB06svUG+fVEi4FCMvEQ=="),
-                P = Convert.FromBase64String("xQGczmp4qD7Sez/ZqgW+O4cciTHvSqJqJUSdDd2l1Pd/szQ8avvzorrbSWOIULyv6eJb32+HuyLgy6rTSJ6THFobAnUv4ZTR7EGK26AJmP/BhD+3G+n21+4fzfbAxpHihkCYmO8aEl8fm/r4qPVXmCzFoXDZLMNIxFsdEXiFRS0="),
-                Q = Convert.FromBase64String("vQy5C++AzF+TRh6qwbKzOqt87ZHEHidIAh6ivRNewjzIgCWXpseVl7DimY1YdViOnw1VI7xY+EyiyTanq5caTqqB3KcDm2t40bJfrZuUcn/5puRIh1bKNDwIMLsuNCrjHmDlNbocqpYMOh0Pgw7ARNbqrnPjWsYGJPuMNFpax/U=")
-            };
-
-            var credentials = new SigningCredentials(new RsaSecurityKey(parameters), algorithm);
+            var credentials = new SigningCredentials(Mock.Of<SecurityKey>(), algorithm);
 
             var server = CreateAuthorizationServer(options => {
                 options.SigningCredentials.Clear();
@@ -410,7 +400,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var algorithms = response[OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported].Values<string>();
+            var algorithms = ((JArray) response[OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(algorithm, algorithms);
@@ -419,18 +409,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
         [Fact]
         public async Task InvokeConfigurationEndpointAsync_DuplicateSigningAlgorithmsAreIgnored() {
             // Arrange
-            var parameters = new RSAParameters {
-                D = Convert.FromBase64String("Uj6NrYBnyddhlJefYEP2nleCntAKlWyIttJC4cJnNxNN+OT2fQXhpTXRwW4R5YIS3HDqK/Fg2yoYm+OTVntAAgRFKveRx/WKwFo6UpnJc5u3lElhFa7IfosO9qXjErpX9ruAVqipekDLwQ++KmVVdgH4PK/o//nEx5zklGCdlEJURZYJPs9/7g1cx3UwvPp8jM7LgZL5OZRNyI3Jz4efrwiI2/vd8P28lAbpv/Ao4NwUDq/WKEnZ8JYSjLEKnZCfbX1ZEwf0Ic48jEKHmi1WEwpru1fMPoYfakrsY/VEfatPiDs8a5HABP/KaXcM4AZsr7HbzqAaNycV2xgdZimGcQ=="),
-                DP = Convert.FromBase64String("hi1e+0eQ/iYrfT4zpZVbx3dyfA7Ch/aujMt6nGMF+1LGaut86vDHM2JI0Gc2BKc+uPEu2bNAorhSmuSyGpfGYl0MYFQoVF/jyiGpzYPmhYpL5yLuN9jWAqNwjfstuRDLU9zTEfZnr3OSN85rZcgT7NUxlY8im1Y2TWYxGiEXw9E="),
-                DQ = Convert.FromBase64String("laVNkWIbnSuGo7nAxyUSdL2sXU3GZWwItwzTG0IK/0woFjArtCxGgNXW+V+GhxT7iHGAVJJSBvJ65TXrUYuBmoWj2CsoUs2mzK8ax4zg3CXrU61esCsGUoS2owR4FXlhYPmoVnglGu89bH72eXKixZsuF7vKW19nG703BXYEaEU="),
-                Exponent = Convert.FromBase64String("AQAB"),
-                InverseQ = Convert.FromBase64String("dhzLDS4F5WYHX+vH4+uL3Ei/K5lxw2A/dBHGtbS2X54gm7vARl+FrptOFFwIjjmsLuTjttAq9K1EP/XZIq8bjW6dXJ/IytnobIPSFkclEeQlMi4/2VDMG5915J0DwnKO9M+B8F3JViUyMv0pvb+ub+HHDVFkIr7zooCmY25i77Q="),
-                Modulus = Convert.FromBase64String("kXv7Pxf6mSf7mu6mPAOAoKAXl5kU7Q3h9zevC5i4Mm5bMk17XCh7ZvVxDzGA+1JmyxOX6sw3gMUl31FtIFlDhis8VnXKAPn8i1zrmebq+7QKzpE2GpoIpXjXbkPaHG/DbC67M1bux7/dE7lSUSifHRRLsbMUC2D4UahJ6miH2iPFNFyoa6CLtwosD8tIJKwmZ9r9zfqc9BrVGu24lZySjTSRttpLaTkgkBjxHmYhinKNEtj9wUfi1S1wPJUvf+roc6o+7jeBBV3EXJCsb6XCCXI7/e3umWp19odeRShXLQNQbNuuVC7yre4iidUDrWJ1jiaB06svUG+fVEi4FCMvEQ=="),
-                P = Convert.FromBase64String("xQGczmp4qD7Sez/ZqgW+O4cciTHvSqJqJUSdDd2l1Pd/szQ8avvzorrbSWOIULyv6eJb32+HuyLgy6rTSJ6THFobAnUv4ZTR7EGK26AJmP/BhD+3G+n21+4fzfbAxpHihkCYmO8aEl8fm/r4qPVXmCzFoXDZLMNIxFsdEXiFRS0="),
-                Q = Convert.FromBase64String("vQy5C++AzF+TRh6qwbKzOqt87ZHEHidIAh6ivRNewjzIgCWXpseVl7DimY1YdViOnw1VI7xY+EyiyTanq5caTqqB3KcDm2t40bJfrZuUcn/5puRIh1bKNDwIMLsuNCrjHmDlNbocqpYMOh0Pgw7ARNbqrnPjWsYGJPuMNFpax/U=")
-            };
-
-            var credentials = new SigningCredentials(new RsaSecurityKey(parameters), SecurityAlgorithms.RsaSha256Signature);
+            var credentials = new SigningCredentials(Mock.Of<SecurityKey>(), SecurityAlgorithms.RsaSha256Signature);
 
             var server = CreateAuthorizationServer(options => {
                 options.SigningCredentials.Clear();
@@ -443,7 +422,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var algorithms = response[OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported].Values<string>();
+            var algorithms = ((JArray) response[OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported]).Values<string>();
 
             // Assert
             Assert.Equal(1, algorithms.Count());
@@ -458,7 +437,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var methods = response[OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported].Values<string>();
+            var methods = ((JArray) response[OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.CodeChallengeMethods.Plain, methods);
@@ -824,17 +803,17 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(CryptographyEndpoint);
-            var key = response[OpenIdConnectConstants.Parameters.Keys].First;
+            var key = response[OpenIdConnectConstants.Parameters.Keys]?[0];
 
             // Assert
-            Assert.Null(key[JsonWebKeyParameterNames.D]);
-            Assert.Null(key[JsonWebKeyParameterNames.DP]);
-            Assert.Null(key[JsonWebKeyParameterNames.DQ]);
-            Assert.Null(key[JsonWebKeyParameterNames.P]);
-            Assert.Null(key[JsonWebKeyParameterNames.Q]);
+            Assert.Null(key?[JsonWebKeyParameterNames.D]);
+            Assert.Null(key?[JsonWebKeyParameterNames.DP]);
+            Assert.Null(key?[JsonWebKeyParameterNames.DQ]);
+            Assert.Null(key?[JsonWebKeyParameterNames.P]);
+            Assert.Null(key?[JsonWebKeyParameterNames.Q]);
 
-            Assert.Equal(parameters.Exponent, Base64UrlEncoder.DecodeBytes((string) key[JsonWebKeyParameterNames.E]));
-            Assert.Equal(parameters.Modulus, Base64UrlEncoder.DecodeBytes((string) key[JsonWebKeyParameterNames.N]));
+            Assert.Equal(parameters.Exponent, Base64UrlEncoder.DecodeBytes((string) key?[JsonWebKeyParameterNames.E]));
+            Assert.Equal(parameters.Modulus, Base64UrlEncoder.DecodeBytes((string) key?[JsonWebKeyParameterNames.N]));
         }
 
 #if SUPPORTS_ECDSA
@@ -880,13 +859,13 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(CryptographyEndpoint);
-            var key = response[OpenIdConnectConstants.Parameters.Keys].First;
+            var key = response[OpenIdConnectConstants.Parameters.Keys]?[0];
 
             // Assert
-            Assert.Null(key[JsonWebKeyParameterNames.D]);
+            Assert.Null(key?[JsonWebKeyParameterNames.D]);
 
-            Assert.Equal(parameters.Q.X, Base64UrlEncoder.DecodeBytes((string) key[JsonWebKeyParameterNames.X]));
-            Assert.Equal(parameters.Q.Y, Base64UrlEncoder.DecodeBytes((string) key[JsonWebKeyParameterNames.Y]));
+            Assert.Equal(parameters.Q.X, Base64UrlEncoder.DecodeBytes((string) key?[JsonWebKeyParameterNames.X]));
+            Assert.Equal(parameters.Q.Y, Base64UrlEncoder.DecodeBytes((string) key?[JsonWebKeyParameterNames.Y]));
         }
 #endif
 
@@ -899,11 +878,11 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(CryptographyEndpoint);
-            var key = response[OpenIdConnectConstants.Parameters.Keys].First;
+            var key = response[OpenIdConnectConstants.Parameters.Keys]?[0];
 
             // Assert
-            Assert.Equal("BSxeQhXNDB4VBeCOavOtvvv9eCI", (string) key[JsonWebKeyParameterNames.X5t]);
-            Assert.Equal("MIIDPjCCAiqgAwIBAgIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAMC0xKzApBgNVBAMTIk93aW4uU2VjdXJpdHkuT3BlbklkQ29ubmVjdC5TZXJ2ZXIwHhcNOTkxMjMxMjIwMDAwWhcNNDkxMjMxMjIwMDAwWjAtMSswKQYDVQQDEyJPd2luLlNlY3VyaXR5Lk9wZW5JZENvbm5lY3QuU2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwD/4uMNSIu+JlPRrtFR8Tm2LAwSOmglvJai6edFrdvDvk6xWzxYkMoIt4v13lFiIAUfI1vyZ1M0hWQfrifyweuzZu06DyWTUZkp9ervhTxK27HFN7XTuaRxHaXLR4KnhA+Nk8bBXN895OZh9g9Hf5+zsHpe17zgikwcyZtF+9OEG16oz7lKRgXGCIeeVZuSZ5Qf4yePwKMZqsx+lTOiZJ3JMs+gytvIpdZ1NWzcMX0XTcVTgvnBeU0O3NR6DQ41+SrGsojk11bd6kP6mVmDkA0K9kc2eh7q1wyJOeTNuCKRqLthwJ5m46/KRsxgY7ND6qHc1L60SqsFlYCJNEy7EdwIDAQABo2IwYDBeBgNVHQEEVzBVgBDQX+HKPiztLNvT3jQeBXqToS8wLTErMCkGA1UEAxMiT3dpbi5TZWN1cml0eS5PcGVuSWRDb25uZWN0LlNlcnZlcoIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAA4IBAQCxbCF5thB+ypGpudLAjv+l3M2VhNITJeR9j7jMlCSMVHvW7iMOL5W++zKvHMMAWuITLgPXTZ4ktsjeVQxWdnS2IcU7SwB9SeLbOMk4lLizoUevkiNaf6v+Hskm5LiH6+k8Zsl0INHyIjF9XlALTh91EqQ820cotDXaQIhHabQy892+dBmGWhSE1kP56IvOPzlLdSTkrcfcOu9gzwPVfuTDWH8Hrmo3FXz/fADmE7ea+yE1ZBeKhaN8kaFTs5zrprJ1BnmegnrjDY3RFgqcTTetahv0VBS0/jHSTIsAXflEPGW7LbHimzcgMytFU4fFtPVbek5eunakhu/JdENbbVmT", (string) key[JsonWebKeyParameterNames.X5c].First);
+            Assert.Equal("BSxeQhXNDB4VBeCOavOtvvv9eCI", (string) key?[JsonWebKeyParameterNames.X5t]);
+            Assert.Equal("MIIDPjCCAiqgAwIBAgIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAMC0xKzApBgNVBAMTIk93aW4uU2VjdXJpdHkuT3BlbklkQ29ubmVjdC5TZXJ2ZXIwHhcNOTkxMjMxMjIwMDAwWhcNNDkxMjMxMjIwMDAwWjAtMSswKQYDVQQDEyJPd2luLlNlY3VyaXR5Lk9wZW5JZENvbm5lY3QuU2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwD/4uMNSIu+JlPRrtFR8Tm2LAwSOmglvJai6edFrdvDvk6xWzxYkMoIt4v13lFiIAUfI1vyZ1M0hWQfrifyweuzZu06DyWTUZkp9ervhTxK27HFN7XTuaRxHaXLR4KnhA+Nk8bBXN895OZh9g9Hf5+zsHpe17zgikwcyZtF+9OEG16oz7lKRgXGCIeeVZuSZ5Qf4yePwKMZqsx+lTOiZJ3JMs+gytvIpdZ1NWzcMX0XTcVTgvnBeU0O3NR6DQ41+SrGsojk11bd6kP6mVmDkA0K9kc2eh7q1wyJOeTNuCKRqLthwJ5m46/KRsxgY7ND6qHc1L60SqsFlYCJNEy7EdwIDAQABo2IwYDBeBgNVHQEEVzBVgBDQX+HKPiztLNvT3jQeBXqToS8wLTErMCkGA1UEAxMiT3dpbi5TZWN1cml0eS5PcGVuSWRDb25uZWN0LlNlcnZlcoIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAA4IBAQCxbCF5thB+ypGpudLAjv+l3M2VhNITJeR9j7jMlCSMVHvW7iMOL5W++zKvHMMAWuITLgPXTZ4ktsjeVQxWdnS2IcU7SwB9SeLbOMk4lLizoUevkiNaf6v+Hskm5LiH6+k8Zsl0INHyIjF9XlALTh91EqQ820cotDXaQIhHabQy892+dBmGWhSE1kP56IvOPzlLdSTkrcfcOu9gzwPVfuTDWH8Hrmo3FXz/fADmE7ea+yE1ZBeKhaN8kaFTs5zrprJ1BnmegnrjDY3RFgqcTTetahv0VBS0/jHSTIsAXflEPGW7LbHimzcgMytFU4fFtPVbek5eunakhu/JdENbbVmT", (string) key?[JsonWebKeyParameterNames.X5c]?[0]);
         }
 
         [Theory]

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Userinfo.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Userinfo.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using static System.Net.Http.HttpMethod;
 
@@ -289,8 +290,8 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
             // Assert
             Assert.Equal(3, response.GetParameters().Count());
             Assert.Equal(server.BaseAddress.AbsoluteUri, (string) response[OpenIdConnectConstants.Claims.Issuer]);
-            Assert.Equal("Bob le Magnifique", response[OpenIdConnectConstants.Claims.Subject]);
-            Assert.Equal(new[] { "Fabrikam", "Contoso" }, response[OpenIdConnectConstants.Claims.Audience].Values<string>());
+            Assert.Equal("Bob le Magnifique", (string) response[OpenIdConnectConstants.Claims.Subject]);
+            Assert.Equal(new[] { "Fabrikam", "Contoso" }, ((JArray) response[OpenIdConnectConstants.Claims.Audience]).Values<string>());
         }
 
         [Fact]
@@ -329,7 +330,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
             // Assert
             Assert.Equal(3, response.GetParameters().Count());
             Assert.Equal(server.BaseAddress.AbsoluteUri, (string) response[OpenIdConnectConstants.Claims.Issuer]);
-            Assert.Equal("Bob le Magnifique", response[OpenIdConnectConstants.Claims.Subject]);
+            Assert.Equal("Bob le Magnifique", (string) response[OpenIdConnectConstants.Claims.Subject]);
             Assert.Equal("Fabrikam", (string) response[OpenIdConnectConstants.Claims.Audience]);
         }
 

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
@@ -15,6 +15,7 @@ using Microsoft.IdentityModel.Protocols;
 using Microsoft.Owin;
 using Moq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Owin.Security.OpenIdConnect.Extensions;
 using Xunit;
 using static System.Net.Http.HttpMethod;
@@ -267,7 +268,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var types = response[OpenIdConnectConstants.Metadata.GrantTypesSupported].Values<string>();
+            var types = ((JArray) response[OpenIdConnectConstants.Metadata.GrantTypesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.GrantTypes.Implicit, types);
@@ -282,7 +283,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var types = response[OpenIdConnectConstants.Metadata.GrantTypesSupported].Values<string>();
+            var types = ((JArray) response[OpenIdConnectConstants.Metadata.GrantTypesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.GrantTypes.ClientCredentials, types);
@@ -299,7 +300,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var modes = response[OpenIdConnectConstants.Metadata.ResponseModesSupported].Values<string>();
+            var modes = ((JArray) response[OpenIdConnectConstants.Metadata.ResponseModesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.ResponseModes.FormPost, modes);
@@ -316,7 +317,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var types = response[OpenIdConnectConstants.Metadata.ResponseTypesSupported].Values<string>();
+            var types = ((JArray) response[OpenIdConnectConstants.Metadata.ResponseTypesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.ResponseTypes.Token, types);
@@ -334,7 +335,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var types = response[OpenIdConnectConstants.Metadata.ResponseTypesSupported].Values<string>();
+            var types = ((JArray) response[OpenIdConnectConstants.Metadata.ResponseTypesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(
@@ -360,7 +361,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var scopes = response[OpenIdConnectConstants.Metadata.ScopesSupported].Values<string>();
+            var scopes = ((JArray) response[OpenIdConnectConstants.Metadata.ScopesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.Scopes.OpenId, scopes);
@@ -375,7 +376,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var types = response[OpenIdConnectConstants.Metadata.SubjectTypesSupported].Values<string>();
+            var types = ((JArray) response[OpenIdConnectConstants.Metadata.SubjectTypesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.SubjectTypes.Public, types);
@@ -387,21 +388,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
         [InlineData(OpenIdConnectConstants.Algorithms.RsaSha512, "http://www.w3.org/2001/04/xmlenc#sha512")]
         public async Task InvokeConfigurationEndpointAsync_SigningAlgorithmsAreCorrectlyReturned(string algorithm, string digest) {
             // Arrange
-            var parameters = new RSAParameters {
-                D = Convert.FromBase64String("Uj6NrYBnyddhlJefYEP2nleCntAKlWyIttJC4cJnNxNN+OT2fQXhpTXRwW4R5YIS3HDqK/Fg2yoYm+OTVntAAgRFKveRx/WKwFo6UpnJc5u3lElhFa7IfosO9qXjErpX9ruAVqipekDLwQ++KmVVdgH4PK/o//nEx5zklGCdlEJURZYJPs9/7g1cx3UwvPp8jM7LgZL5OZRNyI3Jz4efrwiI2/vd8P28lAbpv/Ao4NwUDq/WKEnZ8JYSjLEKnZCfbX1ZEwf0Ic48jEKHmi1WEwpru1fMPoYfakrsY/VEfatPiDs8a5HABP/KaXcM4AZsr7HbzqAaNycV2xgdZimGcQ=="),
-                DP = Convert.FromBase64String("hi1e+0eQ/iYrfT4zpZVbx3dyfA7Ch/aujMt6nGMF+1LGaut86vDHM2JI0Gc2BKc+uPEu2bNAorhSmuSyGpfGYl0MYFQoVF/jyiGpzYPmhYpL5yLuN9jWAqNwjfstuRDLU9zTEfZnr3OSN85rZcgT7NUxlY8im1Y2TWYxGiEXw9E="),
-                DQ = Convert.FromBase64String("laVNkWIbnSuGo7nAxyUSdL2sXU3GZWwItwzTG0IK/0woFjArtCxGgNXW+V+GhxT7iHGAVJJSBvJ65TXrUYuBmoWj2CsoUs2mzK8ax4zg3CXrU61esCsGUoS2owR4FXlhYPmoVnglGu89bH72eXKixZsuF7vKW19nG703BXYEaEU="),
-                Exponent = Convert.FromBase64String("AQAB"),
-                InverseQ = Convert.FromBase64String("dhzLDS4F5WYHX+vH4+uL3Ei/K5lxw2A/dBHGtbS2X54gm7vARl+FrptOFFwIjjmsLuTjttAq9K1EP/XZIq8bjW6dXJ/IytnobIPSFkclEeQlMi4/2VDMG5915J0DwnKO9M+B8F3JViUyMv0pvb+ub+HHDVFkIr7zooCmY25i77Q="),
-                Modulus = Convert.FromBase64String("kXv7Pxf6mSf7mu6mPAOAoKAXl5kU7Q3h9zevC5i4Mm5bMk17XCh7ZvVxDzGA+1JmyxOX6sw3gMUl31FtIFlDhis8VnXKAPn8i1zrmebq+7QKzpE2GpoIpXjXbkPaHG/DbC67M1bux7/dE7lSUSifHRRLsbMUC2D4UahJ6miH2iPFNFyoa6CLtwosD8tIJKwmZ9r9zfqc9BrVGu24lZySjTSRttpLaTkgkBjxHmYhinKNEtj9wUfi1S1wPJUvf+roc6o+7jeBBV3EXJCsb6XCCXI7/e3umWp19odeRShXLQNQbNuuVC7yre4iidUDrWJ1jiaB06svUG+fVEi4FCMvEQ=="),
-                P = Convert.FromBase64String("xQGczmp4qD7Sez/ZqgW+O4cciTHvSqJqJUSdDd2l1Pd/szQ8avvzorrbSWOIULyv6eJb32+HuyLgy6rTSJ6THFobAnUv4ZTR7EGK26AJmP/BhD+3G+n21+4fzfbAxpHihkCYmO8aEl8fm/r4qPVXmCzFoXDZLMNIxFsdEXiFRS0="),
-                Q = Convert.FromBase64String("vQy5C++AzF+TRh6qwbKzOqt87ZHEHidIAh6ivRNewjzIgCWXpseVl7DimY1YdViOnw1VI7xY+EyiyTanq5caTqqB3KcDm2t40bJfrZuUcn/5puRIh1bKNDwIMLsuNCrjHmDlNbocqpYMOh0Pgw7ARNbqrnPjWsYGJPuMNFpax/U=")
-            };
-
-            var rsa = RSA.Create();
-            rsa.ImportParameters(parameters);
-
-            var credentials = new SigningCredentials(new RsaSecurityKey(rsa), algorithm, digest);
+            var credentials = new SigningCredentials(Mock.Of<SecurityKey>(), algorithm, digest);
 
             var server = CreateAuthorizationServer(options => {
                 options.SigningCredentials.Clear();
@@ -412,7 +399,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var algorithms = response[OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported].Values<string>();
+            var algorithms = ((JArray) response[OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported]).Values<string>();
 
             // Assert
             Assert.Contains(algorithm, algorithms);
@@ -421,21 +408,8 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
         [Fact]
         public async Task InvokeConfigurationEndpointAsync_DuplicateSigningAlgorithmsAreIgnored() {
             // Arrange
-            var parameters = new RSAParameters {
-                D = Convert.FromBase64String("Uj6NrYBnyddhlJefYEP2nleCntAKlWyIttJC4cJnNxNN+OT2fQXhpTXRwW4R5YIS3HDqK/Fg2yoYm+OTVntAAgRFKveRx/WKwFo6UpnJc5u3lElhFa7IfosO9qXjErpX9ruAVqipekDLwQ++KmVVdgH4PK/o//nEx5zklGCdlEJURZYJPs9/7g1cx3UwvPp8jM7LgZL5OZRNyI3Jz4efrwiI2/vd8P28lAbpv/Ao4NwUDq/WKEnZ8JYSjLEKnZCfbX1ZEwf0Ic48jEKHmi1WEwpru1fMPoYfakrsY/VEfatPiDs8a5HABP/KaXcM4AZsr7HbzqAaNycV2xgdZimGcQ=="),
-                DP = Convert.FromBase64String("hi1e+0eQ/iYrfT4zpZVbx3dyfA7Ch/aujMt6nGMF+1LGaut86vDHM2JI0Gc2BKc+uPEu2bNAorhSmuSyGpfGYl0MYFQoVF/jyiGpzYPmhYpL5yLuN9jWAqNwjfstuRDLU9zTEfZnr3OSN85rZcgT7NUxlY8im1Y2TWYxGiEXw9E="),
-                DQ = Convert.FromBase64String("laVNkWIbnSuGo7nAxyUSdL2sXU3GZWwItwzTG0IK/0woFjArtCxGgNXW+V+GhxT7iHGAVJJSBvJ65TXrUYuBmoWj2CsoUs2mzK8ax4zg3CXrU61esCsGUoS2owR4FXlhYPmoVnglGu89bH72eXKixZsuF7vKW19nG703BXYEaEU="),
-                Exponent = Convert.FromBase64String("AQAB"),
-                InverseQ = Convert.FromBase64String("dhzLDS4F5WYHX+vH4+uL3Ei/K5lxw2A/dBHGtbS2X54gm7vARl+FrptOFFwIjjmsLuTjttAq9K1EP/XZIq8bjW6dXJ/IytnobIPSFkclEeQlMi4/2VDMG5915J0DwnKO9M+B8F3JViUyMv0pvb+ub+HHDVFkIr7zooCmY25i77Q="),
-                Modulus = Convert.FromBase64String("kXv7Pxf6mSf7mu6mPAOAoKAXl5kU7Q3h9zevC5i4Mm5bMk17XCh7ZvVxDzGA+1JmyxOX6sw3gMUl31FtIFlDhis8VnXKAPn8i1zrmebq+7QKzpE2GpoIpXjXbkPaHG/DbC67M1bux7/dE7lSUSifHRRLsbMUC2D4UahJ6miH2iPFNFyoa6CLtwosD8tIJKwmZ9r9zfqc9BrVGu24lZySjTSRttpLaTkgkBjxHmYhinKNEtj9wUfi1S1wPJUvf+roc6o+7jeBBV3EXJCsb6XCCXI7/e3umWp19odeRShXLQNQbNuuVC7yre4iidUDrWJ1jiaB06svUG+fVEi4FCMvEQ=="),
-                P = Convert.FromBase64String("xQGczmp4qD7Sez/ZqgW+O4cciTHvSqJqJUSdDd2l1Pd/szQ8avvzorrbSWOIULyv6eJb32+HuyLgy6rTSJ6THFobAnUv4ZTR7EGK26AJmP/BhD+3G+n21+4fzfbAxpHihkCYmO8aEl8fm/r4qPVXmCzFoXDZLMNIxFsdEXiFRS0="),
-                Q = Convert.FromBase64String("vQy5C++AzF+TRh6qwbKzOqt87ZHEHidIAh6ivRNewjzIgCWXpseVl7DimY1YdViOnw1VI7xY+EyiyTanq5caTqqB3KcDm2t40bJfrZuUcn/5puRIh1bKNDwIMLsuNCrjHmDlNbocqpYMOh0Pgw7ARNbqrnPjWsYGJPuMNFpax/U=")
-            };
-
-            var rsa = RSA.Create();
-            rsa.ImportParameters(parameters);
-
-            var credentials = new SigningCredentials(new RsaSecurityKey(rsa),
+            var credentials = new SigningCredentials(
+                Mock.Of<SecurityKey>(),
                 SecurityAlgorithms.RsaSha256Signature,
                 SecurityAlgorithms.Sha256Digest);
 
@@ -450,7 +424,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var algorithms = response[OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported].Values<string>();
+            var algorithms = ((JArray) response[OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported]).Values<string>();
 
             // Assert
             Assert.Equal(1, algorithms.Count());
@@ -465,7 +439,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(ConfigurationEndpoint);
-            var methods = response[OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported].Values<string>();
+            var methods = ((JArray) response[OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported]).Values<string>();
 
             // Assert
             Assert.Contains(OpenIdConnectConstants.CodeChallengeMethods.Plain, methods);
@@ -828,11 +802,11 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(CryptographyEndpoint);
-            var key = response[OpenIdConnectConstants.Parameters.Keys].First;
+            var key = response[OpenIdConnectConstants.Parameters.Keys]?[0];
 
             // Assert
-            Assert.Equal(parameters.Exponent, Base64UrlEncoder.DecodeBytes((string) key[JsonWebKeyParameterNames.E]));
-            Assert.Equal(parameters.Modulus, Base64UrlEncoder.DecodeBytes((string) key[JsonWebKeyParameterNames.N]));
+            Assert.Equal(parameters.Exponent, Base64UrlEncoder.DecodeBytes((string) key?[JsonWebKeyParameterNames.E]));
+            Assert.Equal(parameters.Modulus, Base64UrlEncoder.DecodeBytes((string) key?[JsonWebKeyParameterNames.N]));
         }
 
         [Fact]
@@ -844,11 +818,11 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act
             var response = await client.GetAsync(CryptographyEndpoint);
-            var key = response[OpenIdConnectConstants.Parameters.Keys].First;
+            var key = response[OpenIdConnectConstants.Parameters.Keys]?[0];
 
             // Assert
-            Assert.Equal("BSxeQhXNDB4VBeCOavOtvvv9eCI", (string) key[JsonWebKeyParameterNames.X5t]);
-            Assert.Equal("MIIDPjCCAiqgAwIBAgIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAMC0xKzApBgNVBAMTIk93aW4uU2VjdXJpdHkuT3BlbklkQ29ubmVjdC5TZXJ2ZXIwHhcNOTkxMjMxMjIwMDAwWhcNNDkxMjMxMjIwMDAwWjAtMSswKQYDVQQDEyJPd2luLlNlY3VyaXR5Lk9wZW5JZENvbm5lY3QuU2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwD/4uMNSIu+JlPRrtFR8Tm2LAwSOmglvJai6edFrdvDvk6xWzxYkMoIt4v13lFiIAUfI1vyZ1M0hWQfrifyweuzZu06DyWTUZkp9ervhTxK27HFN7XTuaRxHaXLR4KnhA+Nk8bBXN895OZh9g9Hf5+zsHpe17zgikwcyZtF+9OEG16oz7lKRgXGCIeeVZuSZ5Qf4yePwKMZqsx+lTOiZJ3JMs+gytvIpdZ1NWzcMX0XTcVTgvnBeU0O3NR6DQ41+SrGsojk11bd6kP6mVmDkA0K9kc2eh7q1wyJOeTNuCKRqLthwJ5m46/KRsxgY7ND6qHc1L60SqsFlYCJNEy7EdwIDAQABo2IwYDBeBgNVHQEEVzBVgBDQX+HKPiztLNvT3jQeBXqToS8wLTErMCkGA1UEAxMiT3dpbi5TZWN1cml0eS5PcGVuSWRDb25uZWN0LlNlcnZlcoIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAA4IBAQCxbCF5thB+ypGpudLAjv+l3M2VhNITJeR9j7jMlCSMVHvW7iMOL5W++zKvHMMAWuITLgPXTZ4ktsjeVQxWdnS2IcU7SwB9SeLbOMk4lLizoUevkiNaf6v+Hskm5LiH6+k8Zsl0INHyIjF9XlALTh91EqQ820cotDXaQIhHabQy892+dBmGWhSE1kP56IvOPzlLdSTkrcfcOu9gzwPVfuTDWH8Hrmo3FXz/fADmE7ea+yE1ZBeKhaN8kaFTs5zrprJ1BnmegnrjDY3RFgqcTTetahv0VBS0/jHSTIsAXflEPGW7LbHimzcgMytFU4fFtPVbek5eunakhu/JdENbbVmT", (string) key[JsonWebKeyParameterNames.X5c].First);
+            Assert.Equal("BSxeQhXNDB4VBeCOavOtvvv9eCI", (string) key?[JsonWebKeyParameterNames.X5t]);
+            Assert.Equal("MIIDPjCCAiqgAwIBAgIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAMC0xKzApBgNVBAMTIk93aW4uU2VjdXJpdHkuT3BlbklkQ29ubmVjdC5TZXJ2ZXIwHhcNOTkxMjMxMjIwMDAwWhcNNDkxMjMxMjIwMDAwWjAtMSswKQYDVQQDEyJPd2luLlNlY3VyaXR5Lk9wZW5JZENvbm5lY3QuU2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwD/4uMNSIu+JlPRrtFR8Tm2LAwSOmglvJai6edFrdvDvk6xWzxYkMoIt4v13lFiIAUfI1vyZ1M0hWQfrifyweuzZu06DyWTUZkp9ervhTxK27HFN7XTuaRxHaXLR4KnhA+Nk8bBXN895OZh9g9Hf5+zsHpe17zgikwcyZtF+9OEG16oz7lKRgXGCIeeVZuSZ5Qf4yePwKMZqsx+lTOiZJ3JMs+gytvIpdZ1NWzcMX0XTcVTgvnBeU0O3NR6DQ41+SrGsojk11bd6kP6mVmDkA0K9kc2eh7q1wyJOeTNuCKRqLthwJ5m46/KRsxgY7ND6qHc1L60SqsFlYCJNEy7EdwIDAQABo2IwYDBeBgNVHQEEVzBVgBDQX+HKPiztLNvT3jQeBXqToS8wLTErMCkGA1UEAxMiT3dpbi5TZWN1cml0eS5PcGVuSWRDb25uZWN0LlNlcnZlcoIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAA4IBAQCxbCF5thB+ypGpudLAjv+l3M2VhNITJeR9j7jMlCSMVHvW7iMOL5W++zKvHMMAWuITLgPXTZ4ktsjeVQxWdnS2IcU7SwB9SeLbOMk4lLizoUevkiNaf6v+Hskm5LiH6+k8Zsl0INHyIjF9XlALTh91EqQ820cotDXaQIhHabQy892+dBmGWhSE1kP56IvOPzlLdSTkrcfcOu9gzwPVfuTDWH8Hrmo3FXz/fADmE7ea+yE1ZBeKhaN8kaFTs5zrprJ1BnmegnrjDY3RFgqcTTetahv0VBS0/jHSTIsAXflEPGW7LbHimzcgMytFU4fFtPVbek5eunakhu/JdENbbVmT", (string) key?[JsonWebKeyParameterNames.X5c]?[0]);
         }
 
         [Theory]

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Userinfo.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Userinfo.cs
@@ -12,6 +12,7 @@ using AspNet.Security.OpenIdConnect.Client;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.Owin.Security;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Owin.Security.OpenIdConnect.Extensions;
 using Xunit;
 using static System.Net.Http.HttpMethod;
@@ -281,8 +282,8 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
             // Assert
             Assert.Equal(3, response.GetParameters().Count());
             Assert.Equal(server.BaseAddress.AbsoluteUri, (string) response[OpenIdConnectConstants.Claims.Issuer]);
-            Assert.Equal("Bob le Magnifique", response[OpenIdConnectConstants.Claims.Subject]);
-            Assert.Equal(new[] { "Fabrikam", "Contoso" }, response[OpenIdConnectConstants.Claims.Audience].Values<string>());
+            Assert.Equal("Bob le Magnifique", (string) response[OpenIdConnectConstants.Claims.Subject]);
+            Assert.Equal(new[] { "Fabrikam", "Contoso" }, ((JArray) response[OpenIdConnectConstants.Claims.Audience]).Values<string>());
         }
 
         [Fact]
@@ -317,7 +318,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
             // Assert
             Assert.Equal(3, response.GetParameters().Count());
             Assert.Equal(server.BaseAddress.AbsoluteUri, (string) response[OpenIdConnectConstants.Claims.Issuer]);
-            Assert.Equal("Bob le Magnifique", response[OpenIdConnectConstants.Claims.Subject]);
+            Assert.Equal("Bob le Magnifique", (string) response[OpenIdConnectConstants.Claims.Subject]);
             Assert.Equal("Fabrikam", (string) response[OpenIdConnectConstants.Claims.Audience]);
         }
 


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/367.

This PR introduces a whole new primitive, `OpenIdConnectParameter`:
  - It is defined as an immutable `struct` for performance reasons (it saves an allocation for every parameter compared to the previous `JToken`-based approach).
  - It supports implicit conversion from the following types: `bool`/`bool?`, `long`/`long?`, `string`, `JArray`, `JObject` and `JValue` (e.g `request["boolean_parameter"] = true`).
  - It supports explicit conversion to the following types: `bool`/`bool?`, `long`/`long?`, `string` and `JToken` (e.g `var integer = (long?) request["integer_parameter"]`).
  - It catches exceptions caused by impossible conversions and always returns a default value (e.g `null` for `long?`, `0` for `long`).
  - It allows exception-less nodes traversal (e.g `var key = (JToken) request["jwks"]?["keys"]?[0]`).

This PR also comes with a new JSON.NET converter, `OpenIdConnectConverter`, that supports reading and writing `OpenIdConnectMessage`/`OpenIdConnectRequest`/`OpenIdConnectResponse` instances.

/cc @nphmuller @georgeonofrei