### PR TITLE
Fix how scopes are formatted and returned by the introspection endpoint

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -370,7 +370,7 @@ namespace AspNet.Security.OpenIdConnect.Server
             if (!ticket.HasAudience() || (!string.IsNullOrEmpty(request.ClientId) && ticket.HasAudience(request.ClientId)))
             {
                 notification.Username = ticket.Principal.Identity?.Name;
-                notification.Scope = ticket.GetProperty(OpenIdConnectConstants.Properties.Scopes);
+                notification.Scope = string.Join(" ", ticket.GetScopes());
 
                 // Potentially sensitive claims are only exposed to trusted callers
                 // if the ticket corresponds to an access or identity token.

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -368,7 +368,7 @@ namespace Owin.Security.OpenIdConnect.Server
             if (!ticket.HasAudience() || (!string.IsNullOrEmpty(request.ClientId) && ticket.HasAudience(request.ClientId)))
             {
                 notification.Username = ticket.Identity.Name;
-                notification.Scope = ticket.GetProperty(OpenIdConnectConstants.Properties.Scopes);
+                notification.Scope = string.Join(" ", ticket.GetScopes());
 
                 // Potentially sensitive claims are only exposed to trusted callers
                 // if the ticket corresponds to an access or identity token.

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Introspection.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Introspection.cs
@@ -622,6 +622,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.AccessToken);
 
                     var identity = new ClaimsIdentity(context.Options.AuthenticationScheme);
+                    identity.AddClaim(OpenIdConnectConstants.Claims.Username, "Bob");
                     identity.AddClaim("custom_claim", "secret_value");
 
                     context.Ticket = new AuthenticationTicket(
@@ -630,6 +631,8 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
                         context.Options.AuthenticationScheme);
 
                     context.Ticket.SetAudiences("Contoso");
+                    context.Ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId,
+                                             OpenIdConnectConstants.Scopes.Profile);
 
                     return Task.FromResult(0);
                 };
@@ -654,6 +657,8 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
 
             // Assert
             Assert.Null(response["custom_claim"]);
+            Assert.Null(response[OpenIdConnectConstants.Claims.Username]);
+            Assert.Null(response[OpenIdConnectConstants.Claims.Scope]);
         }
 
         [Fact]
@@ -667,6 +672,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.AccessToken);
 
                     var identity = new ClaimsIdentity(context.Options.AuthenticationScheme);
+                    identity.AddClaim(OpenIdConnectConstants.Claims.Username, "Bob");
                     identity.AddClaim("custom_claim", "secret_value");
 
                     context.Ticket = new AuthenticationTicket(
@@ -675,6 +681,8 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
                         context.Options.AuthenticationScheme);
 
                     context.Ticket.SetAudiences("Fabrikam");
+                    context.Ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId,
+                                             OpenIdConnectConstants.Scopes.Profile);
 
                     return Task.FromResult(0);
                 };
@@ -699,6 +707,8 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
 
             // Assert
             Assert.Equal("secret_value", (string) response["custom_claim"]);
+            Assert.Equal("Bob", (string) response[OpenIdConnectConstants.Claims.Username]);
+            Assert.Equal("openid profile", (string) response[OpenIdConnectConstants.Claims.Scope]);
         }
 
         [Theory]

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Introspection.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Introspection.cs
@@ -610,6 +610,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.AccessToken);
 
                     var identity = new ClaimsIdentity(context.Options.AuthenticationType);
+                    identity.AddClaim(OpenIdConnectConstants.Claims.Username, "Bob");
                     identity.AddClaim("custom_claim", "secret_value");
 
                     context.Ticket = new AuthenticationTicket(
@@ -617,6 +618,8 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
                         new AuthenticationProperties());
 
                     context.Ticket.SetAudiences("Contoso");
+                    context.Ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId,
+                                             OpenIdConnectConstants.Scopes.Profile);
 
                     return Task.FromResult(0);
                 };
@@ -641,6 +644,8 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
 
             // Assert
             Assert.Null(response["custom_claim"]);
+            Assert.Null(response[OpenIdConnectConstants.Claims.Username]);
+            Assert.Null(response[OpenIdConnectConstants.Claims.Scope]);
         }
 
         [Fact]
@@ -654,10 +659,13 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.AccessToken);
 
                     var identity = new ClaimsIdentity(context.Options.AuthenticationType);
+                    identity.AddClaim(OpenIdConnectConstants.Claims.Username, "Bob");
                     identity.AddClaim("custom_claim", "secret_value");
 
                     context.Ticket = new AuthenticationTicket(identity, new AuthenticationProperties());
                     context.Ticket.SetAudiences("Fabrikam");
+                    context.Ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId,
+                                             OpenIdConnectConstants.Scopes.Profile);
 
                     return Task.FromResult(0);
                 };
@@ -682,6 +690,8 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
 
             // Assert
             Assert.Equal("secret_value", (string) response["custom_claim"]);
+            Assert.Equal("Bob", (string) response[OpenIdConnectConstants.Claims.Username]);
+            Assert.Equal("openid profile", (string) response[OpenIdConnectConstants.Claims.Scope]);
         }
 
         [Theory]


### PR DESCRIPTION
Fix a regression introduced by https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/pull/385.