### PR TITLE
Update OpenIdConnectServerHandler.HandleRequestAsync to support trailing slash comparison

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -18,7 +18,6 @@ using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OpenIdConnect.Server {
     internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions> {
@@ -26,42 +25,42 @@ namespace AspNet.Security.OpenIdConnect.Server {
             var notification = new MatchEndpointContext(Context, Options);
 
             if (Options.AuthorizationEndpointPath.HasValue &&
-                Options.AuthorizationEndpointPath == Request.Path) {
+                Options.AuthorizationEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchAuthorizationEndpoint();
             }
 
             else if (Options.ConfigurationEndpointPath.HasValue &&
-                     Options.ConfigurationEndpointPath == Request.Path) {
+                     Options.ConfigurationEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchConfigurationEndpoint();
             }
 
             else if (Options.CryptographyEndpointPath.HasValue &&
-                     Options.CryptographyEndpointPath == Request.Path) {
+                     Options.CryptographyEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchCryptographyEndpoint();
             }
 
             else if (Options.IntrospectionEndpointPath.HasValue &&
-                     Options.IntrospectionEndpointPath == Request.Path) {
+                     Options.IntrospectionEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchIntrospectionEndpoint();
             }
 
             else if (Options.LogoutEndpointPath.HasValue &&
-                     Options.LogoutEndpointPath == Request.Path) {
+                     Options.LogoutEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchLogoutEndpoint();
             }
 
             else if (Options.RevocationEndpointPath.HasValue &&
-                     Options.RevocationEndpointPath == Request.Path) {
+                     Options.RevocationEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchRevocationEndpoint();
             }
 
             else if (Options.TokenEndpointPath.HasValue &&
-                     Options.TokenEndpointPath == Request.Path) {
+                     Options.TokenEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchTokenEndpoint();
             }
 
             else if (Options.UserinfoEndpointPath.HasValue &&
-                     Options.UserinfoEndpointPath == Request.Path) {
+                     Options.UserinfoEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchUserinfoEndpoint();
             }
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
@@ -94,6 +94,22 @@ namespace AspNet.Security.OpenIdConnect.Server {
             return address + path;
         }
 
+        public static bool IsEquivalentTo(this PathString path, PathString other) {
+            if (path.Equals(other)) {
+                return true;
+            }
+
+            if (path.Equals(other + "/")) {
+                return true;
+            }
+
+            if (other.Equals(path + "/")) {
+                return true;
+            }
+
+            return false;
+        }
+
         public static bool IsSupportedAlgorithm(this SecurityKey key, string algorithm) {
             return key.CryptoProviderFactory.IsSupportedAlgorithm(algorithm, key);
         }

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -14,7 +14,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Infrastructure;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Owin.Security.OpenIdConnect.Extensions;
 
 namespace Owin.Security.OpenIdConnect.Server {
@@ -23,42 +22,42 @@ namespace Owin.Security.OpenIdConnect.Server {
             var notification = new MatchEndpointContext(Context, Options);
 
             if (Options.AuthorizationEndpointPath.HasValue &&
-                Options.AuthorizationEndpointPath == Request.Path) {
+                Options.AuthorizationEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchAuthorizationEndpoint();
             }
 
             else if (Options.ConfigurationEndpointPath.HasValue &&
-                     Options.ConfigurationEndpointPath == Request.Path) {
+                     Options.ConfigurationEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchConfigurationEndpoint();
             }
 
             else if (Options.CryptographyEndpointPath.HasValue &&
-                     Options.CryptographyEndpointPath == Request.Path) {
+                     Options.CryptographyEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchCryptographyEndpoint();
             }
 
             else if (Options.IntrospectionEndpointPath.HasValue &&
-                     Options.IntrospectionEndpointPath == Request.Path) {
+                     Options.IntrospectionEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchIntrospectionEndpoint();
             }
 
             else if (Options.LogoutEndpointPath.HasValue &&
-                     Options.LogoutEndpointPath == Request.Path) {
+                     Options.LogoutEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchLogoutEndpoint();
             }
 
             else if (Options.RevocationEndpointPath.HasValue &&
-                     Options.RevocationEndpointPath == Request.Path) {
+                     Options.RevocationEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchRevocationEndpoint();
             }
 
             else if (Options.TokenEndpointPath.HasValue &&
-                     Options.TokenEndpointPath == Request.Path) {
+                     Options.TokenEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchTokenEndpoint();
             }
 
             else if (Options.UserinfoEndpointPath.HasValue &&
-                     Options.UserinfoEndpointPath == Request.Path) {
+                     Options.UserinfoEndpointPath.IsEquivalentTo(Request.Path)) {
                 notification.MatchUserinfoEndpoint();
             }
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
@@ -120,6 +120,22 @@ namespace Owin.Security.OpenIdConnect.Server {
             return address + path;
         }
 
+        public static bool IsEquivalentTo(this PathString path, PathString other) {
+            if (path.Equals(other)) {
+                return true;
+            }
+
+            if (path.Equals(other + new PathString("/"))) {
+                return true;
+            }
+            
+            if (other.Equals(path + new PathString("/"))) {
+                return true;
+            }
+
+            return false;
+        }
+
         public static string GetJwtAlgorithm(string algorithm) {
             if (string.IsNullOrEmpty(algorithm)) {
                 throw new ArgumentNullException(nameof(algorithm));

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.cs
@@ -38,28 +38,88 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
         public const string UserinfoEndpoint = "/connect/userinfo";
 
         [Theory]
-        [InlineData(ConfigurationEndpoint)]
-        [InlineData(CryptographyEndpoint)]
-        [InlineData(CustomEndpoint)]
-        [InlineData(AuthorizationEndpoint)]
-        [InlineData(IntrospectionEndpoint)]
-        [InlineData(LogoutEndpoint)]
-        [InlineData(RevocationEndpoint)]
-        [InlineData(TokenEndpoint)]
-        [InlineData(UserinfoEndpoint)]
-        public Task HandleRequestAsync_MatchEndpoint_MatchesCorrespondingEndpoint(string address) {
+        [InlineData("/", null)]
+        [InlineData("/connect", null)]
+        [InlineData("/CONNECT", null)]
+        [InlineData("/connect/", null)]
+        [InlineData("/CONNECT/", null)]
+        [InlineData("/connect/authorize", AuthorizationEndpoint)]
+        [InlineData("/CONNECT/AUTHORIZE", AuthorizationEndpoint)]
+        [InlineData("/connect/authorize/", AuthorizationEndpoint)]
+        [InlineData("/CONNECT/AUTHORIZE/", AuthorizationEndpoint)]
+        [InlineData("/connect/authorize/subpath", null)]
+        [InlineData("/CONNECT/AUTHORIZE/SUBPATH", null)]
+        [InlineData("/connect/authorize/subpath/", null)]
+        [InlineData("/CONNECT/AUTHORIZE/SUBPATH/", null)]
+        [InlineData("/connect/introspect", IntrospectionEndpoint)]
+        [InlineData("/CONNECT/INTROSPECT", IntrospectionEndpoint)]
+        [InlineData("/connect/introspect/", IntrospectionEndpoint)]
+        [InlineData("/CONNECT/INTROSPECT/", IntrospectionEndpoint)]
+        [InlineData("/connect/introspect/subpath", null)]
+        [InlineData("/CONNECT/INTROSPECT/SUBPATH", null)]
+        [InlineData("/connect/introspect/subpath/", null)]
+        [InlineData("/CONNECT/INTROSPECT/SUBPATH/", null)]
+        [InlineData("/connect/logout", LogoutEndpoint)]
+        [InlineData("/CONNECT/LOGOUT", LogoutEndpoint)]
+        [InlineData("/connect/logout/", LogoutEndpoint)]
+        [InlineData("/CONNECT/LOGOUT/", LogoutEndpoint)]
+        [InlineData("/connect/logout/subpath", null)]
+        [InlineData("/CONNECT/LOGOUT/SUBPATH", null)]
+        [InlineData("/connect/logout/subpath/", null)]
+        [InlineData("/CONNECT/LOGOUT/SUBPATH/", null)]
+        [InlineData("/connect/revoke", RevocationEndpoint)]
+        [InlineData("/CONNECT/REVOKE", RevocationEndpoint)]
+        [InlineData("/connect/revoke/", RevocationEndpoint)]
+        [InlineData("/CONNECT/REVOKE/", RevocationEndpoint)]
+        [InlineData("/connect/revoke/subpath", null)]
+        [InlineData("/CONNECT/REVOKE/SUBPATH", null)]
+        [InlineData("/connect/revoke/subpath/", null)]
+        [InlineData("/CONNECT/REVOKE/SUBPATH/", null)]
+        [InlineData("/connect/token", TokenEndpoint)]
+        [InlineData("/CONNECT/TOKEN", TokenEndpoint)]
+        [InlineData("/connect/token/", TokenEndpoint)]
+        [InlineData("/CONNECT/TOKEN/", TokenEndpoint)]
+        [InlineData("/connect/token/subpath", null)]
+        [InlineData("/CONNECT/TOKEN/SUBPATH", null)]
+        [InlineData("/connect/token/subpath/", null)]
+        [InlineData("/CONNECT/TOKEN/SUBPATH/", null)]
+        [InlineData("/connect/userinfo", UserinfoEndpoint)]
+        [InlineData("/CONNECT/USERINFO", UserinfoEndpoint)]
+        [InlineData("/connect/userinfo/", UserinfoEndpoint)]
+        [InlineData("/CONNECT/USERINFO/", UserinfoEndpoint)]
+        [InlineData("/connect/userinfo/subpath", null)]
+        [InlineData("/CONNECT/USERINFO/SUBPATH", null)]
+        [InlineData("/connect/userinfo/subpath/", null)]
+        [InlineData("/CONNECT/USERINFO/SUBPATH/", null)]
+        [InlineData("/.well-known/openid-configuration", ConfigurationEndpoint)]
+        [InlineData("/.WELL-KNOWN/OPENID-CONFIGURATION", ConfigurationEndpoint)]
+        [InlineData("/.well-known/openid-configuration/", ConfigurationEndpoint)]
+        [InlineData("/.WELL-KNOWN/OPENID-CONFIGURATION/", ConfigurationEndpoint)]
+        [InlineData("/.well-known/openid-configuration/subpath", null)]
+        [InlineData("/.WELL-KNOWN/OPENID-CONFIGURATION/SUBPATH", null)]
+        [InlineData("/.well-known/openid-configuration/subpath/", null)]
+        [InlineData("/.WELL-KNOWN/OPENID-CONFIGURATION/SUBPATH/", null)]
+        [InlineData("/.well-known/jwks", CryptographyEndpoint)]
+        [InlineData("/.WELL-KNOWN/JWKS", CryptographyEndpoint)]
+        [InlineData("/.well-known/jwks/", CryptographyEndpoint)]
+        [InlineData("/.WELL-KNOWN/JWKS/", CryptographyEndpoint)]
+        [InlineData("/.well-known/jwks/subpath", null)]
+        [InlineData("/.WELL-KNOWN/JWKS/SUBPATH", null)]
+        [InlineData("/.well-known/jwks/subpath/", null)]
+        [InlineData("/.WELL-KNOWN/JWKS/SUBPATH/", null)]
+        public Task HandleRequestAsync_MatchEndpoint_MatchesCorrespondingEndpoint(string path, string endpoint) {
             // Arrange
             var server = CreateAuthorizationServer(options => {
                 options.Provider.OnMatchEndpoint = context => {
                     // Assert
-                    Assert.Equal(context.IsAuthorizationEndpoint, address == AuthorizationEndpoint);
-                    Assert.Equal(context.IsConfigurationEndpoint, address == ConfigurationEndpoint);
-                    Assert.Equal(context.IsCryptographyEndpoint, address == CryptographyEndpoint);
-                    Assert.Equal(context.IsIntrospectionEndpoint, address == IntrospectionEndpoint);
-                    Assert.Equal(context.IsLogoutEndpoint, address == LogoutEndpoint);
-                    Assert.Equal(context.IsRevocationEndpoint, address == RevocationEndpoint);
-                    Assert.Equal(context.IsTokenEndpoint, address == TokenEndpoint);
-                    Assert.Equal(context.IsUserinfoEndpoint, address == UserinfoEndpoint);
+                    Assert.Equal(context.IsAuthorizationEndpoint, endpoint == AuthorizationEndpoint);
+                    Assert.Equal(context.IsConfigurationEndpoint, endpoint == ConfigurationEndpoint);
+                    Assert.Equal(context.IsCryptographyEndpoint, endpoint == CryptographyEndpoint);
+                    Assert.Equal(context.IsIntrospectionEndpoint, endpoint == IntrospectionEndpoint);
+                    Assert.Equal(context.IsLogoutEndpoint, endpoint == LogoutEndpoint);
+                    Assert.Equal(context.IsRevocationEndpoint, endpoint == RevocationEndpoint);
+                    Assert.Equal(context.IsTokenEndpoint, endpoint == TokenEndpoint);
+                    Assert.Equal(context.IsUserinfoEndpoint, endpoint == UserinfoEndpoint);
 
                     return Task.FromResult(0);
                 };
@@ -68,12 +128,10 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
             var client = new OpenIdConnectClient(server.CreateClient());
 
             // Act
-            return client.PostAsync(address, new OpenIdConnectRequest());
+            return client.PostAsync(path, new OpenIdConnectRequest());
         }
 
         [Theory]
-        [InlineData("/custom/.well-known/openid-configuration")]
-        [InlineData("/custom/.well-known/jwks")]
         [InlineData("/custom/connect/authorize")]
         [InlineData("/custom/connect/custom")]
         [InlineData("/custom/connect/introspect")]
@@ -81,6 +139,8 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests {
         [InlineData("/custom/connect/revoke")]
         [InlineData("/custom/connect/token")]
         [InlineData("/custom/connect/userinfo")]
+        [InlineData("/custom/.well-known/openid-configuration")]
+        [InlineData("/custom/.well-known/jwks")]
         public Task HandleRequestAsync_MatchEndpoint_AllowsOverridingEndpoint(string address) {
             // Arrange
             var server = CreateAuthorizationServer(options => {

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.cs
@@ -33,28 +33,88 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
         public const string UserinfoEndpoint = "/connect/userinfo";
 
         [Theory]
-        [InlineData(ConfigurationEndpoint)]
-        [InlineData(CryptographyEndpoint)]
-        [InlineData(CustomEndpoint)]
-        [InlineData(AuthorizationEndpoint)]
-        [InlineData(IntrospectionEndpoint)]
-        [InlineData(LogoutEndpoint)]
-        [InlineData(RevocationEndpoint)]
-        [InlineData(TokenEndpoint)]
-        [InlineData(UserinfoEndpoint)]
-        public Task HandleRequestAsync_MatchEndpoint_MatchesCorrespondingEndpoint(string address) {
+        [InlineData("/", null)]
+        [InlineData("/connect", null)]
+        [InlineData("/CONNECT", null)]
+        [InlineData("/connect/", null)]
+        [InlineData("/CONNECT/", null)]
+        [InlineData("/connect/authorize", AuthorizationEndpoint)]
+        [InlineData("/CONNECT/AUTHORIZE", AuthorizationEndpoint)]
+        [InlineData("/connect/authorize/", AuthorizationEndpoint)]
+        [InlineData("/CONNECT/AUTHORIZE/", AuthorizationEndpoint)]
+        [InlineData("/connect/authorize/subpath", null)]
+        [InlineData("/CONNECT/AUTHORIZE/SUBPATH", null)]
+        [InlineData("/connect/authorize/subpath/", null)]
+        [InlineData("/CONNECT/AUTHORIZE/SUBPATH/", null)]
+        [InlineData("/connect/introspect", IntrospectionEndpoint)]
+        [InlineData("/CONNECT/INTROSPECT", IntrospectionEndpoint)]
+        [InlineData("/connect/introspect/", IntrospectionEndpoint)]
+        [InlineData("/CONNECT/INTROSPECT/", IntrospectionEndpoint)]
+        [InlineData("/connect/introspect/subpath", null)]
+        [InlineData("/CONNECT/INTROSPECT/SUBPATH", null)]
+        [InlineData("/connect/introspect/subpath/", null)]
+        [InlineData("/CONNECT/INTROSPECT/SUBPATH/", null)]
+        [InlineData("/connect/logout", LogoutEndpoint)]
+        [InlineData("/CONNECT/LOGOUT", LogoutEndpoint)]
+        [InlineData("/connect/logout/", LogoutEndpoint)]
+        [InlineData("/CONNECT/LOGOUT/", LogoutEndpoint)]
+        [InlineData("/connect/logout/subpath", null)]
+        [InlineData("/CONNECT/LOGOUT/SUBPATH", null)]
+        [InlineData("/connect/logout/subpath/", null)]
+        [InlineData("/CONNECT/LOGOUT/SUBPATH/", null)]
+        [InlineData("/connect/revoke", RevocationEndpoint)]
+        [InlineData("/CONNECT/REVOKE", RevocationEndpoint)]
+        [InlineData("/connect/revoke/", RevocationEndpoint)]
+        [InlineData("/CONNECT/REVOKE/", RevocationEndpoint)]
+        [InlineData("/connect/revoke/subpath", null)]
+        [InlineData("/CONNECT/REVOKE/SUBPATH", null)]
+        [InlineData("/connect/revoke/subpath/", null)]
+        [InlineData("/CONNECT/REVOKE/SUBPATH/", null)]
+        [InlineData("/connect/token", TokenEndpoint)]
+        [InlineData("/CONNECT/TOKEN", TokenEndpoint)]
+        [InlineData("/connect/token/", TokenEndpoint)]
+        [InlineData("/CONNECT/TOKEN/", TokenEndpoint)]
+        [InlineData("/connect/token/subpath", null)]
+        [InlineData("/CONNECT/TOKEN/SUBPATH", null)]
+        [InlineData("/connect/token/subpath/", null)]
+        [InlineData("/CONNECT/TOKEN/SUBPATH/", null)]
+        [InlineData("/connect/userinfo", UserinfoEndpoint)]
+        [InlineData("/CONNECT/USERINFO", UserinfoEndpoint)]
+        [InlineData("/connect/userinfo/", UserinfoEndpoint)]
+        [InlineData("/CONNECT/USERINFO/", UserinfoEndpoint)]
+        [InlineData("/connect/userinfo/subpath", null)]
+        [InlineData("/CONNECT/USERINFO/SUBPATH", null)]
+        [InlineData("/connect/userinfo/subpath/", null)]
+        [InlineData("/CONNECT/USERINFO/SUBPATH/", null)]
+        [InlineData("/.well-known/openid-configuration", ConfigurationEndpoint)]
+        [InlineData("/.WELL-KNOWN/OPENID-CONFIGURATION", ConfigurationEndpoint)]
+        [InlineData("/.well-known/openid-configuration/", ConfigurationEndpoint)]
+        [InlineData("/.WELL-KNOWN/OPENID-CONFIGURATION/", ConfigurationEndpoint)]
+        [InlineData("/.well-known/openid-configuration/subpath", null)]
+        [InlineData("/.WELL-KNOWN/OPENID-CONFIGURATION/SUBPATH", null)]
+        [InlineData("/.well-known/openid-configuration/subpath/", null)]
+        [InlineData("/.WELL-KNOWN/OPENID-CONFIGURATION/SUBPATH/", null)]
+        [InlineData("/.well-known/jwks", CryptographyEndpoint)]
+        [InlineData("/.WELL-KNOWN/JWKS", CryptographyEndpoint)]
+        [InlineData("/.well-known/jwks/", CryptographyEndpoint)]
+        [InlineData("/.WELL-KNOWN/JWKS/", CryptographyEndpoint)]
+        [InlineData("/.well-known/jwks/subpath", null)]
+        [InlineData("/.WELL-KNOWN/JWKS/SUBPATH", null)]
+        [InlineData("/.well-known/jwks/subpath/", null)]
+        [InlineData("/.WELL-KNOWN/JWKS/SUBPATH/", null)]
+        public Task HandleRequestAsync_MatchEndpoint_MatchesCorrespondingEndpoint(string path, string endpoint) {
             // Arrange
             var server = CreateAuthorizationServer(options => {
                 options.Provider.OnMatchEndpoint = context => {
                     // Assert
-                    Assert.Equal(context.IsAuthorizationEndpoint, address == AuthorizationEndpoint);
-                    Assert.Equal(context.IsConfigurationEndpoint, address == ConfigurationEndpoint);
-                    Assert.Equal(context.IsCryptographyEndpoint, address == CryptographyEndpoint);
-                    Assert.Equal(context.IsIntrospectionEndpoint, address == IntrospectionEndpoint);
-                    Assert.Equal(context.IsLogoutEndpoint, address == LogoutEndpoint);
-                    Assert.Equal(context.IsRevocationEndpoint, address == RevocationEndpoint);
-                    Assert.Equal(context.IsTokenEndpoint, address == TokenEndpoint);
-                    Assert.Equal(context.IsUserinfoEndpoint, address == UserinfoEndpoint);
+                    Assert.Equal(context.IsAuthorizationEndpoint, endpoint == AuthorizationEndpoint);
+                    Assert.Equal(context.IsConfigurationEndpoint, endpoint == ConfigurationEndpoint);
+                    Assert.Equal(context.IsCryptographyEndpoint, endpoint == CryptographyEndpoint);
+                    Assert.Equal(context.IsIntrospectionEndpoint, endpoint == IntrospectionEndpoint);
+                    Assert.Equal(context.IsLogoutEndpoint, endpoint == LogoutEndpoint);
+                    Assert.Equal(context.IsRevocationEndpoint, endpoint == RevocationEndpoint);
+                    Assert.Equal(context.IsTokenEndpoint, endpoint == TokenEndpoint);
+                    Assert.Equal(context.IsUserinfoEndpoint, endpoint == UserinfoEndpoint);
 
                     return Task.FromResult(0);
                 };
@@ -63,12 +123,10 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
             var client = new OpenIdConnectClient(server.HttpClient);
 
             // Act
-            return client.PostAsync(address, new OpenIdConnectRequest());
+            return client.PostAsync(path, new OpenIdConnectRequest());
         }
 
         [Theory]
-        [InlineData("/custom/.well-known/openid-configuration")]
-        [InlineData("/custom/.well-known/jwks")]
         [InlineData("/custom/connect/authorize")]
         [InlineData("/custom/connect/custom")]
         [InlineData("/custom/connect/introspect")]
@@ -76,6 +134,8 @@ namespace Owin.Security.OpenIdConnect.Server.Tests {
         [InlineData("/custom/connect/revoke")]
         [InlineData("/custom/connect/token")]
         [InlineData("/custom/connect/userinfo")]
+        [InlineData("/custom/.well-known/openid-configuration")]
+        [InlineData("/custom/.well-known/jwks")]
         public Task HandleRequestAsync_MatchEndpoint_AllowsOverridingEndpoint(string address) {
             // Arrange
             var server = CreateAuthorizationServer(options => {


### PR DESCRIPTION
Related post: http://stackoverflow.com/questions/42048770/asp-net-core-openiddict-throws-an-openid-connect-response-cannot-be-returned-fr