### PR TITLE
Allow customizing error/error_description/error_uri when using Challenge()/Forbid()

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConstants.cs
+++ b/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConstants.cs
@@ -208,6 +208,9 @@ namespace AspNet.Security.OpenIdConnect.Primitives {
             public const string CodeChallengeMethod = ".code_challenge_method";
             public const string ConfidentialityLevel = ".confidentiality_level";
             public const string Destinations = ".destinations";
+            public const string Error = ".error";
+            public const string ErrorDescription = ".error_description";
+            public const string ErrorUri = ".error_uri";
             public const string IdentityTokenLifetime = ".identity_token_lifetime";
             public const string MessageType = ".message_type";
             public const string Nonce = ".nonce";

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -228,6 +228,8 @@ namespace Owin.Security.OpenIdConnect.Server {
 
                     return ticket;
                 }
+
+                return null;
             }
 
             throw new InvalidOperationException("An identity cannot be extracted from this request.");
@@ -426,25 +428,40 @@ namespace Owin.Security.OpenIdConnect.Server {
                 throw new InvalidOperationException("An OpenID Connect response has already been sent.");
             }
 
-            // Prepare a new a OpenID Connect response.
-            response = new OpenIdConnectResponse();
-
-            if (request.IsAuthorizationRequest()) {
-                response.RedirectUri = request.RedirectUri;
-                response.State = request.State;
-
-                response.Error = OpenIdConnectConstants.Errors.AccessDenied;
-                response.ErrorDescription = "The authorization grant has been denied by the resource owner.";
-            }
-
-            else {
-                response.Error = OpenIdConnectConstants.Errors.InvalidGrant;
-                response.ErrorDescription = "The token request was rejected by the authorization server.";
-            }
-
             // Create a new ticket containing an empty identity and
             // the authentication properties extracted from the challenge.
             var ticket = new AuthenticationTicket(new ClaimsIdentity(), context.Properties);
+
+            // Prepare a new OpenID Connect response.
+            response = new OpenIdConnectResponse {
+                Error = ticket.GetProperty(OpenIdConnectConstants.Properties.Error),
+                ErrorDescription = ticket.GetProperty(OpenIdConnectConstants.Properties.ErrorDescription),
+                ErrorUri = ticket.GetProperty(OpenIdConnectConstants.Properties.ErrorUri)
+            };
+
+            // Remove the error/error_description/error_uri properties from the ticket.
+            ticket.SetProperty(OpenIdConnectConstants.Properties.Error, null)
+                  .SetProperty(OpenIdConnectConstants.Properties.ErrorDescription, null)
+                  .SetProperty(OpenIdConnectConstants.Properties.ErrorUri, null);
+
+            // If the request is an authorization request, attach the
+            // redirect_uri and the state to the OpenID Connect response.
+            if (request.IsAuthorizationRequest()) {
+                response.RedirectUri = request.RedirectUri;
+                response.State = request.State;
+            }
+
+            if (string.IsNullOrEmpty(response.Error)) {
+                response.Error = request.IsAuthorizationRequest() ?
+                    OpenIdConnectConstants.Errors.AccessDenied :
+                    OpenIdConnectConstants.Errors.InvalidGrant;
+            }
+
+            if (string.IsNullOrEmpty(response.ErrorDescription)) {
+                response.ErrorDescription = request.IsAuthorizationRequest() ?
+                    "The authorization grant has been denied by the resource owner." :
+                    "The token request was rejected by the authorization server.";
+            }
 
             if (request.IsAuthorizationRequest()) {
                 return SendAuthorizationResponseAsync(response, ticket);


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/379.