### PR TITLE
Relax the default signing credentials policy to allow using the OpenID Connect server middleware in degraded mode

### DIFF
--- a/samples/Mvc/Mvc.Server/Startup.cs
+++ b/samples/Mvc/Mvc.Server/Startup.cs
@@ -82,11 +82,22 @@ namespace Mvc.Server {
                 options.TokenEndpointPath = "/connect/token";
                 options.UserinfoEndpointPath = "/connect/userinfo";
 
-                // Register a new ephemeral key, that is discarded when the application
-                // shuts down. Tokens signed using this key are automatically invalidated.
-                // This method should only be used during development.
-                options.SigningCredentials.AddEphemeralKey();
+                // Note: see AuthorizationController.cs for more
+                // information concerning ApplicationCanDisplayErrors.
+                options.ApplicationCanDisplayErrors = true;
+                options.AllowInsecureHttp = true;
 
+                // Note: to override the default access token format and use JWT, assign AccessTokenHandler.
+                // options.AccessTokenHandler = new JwtSecurityTokenHandler();
+                //
+                // Note: when using JWT as the access token format, you have to register a signing key.
+                //
+                // You can register a new ephemeral key, that is discarded when the application shuts down.
+                // Tokens signed using this key are automatically invalidated and thus this method
+                // should only be used during development:
+                //
+                // options.SigningCredentials.AddEphemeralKey();
+                //
                 // On production, using a X.509 certificate stored in the machine store is recommended.
                 // You can generate a self-signed certificate using Pluralsight's self-cert utility:
                 // https://s3.amazonaws.com/pluralsight-free/keith-brown/samples/SelfCert.zip
@@ -100,14 +111,6 @@ namespace Mvc.Server {
                 //     assembly: typeof(Startup).GetTypeInfo().Assembly,
                 //     resource: "Mvc.Server.Certificate.pfx",
                 //     password: "Owin.Security.OpenIdConnect.Server");
-
-                // Note: see AuthorizationController.cs for more
-                // information concerning ApplicationCanDisplayErrors.
-                options.ApplicationCanDisplayErrors = true;
-                options.AllowInsecureHttp = true;
-
-                // Note: to override the default access token format and use JWT, assign AccessTokenHandler:
-                // options.AccessTokenHandler = new JwtSecurityTokenHandler();
             });
 
             app.UseStaticFiles();

--- a/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConstants.cs
+++ b/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConstants.cs
@@ -109,14 +109,14 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
         }
 
         public static class MessageTypes {
-            public const string Authorization = "authorization";
-            public const string Configuration = "configuration";
-            public const string Cryptography = "cryptography";
-            public const string Introspection = "introspection";
-            public const string Logout = "logout";
-            public const string Revocation = "revocation";
-            public const string Token = "token";
-            public const string Userinfo = "userinfo";
+            public const string AuthorizationRequest = "authorization_request";
+            public const string ConfigurationRequest = "configuration_request";
+            public const string CryptographyRequest = "cryptography_request";
+            public const string IntrospectionRequest = "introspection_request";
+            public const string LogoutRequest = "logout_request";
+            public const string RevocationRequest = "revocation_request";
+            public const string TokenRequest = "token_request";
+            public const string UserinfoRequest = "userinfo_request";
         }
 
         public static class Metadata {

--- a/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectExtensions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectExtensions.cs
@@ -86,7 +86,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.MessageTypes.Authorization, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.MessageTypes.AuthorizationRequest, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.MessageTypes.Configuration, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.MessageTypes.ConfigurationRequest, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.MessageTypes.Cryptography, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.MessageTypes.CryptographyRequest, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.MessageTypes.Introspection, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.MessageTypes.IntrospectionRequest, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.MessageTypes.Logout, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.MessageTypes.LogoutRequest, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.MessageTypes.Revocation, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.MessageTypes.RevocationRequest, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -213,7 +213,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.MessageTypes.Token, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.MessageTypes.TokenRequest, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
                 return false;
             }
 
-            return string.Equals(value, OpenIdConnectConstants.MessageTypes.Userinfo, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(value, OpenIdConnectConstants.MessageTypes.UserinfoRequest, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -7,12 +7,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OpenIdConnect.Server {
@@ -139,7 +141,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 // Note: when specified, redirect_uri MUST NOT include a fragment component.
                 // See http://tools.ietf.org/html/rfc6749#section-3.1.2
                 // and http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
-                else if (!string.IsNullOrEmpty(uri.Fragment)) {
+                if (!string.IsNullOrEmpty(uri.Fragment)) {
                     Logger.LogError("The authorization request was rejected because the 'redirect_uri' " +
                                     "contained a URL fragment: {RedirectUri}.", request.RedirectUri);
 
@@ -164,8 +166,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
             // response_mode=query (explicit or not) and a response_type containing id_token
             // or token are not considered as a safe combination and MUST be rejected.
             // See http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#Security
-            else if (request.IsQueryResponseMode() && (request.HasResponseType(OpenIdConnectConstants.ResponseTypes.IdToken) ||
-                                                       request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Token))) {
+            if (request.IsQueryResponseMode() && (request.HasResponseType(OpenIdConnectConstants.ResponseTypes.IdToken) ||
+                                                  request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Token))) {
                 Logger.LogError("The authorization request was rejected because the 'response_type'/'response_mode' combination " +
                                 "was invalid: {ResponseType} ; {ResponseMode}.", request.ResponseType, request.ResponseMode);
 
@@ -179,8 +181,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
             // See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest,
             // http://openid.net/specs/openid-connect-implicit-1_0.html#RequestParameters
             // and http://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken.
-            else if (string.IsNullOrEmpty(request.Nonce) && request.HasScope(OpenIdConnectConstants.Scopes.OpenId) &&
-                                                           (request.IsImplicitFlow() || request.IsHybridFlow())) {
+            if (string.IsNullOrEmpty(request.Nonce) && request.HasScope(OpenIdConnectConstants.Scopes.OpenId) &&
+                                                      (request.IsImplicitFlow() || request.IsHybridFlow())) {
                 Logger.LogError("The authorization request was rejected because the mandatory 'nonce' parameter was missing.");
 
                 return await SendAuthorizationResponseAsync(new OpenIdConnectResponse {
@@ -190,8 +192,8 @@ namespace AspNet.Security.OpenIdConnect.Server {
             }
 
             // Reject requests containing the id_token response_type if no openid scope has been received.
-            else if (request.HasResponseType(OpenIdConnectConstants.ResponseTypes.IdToken) &&
-                    !request.HasScope(OpenIdConnectConstants.Scopes.OpenId)) {
+            if (request.HasResponseType(OpenIdConnectConstants.ResponseTypes.IdToken) &&
+               !request.HasScope(OpenIdConnectConstants.Scopes.OpenId)) {
                 Logger.LogError("The authorization request was rejected because the 'openid' scope was missing.");
 
                 return await SendAuthorizationResponseAsync(new OpenIdConnectResponse {
@@ -200,8 +202,20 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 });
             }
 
+            // Reject requests containing the id_token response_type if no asymmetric signing key have been registered.
+            if (request.HasResponseType(OpenIdConnectConstants.ResponseTypes.IdToken) &&
+               !Options.SigningCredentials.Any(credentials => credentials.Key is AsymmetricSecurityKey)) {
+                Logger.LogError("The authorization request was rejected because the 'id_token' response type could not be honored. " +
+                                "To fix this error, consider registering a X.509 signing certificate or an ephemeral signing key.");
+
+                return await SendAuthorizationResponseAsync(new OpenIdConnectResponse {
+                    Error = OpenIdConnectConstants.Errors.UnsupportedResponseType,
+                    ErrorDescription = "The specified response type is not supported by this server."
+                });
+            }
+
             // Reject requests containing the code response_type if the token endpoint has been disabled.
-            else if (request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Code) && !Options.TokenEndpointPath.HasValue) {
+            if (request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Code) && !Options.TokenEndpointPath.HasValue) {
                 Logger.LogError("The authorization request was rejected because the authorization code flow was disabled.");
 
                 return await SendAuthorizationResponseAsync(new OpenIdConnectResponse {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -68,7 +68,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractAuthorizationRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Authorization);
+                                OpenIdConnectConstants.MessageTypes.AuthorizationRequest);
 
             // Store the authorization request in the ASP.NET context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -36,7 +36,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractConfigurationRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Configuration);
+                                OpenIdConnectConstants.MessageTypes.ConfigurationRequest);
 
             // Store the discovery request in the ASP.NET context.
             Context.SetOpenIdConnectRequest(request);
@@ -264,7 +264,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractCryptographyRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Cryptography);
+                                OpenIdConnectConstants.MessageTypes.CryptographyRequest);
 
             // Store the discovery request in the ASP.NET context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
@@ -61,7 +61,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractTokenRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Token);
+                                OpenIdConnectConstants.MessageTypes.TokenRequest);
 
             // Store the token request in the ASP.NET context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -72,7 +72,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractIntrospectionRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Introspection);
+                                OpenIdConnectConstants.MessageTypes.IntrospectionRequest);
 
             // Store the introspection request in the ASP.NET context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -57,7 +57,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractRevocationRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Revocation);
+                                OpenIdConnectConstants.MessageTypes.RevocationRequest);
 
             // Insert the revocation request in the ASP.NET context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -131,6 +131,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 return notification.DataFormat?.Protect(ticket);
             }
 
+            // At this stage, throw an exception if no signing credentials were provided.
             if (notification.SigningCredentials == null) {
                 throw new InvalidOperationException("A signing key must be provided.");
             }
@@ -275,10 +276,6 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 return null;
             }
 
-            if (notification.SigningCredentials == null) {
-                throw new InvalidOperationException("A signing key must be provided.");
-            }
-
             // Extract the main identity from the principal.
             identity = (ClaimsIdentity) ticket.Principal.Identity;
 
@@ -287,6 +284,14 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 string.IsNullOrEmpty(identity.GetClaim(ClaimTypes.Upn))) {
                 throw new InvalidOperationException("The authentication ticket was rejected because " +
                                                     "it doesn't contain the mandatory subject claim.");
+            }
+
+            // Note: identity tokens must be signed but an exception is made by the OpenID Connect specification
+            // when they are returned from the token endpoint: in this case, signing is not mandatory, as the TLS
+            // server validation can be used as a way to ensure an identity token was issued by a trusted party.
+            // See http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation for more information.
+            if (notification.SigningCredentials == null && request.IsAuthorizationRequest()) {
+                throw new InvalidOperationException("A signing key must be provided.");
             }
 
             // Note: if the "sub" claim was not explicitly added, try to use
@@ -341,23 +346,26 @@ namespace AspNet.Security.OpenIdConnect.Server {
                 identity.AddClaim(OpenIdConnectConstants.Claims.Nonce, nonce);
             }
 
-            using (var algorithm = OpenIdConnectServerHelpers.GetHashAlgorithm(notification.SigningCredentials.Algorithm)) {
-                // Create an authorization code hash if necessary.
-                if (!string.IsNullOrEmpty(response.Code)) {
-                    var hash = algorithm.ComputeHash(Encoding.ASCII.GetBytes(response.Code));
+            if (notification.SigningCredentials != null && (!string.IsNullOrEmpty(response.Code) ||
+                                                            !string.IsNullOrEmpty(response.AccessToken))) {
+                using (var algorithm = OpenIdConnectServerHelpers.GetHashAlgorithm(notification.SigningCredentials.Algorithm)) {
+                    // Create an authorization code hash if necessary.
+                    if (!string.IsNullOrEmpty(response.Code)) {
+                        var hash = algorithm.ComputeHash(Encoding.ASCII.GetBytes(response.Code));
 
-                    // Note: only the left-most half of the hash of the octets is used.
-                    // See http://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken
-                    identity.AddClaim(OpenIdConnectConstants.Claims.CodeHash, Base64UrlEncoder.Encode(hash, 0, hash.Length / 2));
-                }
+                        // Note: only the left-most half of the hash of the octets is used.
+                        // See http://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken
+                        identity.AddClaim(OpenIdConnectConstants.Claims.CodeHash, Base64UrlEncoder.Encode(hash, 0, hash.Length / 2));
+                    }
 
-                // Create an access token hash if necessary.
-                if (!string.IsNullOrEmpty(response.AccessToken)) {
-                    var hash = algorithm.ComputeHash(Encoding.ASCII.GetBytes(response.AccessToken));
+                    // Create an access token hash if necessary.
+                    if (!string.IsNullOrEmpty(response.AccessToken)) {
+                        var hash = algorithm.ComputeHash(Encoding.ASCII.GetBytes(response.AccessToken));
 
-                    // Note: only the left-most half of the hash of the octets is used.
-                    // See http://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken
-                    identity.AddClaim(OpenIdConnectConstants.Claims.AccessTokenHash, Base64UrlEncoder.Encode(hash, 0, hash.Length / 2));
+                        // Note: only the left-most half of the hash of the octets is used.
+                        // See http://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken
+                        identity.AddClaim(OpenIdConnectConstants.Claims.AccessTokenHash, Base64UrlEncoder.Encode(hash, 0, hash.Length / 2));
+                    }
                 }
             }
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
@@ -68,7 +68,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractLogoutRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Logout);
+                                OpenIdConnectConstants.MessageTypes.LogoutRequest);
 
             // Store the logout request in the ASP.NET context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -67,7 +67,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractUserinfoRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Userinfo);
+                                OpenIdConnectConstants.MessageTypes.UserinfoRequest);
 
             // Insert the userinfo request in the ASP.NET context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
@@ -71,14 +71,15 @@ namespace AspNet.Security.OpenIdConnect.Server {
                                             "the OpenID Connect server middleware.", nameof(options));
             }
 
-            if (Options.SigningCredentials.Count == 0) {
-                throw new ArgumentException("At least one signing key must be registered. Consider registering " +
-                                            "a X.509 certificate or call 'options.SigningCredentials.AddEphemeralKey()' " +
-                                            "to generate and register an ephemeral signing key.", nameof(options));
-            }
-
             if (Options.AccessTokenHandler != null && !(Options.AccessTokenHandler is JwtSecurityTokenHandler)) {
                 throw new ArgumentException("The access token handler must be derived from 'JwtSecurityTokenHandler'.", nameof(options));
+            }
+
+            // Ensure at least one signing certificate/key was registered if an access token handler was registered.
+            if (Options.AccessTokenHandler != null && Options.SigningCredentials.Count == 0) {
+                throw new ArgumentException("At least one signing key must be registered when using JWT as the access token format. " +
+                                            "Consider registering a X.509 certificate using 'services.AddOpenIddict().AddSigningCertificate()' " +
+                                            "or call 'services.AddOpenIddict().AddEphemeralSigningKey()' to use an ephemeral key.", nameof(options));
             }
 
             if (Options.DataProtectionProvider == null) {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
@@ -35,7 +35,7 @@ namespace AspNet.Security.OpenIdConnect.Server {
         public Uri Issuer { get; set; }
 
         /// <summary>
-        /// Gets the list of the credentials used to sign tokens. You can provide any symmetric (e.g <see cref="SymmetricSecurityKey"/>)
+        /// Gets the list of the credentials used to sign JWT tokens. You can provide any symmetric (e.g <see cref="SymmetricSecurityKey"/>)
         /// or asymmetric (e.g <see cref="RsaSecurityKey"/>, or <see cref="X509SecurityKey"/>) security key, but you're strongly
         /// encouraged to use a 2048 or 4096-bits RSA asymmetric key in production. Note that only keys supporting the
         /// <see cref="SecurityAlgorithms.RsaSha256Signature"/> algorithm can be exposed on the configuration metadata endpoint.

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -69,7 +69,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractAuthorizationRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Authorization);
+                                OpenIdConnectConstants.MessageTypes.AuthorizationRequest);
 
             // Store the authorization request in the OWIN context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -38,7 +38,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractConfigurationRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Configuration);
+                                OpenIdConnectConstants.MessageTypes.ConfigurationRequest);
 
             // Store the discovery request in the OWIN context.
             Context.SetOpenIdConnectRequest(request);
@@ -266,7 +266,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractCryptographyRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Cryptography);
+                                OpenIdConnectConstants.MessageTypes.CryptographyRequest);
 
             // Store the discovery request in the OWIN context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
@@ -60,7 +60,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractTokenRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Token);
+                                OpenIdConnectConstants.MessageTypes.TokenRequest);
 
             // Store the token request in the OWIN context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -70,7 +70,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractIntrospectionRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Introspection);
+                                OpenIdConnectConstants.MessageTypes.IntrospectionRequest);
 
             // Insert the introspection request in the OWIN context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -56,7 +56,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractRevocationRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Revocation);
+                                OpenIdConnectConstants.MessageTypes.RevocationRequest);
 
             // Insert the revocation request in the OWIN context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
@@ -67,7 +67,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractLogoutRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Logout);
+                                OpenIdConnectConstants.MessageTypes.LogoutRequest);
 
             // Store the logout request in the OWIN context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -65,7 +65,7 @@ namespace Owin.Security.OpenIdConnect.Server {
 
             // Note: set the message type before invoking the ExtractUserinfoRequest event.
             request.SetProperty(OpenIdConnectConstants.Properties.MessageType,
-                                OpenIdConnectConstants.MessageTypes.Userinfo);
+                                OpenIdConnectConstants.MessageTypes.UserinfoRequest);
 
             // Insert the userinfo request in the OWIN context.
             Context.SetOpenIdConnectRequest(request);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
@@ -71,10 +71,11 @@ namespace Owin.Security.OpenIdConnect.Server {
                 throw new ArgumentException("The access token handler must be derived from 'JwtSecurityTokenHandler'.", nameof(options));
             }
 
-            if (Options.SigningCredentials.Count == 0) {
-                throw new ArgumentException("At least one signing key must be registered. Consider registering " +
-                                            "a X.509 certificate or call 'options.SigningCredentials.AddEphemeralKey()' " +
-                                            "to generate and register an ephemeral signing key.", nameof(options));
+            // Ensure at least one signing certificate/key was registered if an access token handler was registered.
+            if (Options.AccessTokenHandler != null && Options.SigningCredentials.Count == 0) {
+                throw new ArgumentException("At least one signing key must be registered when using JWT as the access token format. " +
+                                            "Consider registering a X.509 certificate using 'services.AddOpenIddict().AddSigningCertificate()' " +
+                                            "or call 'services.AddOpenIddict().AddEphemeralSigningKey()' to use an ephemeral key.", nameof(options));
             }
 
             if (Options.Logger == null) {

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
@@ -36,7 +36,7 @@ namespace Owin.Security.OpenIdConnect.Server {
         public Uri Issuer { get; set; }
 
         /// <summary>
-        /// Gets the list of the credentials used to sign tokens. You can provide any symmetric (e.g <see cref="InMemorySymmetricSecurityKey"/>)
+        /// Gets the list of the credentials used to sign JWT tokens. You can provide any symmetric (e.g <see cref="InMemorySymmetricSecurityKey"/>)
         /// or asymmetric (e.g <see cref="RsaSecurityKey"/>, <see cref="X509AsymmetricSecurityKey"/> or <see cref="X509SecurityKey"/>)
         /// security key, but you're strongly encouraged to use a 2048 or 4096-bits RSA asymmetric key in production.
         /// Note that only keys supporting the <see cref="SecurityAlgorithms.RsaSha256Signature"/> algorithm can be exposed

--- a/test/AspNet.Security.OpenIdConnect.Primitives.Tests/OpenIdConnectExtensionsTests.cs
+++ b/test/AspNet.Security.OpenIdConnect.Primitives.Tests/OpenIdConnectExtensionsTests.cs
@@ -107,7 +107,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
         [Theory]
         [InlineData(null, false)]
         [InlineData("unknown", false)]
-        [InlineData(OpenIdConnectConstants.MessageTypes.Authorization, true)]
+        [InlineData(OpenIdConnectConstants.MessageTypes.AuthorizationRequest, true)]
         public void IsAuthorizationRequest_ReturnsExpectedResult(string type, bool result) {
             // Arrange
             var request = new OpenIdConnectRequest();
@@ -134,7 +134,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
         [Theory]
         [InlineData(null, false)]
         [InlineData("unknown", false)]
-        [InlineData(OpenIdConnectConstants.MessageTypes.Configuration, true)]
+        [InlineData(OpenIdConnectConstants.MessageTypes.ConfigurationRequest, true)]
         public void IsConfigurationRequest_ReturnsExpectedResult(string type, bool result) {
             // Arrange
             var request = new OpenIdConnectRequest();
@@ -147,7 +147,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
         [Theory]
         [InlineData(null, false)]
         [InlineData("unknown", false)]
-        [InlineData(OpenIdConnectConstants.MessageTypes.Cryptography, true)]
+        [InlineData(OpenIdConnectConstants.MessageTypes.CryptographyRequest, true)]
         public void IsCryptographyRequest_ReturnsExpectedResult(string type, bool result) {
             // Arrange
             var request = new OpenIdConnectRequest();
@@ -160,7 +160,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
         [Theory]
         [InlineData(null, false)]
         [InlineData("unknown", false)]
-        [InlineData(OpenIdConnectConstants.MessageTypes.Introspection, true)]
+        [InlineData(OpenIdConnectConstants.MessageTypes.IntrospectionRequest, true)]
         public void IsIntrospectionRequest_ReturnsExpectedResult(string type, bool result) {
             // Arrange
             var request = new OpenIdConnectRequest();
@@ -173,7 +173,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
         [Theory]
         [InlineData(null, false)]
         [InlineData("unknown", false)]
-        [InlineData(OpenIdConnectConstants.MessageTypes.Logout, true)]
+        [InlineData(OpenIdConnectConstants.MessageTypes.LogoutRequest, true)]
         public void IsLogoutRequest_ReturnsExpectedResult(string type, bool result) {
             // Arrange
             var request = new OpenIdConnectRequest();
@@ -186,7 +186,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
         [Theory]
         [InlineData(null, false)]
         [InlineData("unknown", false)]
-        [InlineData(OpenIdConnectConstants.MessageTypes.Revocation, true)]
+        [InlineData(OpenIdConnectConstants.MessageTypes.RevocationRequest, true)]
         public void IsRevocationRequest_ReturnsExpectedResult(string type, bool result) {
             // Arrange
             var request = new OpenIdConnectRequest();
@@ -199,7 +199,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
         [Theory]
         [InlineData(null, false)]
         [InlineData("unknown", false)]
-        [InlineData(OpenIdConnectConstants.MessageTypes.Token, true)]
+        [InlineData(OpenIdConnectConstants.MessageTypes.TokenRequest, true)]
         public void IsTokenRequest_ReturnsExpectedResult(string type, bool result) {
             // Arrange
             var request = new OpenIdConnectRequest();
@@ -212,7 +212,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives.Tests {
         [Theory]
         [InlineData(null, false)]
         [InlineData("unknown", false)]
-        [InlineData(OpenIdConnectConstants.MessageTypes.Userinfo, true)]
+        [InlineData(OpenIdConnectConstants.MessageTypes.UserinfoRequest, true)]
         public void IsUserinfoRequest_ReturnsExpectedResult(string type, bool result) {
             // Arrange
             var request = new OpenIdConnectRequest();

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Serialization.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Serialization.cs
@@ -1195,8 +1195,12 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
             Assert.Null(response.IdToken);
         }
 
-        [Fact]
-        public async Task SerializeIdentityTokenAsync_MissingSigningCredentialsCauseAnException() {
+        [Theory]
+        [InlineData("code id_token")]
+        [InlineData("code id_token token")]
+        [InlineData("id_token")]
+        [InlineData("id_token token")]
+        public async Task SerializeIdentityTokenAsync_MissingSigningCredentialsCauseAnException(string type) {
             // Arrange
             var server = CreateAuthorizationServer(options => {
                 options.IdentityTokenHandler = Mock.Of<JwtSecurityTokenHandler>();
@@ -1207,13 +1211,13 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
                     return Task.FromResult(0);
                 };
 
-                options.Provider.OnValidateTokenRequest = context => {
-                    context.Skip();
+                options.Provider.OnValidateAuthorizationRequest = context => {
+                    context.Validate();
 
                     return Task.FromResult(0);
                 };
 
-                options.Provider.OnHandleTokenRequest = context => {
+                options.Provider.OnHandleAuthorizationRequest = context => {
                     var identity = new ClaimsIdentity(context.Options.AuthenticationType);
                     identity.AddClaim(OpenIdConnectConstants.Claims.Subject, "Bob le Magnifique");
 
@@ -1227,10 +1231,11 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
 
             // Act and assert
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(delegate {
-                return client.PostAsync(TokenEndpoint, new OpenIdConnectRequest {
-                    GrantType = OpenIdConnectConstants.GrantTypes.Password,
-                    Username = "johndoe",
-                    Password = "A3ddj3w",
+                return client.PostAsync(AuthorizationEndpoint, new OpenIdConnectRequest {
+                    ClientId = "Fabrikam",
+                    Nonce = "n-0S6_WzA2Mj",
+                    RedirectUri = "http://www.fabrikam.com/path",
+                    ResponseType = type,
                     Scope = OpenIdConnectConstants.Scopes.OpenId
                 });
             });

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerMiddlewareTests.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerMiddlewareTests.cs
@@ -5,6 +5,7 @@
  */
 
 using System;
+using System.IdentityModel.Tokens;
 using System.Reflection;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Owin.Security;
@@ -95,14 +96,15 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
         public void Constructor_MissingSigningCredentialsThrowAnException() {
             // Arrange, act, assert
             var exception = Assert.Throws<TargetInvocationException>(() => CreateAuthorizationServer(options => {
+                options.AccessTokenHandler = new JwtSecurityTokenHandler();
                 options.SigningCredentials.Clear();
             }));
 
             Assert.IsType<ArgumentException>(exception.InnerException);
             Assert.Equal("options", ((ArgumentException) exception.InnerException).ParamName);
-            Assert.StartsWith("At least one signing key must be registered. Consider registering " +
-                              "a X.509 certificate or call 'options.SigningCredentials.AddEphemeralKey()' " +
-                              "to generate and register an ephemeral signing key.", exception.InnerException.Message);
+            Assert.StartsWith("At least one signing key must be registered when using JWT as the access token format. " +
+                              "Consider registering a X.509 certificate using 'services.AddOpenIddict().AddSigningCertificate()' " +
+                              "or call 'services.AddOpenIddict().AddEphemeralSigningKey()' to use an ephemeral key.", exception.InnerException.Message);
         }
 
         private static TestServer CreateAuthorizationServer(Action<OpenIdConnectServerOptions> configuration = null) {


### PR DESCRIPTION
With this change, registering a signing key will no longer be necessary for simple scenarios, except when using `response_type=id_token` or when opting for JWT as the access token format (in the last case, an exception will be thrown at startup indicating that a certificate must be registered).