### PR TITLE
Update the configuration endpoint to expose the client authentication methods supported by the introspection/revocation/token endpoints

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConstants.cs
+++ b/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConstants.cs
@@ -77,6 +77,12 @@ namespace AspNet.Security.OpenIdConnect.Primitives
             public const string JsonArray = "JSON_ARRAY";
         }
 
+        public static class ClientAuthenticationMethods
+        {
+            public const string ClientSecretBasic = "client_secret_basic";
+            public const string ClientSecretPost = "client_secret_post";
+        }
+
         public static class CodeChallengeMethods
         {
             public const string Plain = "plain";
@@ -151,6 +157,8 @@ namespace AspNet.Security.OpenIdConnect.Primitives
             public const string IdTokenEncryptionEncValuesSupported = "id_token_encryption_enc_values_supported";
             public const string IdTokenSigningAlgValuesSupported = "id_token_signing_alg_values_supported";
             public const string IntrospectionEndpoint = "introspection_endpoint";
+            public const string IntrospectionEndpointAuthMethodsSupported = "introspection_endpoint_auth_methods_supported";
+            public const string IntrospectionEndpointAuthSigningAlgValuesSupported = "introspection_endpoint_auth_signing_alg_values_supported";
             public const string Issuer = "issuer";
             public const string JwksUri = "jwks_uri";
             public const string OpPolicyUri = "op_policy_uri";
@@ -164,6 +172,8 @@ namespace AspNet.Security.OpenIdConnect.Primitives
             public const string ResponseModesSupported = "response_modes_supported";
             public const string ResponseTypesSupported = "response_types_supported";
             public const string RevocationEndpoint = "revocation_endpoint";
+            public const string RevocationEndpointAuthMethodsSupported = "revocation_endpoint_auth_methods_supported";
+            public const string RevocationEndpointAuthSigningAlgValuesSupported = "revocation_endpoint_auth_signing_alg_values_supported";
             public const string ScopesSupported = "scopes_supported";
             public const string ServiceDocumentation = "service_documentation";
             public const string SubjectTypesSupported = "subject_types_supported";

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
@@ -90,6 +90,20 @@ namespace AspNet.Security.OpenIdConnect.Server
             new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
+        /// Gets a list of the signing algorithms supported by the
+        /// authorization server for signing the identity tokens.
+        /// </summary>
+        public ISet<string> IdTokenSigningAlgorithms { get; } =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets a list of the client authentication methods supported by
+        /// the introspection endpoint provided by the authorization server.
+        /// </summary>
+        public ISet<string> IntrospectionEndpointAuthenticationMethods { get; } =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets a list of the response modes
         /// supported by the authorization server.
         /// </summary>
@@ -104,6 +118,13 @@ namespace AspNet.Security.OpenIdConnect.Server
             new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
+        /// Gets a list of the client authentication methods supported by
+        /// the revocation endpoint provided by the authorization server.
+        /// </summary>
+        public ISet<string> RevocationEndpointAuthenticationMethods { get; } =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets a list of the scope values
         /// supported by the authorization server.
         /// </summary>
@@ -111,17 +132,17 @@ namespace AspNet.Security.OpenIdConnect.Server
             new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
-        /// Gets a list of the signing algorithms
-        /// supported by the authorization server.
-        /// </summary>
-        public ISet<string> SigningAlgorithms { get; } =
-            new HashSet<string>(StringComparer.Ordinal);
-
-        /// <summary>
         /// Gets a list of the subject types
         /// supported by the authorization server.
         /// </summary>
         public ISet<string> SubjectTypes { get; } =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets a list of the client authentication methods supported by
+        /// the token endpoint provided by the authorization server.
+        /// </summary>
+        public ISet<string> TokenEndpointAuthenticationMethods { get; } =
             new HashSet<string>(StringComparer.Ordinal);
     }
 }

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -129,6 +129,11 @@ namespace AspNet.Security.OpenIdConnect.Server
             if (Options.IntrospectionEndpointPath.HasValue)
             {
                 notification.IntrospectionEndpoint = notification.Issuer.AddPath(Options.IntrospectionEndpointPath);
+
+                notification.IntrospectionEndpointAuthenticationMethods.Add(
+                    OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretBasic);
+                notification.IntrospectionEndpointAuthenticationMethods.Add(
+                    OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretPost);
             }
 
             if (Options.LogoutEndpointPath.HasValue)
@@ -139,11 +144,21 @@ namespace AspNet.Security.OpenIdConnect.Server
             if (Options.RevocationEndpointPath.HasValue)
             {
                 notification.RevocationEndpoint = notification.Issuer.AddPath(Options.RevocationEndpointPath);
+
+                notification.RevocationEndpointAuthenticationMethods.Add(
+                    OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretBasic);
+                notification.RevocationEndpointAuthenticationMethods.Add(
+                    OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretPost);
             }
 
             if (Options.TokenEndpointPath.HasValue)
             {
                 notification.TokenEndpoint = notification.Issuer.AddPath(Options.TokenEndpointPath);
+
+                notification.TokenEndpointAuthenticationMethods.Add(
+                    OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretBasic);
+                notification.TokenEndpointAuthenticationMethods.Add(
+                    OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretPost);
             }
 
             if (Options.UserinfoEndpointPath.HasValue)
@@ -157,9 +172,14 @@ namespace AspNet.Security.OpenIdConnect.Server
 
                 if (Options.TokenEndpointPath.HasValue)
                 {
-                    // Only expose the authorization code and refresh token grant types
+                    // Only expose the code grant type and the code challenge methods
                     // if both the authorization and the token endpoints are enabled.
                     notification.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
+
+                    // Note: supporting S256 is mandatory for authorization servers that implement PKCE.
+                    // See https://tools.ietf.org/html/rfc7636#section-4.2 for more information.
+                    notification.CodeChallengeMethods.Add(OpenIdConnectConstants.CodeChallengeMethods.Plain);
+                    notification.CodeChallengeMethods.Add(OpenIdConnectConstants.CodeChallengeMethods.Sha256);
                 }
             }
 
@@ -220,11 +240,6 @@ namespace AspNet.Security.OpenIdConnect.Server
 
             notification.SubjectTypes.Add(OpenIdConnectConstants.SubjectTypes.Public);
 
-            // Note: supporting S256 is mandatory for authorization servers that implement PKCE.
-            // See https://tools.ietf.org/html/rfc7636#section-4.2 for more information.
-            notification.CodeChallengeMethods.Add(OpenIdConnectConstants.CodeChallengeMethods.Plain);
-            notification.CodeChallengeMethods.Add(OpenIdConnectConstants.CodeChallengeMethods.Sha256);
-
             foreach (var credentials in Options.SigningCredentials)
             {
                 // If the signing key is not an asymmetric key, ignore it.
@@ -240,7 +255,7 @@ namespace AspNet.Security.OpenIdConnect.Server
                     continue;
                 }
 
-                notification.SigningAlgorithms.Add(algorithm);
+                notification.IdTokenSigningAlgorithms.Add(algorithm);
             }
 
             await Options.Provider.HandleConfigurationRequest(notification);
@@ -287,9 +302,12 @@ namespace AspNet.Security.OpenIdConnect.Server
                 [OpenIdConnectConstants.Metadata.ResponseTypesSupported] = new JArray(notification.ResponseTypes),
                 [OpenIdConnectConstants.Metadata.ResponseModesSupported] = new JArray(notification.ResponseModes),
                 [OpenIdConnectConstants.Metadata.ScopesSupported] = new JArray(notification.Scopes),
-                [OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported] = new JArray(notification.SigningAlgorithms),
+                [OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported] = new JArray(notification.IdTokenSigningAlgorithms),
                 [OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported] = new JArray(notification.CodeChallengeMethods),
-                [OpenIdConnectConstants.Metadata.SubjectTypesSupported] = new JArray(notification.SubjectTypes)
+                [OpenIdConnectConstants.Metadata.SubjectTypesSupported] = new JArray(notification.SubjectTypes),
+                [OpenIdConnectConstants.Metadata.TokenEndpointAuthMethodsSupported] = new JArray(notification.TokenEndpointAuthenticationMethods),
+                [OpenIdConnectConstants.Metadata.IntrospectionEndpointAuthMethodsSupported] = new JArray(notification.IntrospectionEndpointAuthenticationMethods),
+                [OpenIdConnectConstants.Metadata.RevocationEndpointAuthMethodsSupported] = new JArray(notification.RevocationEndpointAuthenticationMethods)
             };
 
             foreach (var metadata in notification.Metadata)

--- a/src/Owin.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
@@ -90,6 +90,20 @@ namespace Owin.Security.OpenIdConnect.Server
             new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
+        /// Gets a list of the signing algorithms supported by the
+        /// authorization server for signing the identity tokens.
+        /// </summary>
+        public ISet<string> IdTokenSigningAlgorithms { get; } =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets a list of the client authentication methods supported by
+        /// the introspection endpoint provided by the authorization server.
+        /// </summary>
+        public ISet<string> IntrospectionEndpointAuthenticationMethods { get; } =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets a HashSet of the response modes
         /// supported by the authorization server.
         /// </summary>
@@ -104,6 +118,13 @@ namespace Owin.Security.OpenIdConnect.Server
             new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
+        /// Gets a list of the client authentication methods supported by
+        /// the revocation endpoint provided by the authorization server.
+        /// </summary>
+        public ISet<string> RevocationEndpointAuthenticationMethods { get; } =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets a HashSet of the scope values
         /// supported by the authorization server.
         /// </summary>
@@ -111,17 +132,17 @@ namespace Owin.Security.OpenIdConnect.Server
             new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
-        /// Gets a HashSet of the signing algorithms
-        /// supported by the authorization server.
-        /// </summary>
-        public ISet<string> SigningAlgorithms { get; } =
-            new HashSet<string>(StringComparer.Ordinal);
-
-        /// <summary>
         /// Gets a HashSet of the subject types
         /// supported by the authorization server.
         /// </summary>
         public ISet<string> SubjectTypes { get; } =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets a list of the client authentication methods supported by
+        /// the token endpoint provided by the authorization server.
+        /// </summary>
+        public ISet<string> TokenEndpointAuthenticationMethods { get; } =
             new HashSet<string>(StringComparer.Ordinal);
     }
 }

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
@@ -287,6 +287,111 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
         }
 
         [Fact]
+        public async Task InvokeConfigurationEndpointAsync_NoClientAuthenticationMethodIsIncludedWhenTokenEndpointIsDisabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.TokenEndpointPath = PathString.Empty;
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+
+            // Assert
+            Assert.False(response.HasParameter(OpenIdConnectConstants.Metadata.TokenEndpointAuthMethodsSupported));
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_DefaultClientAuthenticationMethodsAreIncludedWhenTokenEndpointIsEnabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer();
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+            var methods = (string[]) response[OpenIdConnectConstants.Metadata.TokenEndpointAuthMethodsSupported];
+
+            // Assert
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretBasic, methods);
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretPost, methods);
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_NoClientAuthenticationMethodIsIncludedWhenIntrospectionEndpointIsDisabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.IntrospectionEndpointPath = PathString.Empty;
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+
+            // Assert
+            Assert.False(response.HasParameter(OpenIdConnectConstants.Metadata.IntrospectionEndpointAuthMethodsSupported));
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_DefaultClientAuthenticationMethodsAreIncludedWhenIntrospectionEndpointIsEnabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer();
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+            var methods = (string[]) response[OpenIdConnectConstants.Metadata.IntrospectionEndpointAuthMethodsSupported];
+
+            // Assert
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretBasic, methods);
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretPost, methods);
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_NoClientAuthenticationMethodIsIncludedWhenRevocationEndpointIsDisabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.RevocationEndpointPath = PathString.Empty;
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+
+            // Assert
+            Assert.False(response.HasParameter(OpenIdConnectConstants.Metadata.RevocationEndpointAuthMethodsSupported));
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_DefaultClientAuthenticationMethodsAreIncludedWhenRevocationEndpointIsEnabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer();
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+            var methods = (string[]) response[OpenIdConnectConstants.Metadata.RevocationEndpointAuthMethodsSupported];
+
+            // Assert
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretBasic, methods);
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretPost, methods);
+        }
+
+        [Fact]
         public async Task InvokeConfigurationEndpointAsync_GrantTypesIncludeCodeWhenAuthorizationEndpointIsEnabled()
         {
             // Arrange
@@ -334,6 +439,59 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
             Assert.Contains(OpenIdConnectConstants.GrantTypes.ClientCredentials, types);
             Assert.Contains(OpenIdConnectConstants.GrantTypes.Password, types);
             Assert.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken, types);
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_NoCodeChallengeMethodIsIncludedWhenAuthorizationEndpointIsDisabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.AuthorizationEndpointPath = PathString.Empty;
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+
+            // Assert
+            Assert.False(response.HasParameter(OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported));
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_NoCodeChallengeMethodIsIncludedWhenTokenEndpointIsDisabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.TokenEndpointPath = PathString.Empty;
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+
+            // Assert
+            Assert.False(response.HasParameter(OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported));
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_DefaultCodeChallengeMethodsAreCorrectlyReturned()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer();
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+            var methods = (string[]) response[OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported];
+
+            // Assert
+            Assert.Contains(OpenIdConnectConstants.CodeChallengeMethods.Plain, methods);
+            Assert.Contains(OpenIdConnectConstants.CodeChallengeMethods.Sha256, methods);
         }
 
         [Fact]
@@ -536,23 +694,6 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
 
             // Assert
             Assert.Equal(1, algorithms.Count());
-        }
-
-        [Fact]
-        public async Task InvokeConfigurationEndpointAsync_DefaultCodeChallengeMethodsAreCorrectlyReturned()
-        {
-            // Arrange
-            var server = CreateAuthorizationServer();
-
-            var client = new OpenIdConnectClient(server.CreateClient());
-
-            // Act
-            var response = await client.GetAsync(ConfigurationEndpoint);
-            var methods = (string[]) response[OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported];
-
-            // Assert
-            Assert.Contains(OpenIdConnectConstants.CodeChallengeMethods.Plain, methods);
-            Assert.Contains(OpenIdConnectConstants.CodeChallengeMethods.Sha256, methods);
         }
 
         [Theory]

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
@@ -286,6 +286,111 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
         }
 
         [Fact]
+        public async Task InvokeConfigurationEndpointAsync_NoClientAuthenticationMethodIsIncludedWhenTokenEndpointIsDisabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.TokenEndpointPath = PathString.Empty;
+            });
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+
+            // Assert
+            Assert.False(response.HasParameter(OpenIdConnectConstants.Metadata.TokenEndpointAuthMethodsSupported));
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_DefaultClientAuthenticationMethodsAreIncludedWhenTokenEndpointIsEnabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer();
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+            var methods = (string[]) response[OpenIdConnectConstants.Metadata.TokenEndpointAuthMethodsSupported];
+
+            // Assert
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretBasic, methods);
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretPost, methods);
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_NoClientAuthenticationMethodIsIncludedWhenIntrospectionEndpointIsDisabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.IntrospectionEndpointPath = PathString.Empty;
+            });
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+
+            // Assert
+            Assert.False(response.HasParameter(OpenIdConnectConstants.Metadata.IntrospectionEndpointAuthMethodsSupported));
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_DefaultClientAuthenticationMethodsAreIncludedWhenIntrospectionEndpointIsEnabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer();
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+            var methods = (string[]) response[OpenIdConnectConstants.Metadata.IntrospectionEndpointAuthMethodsSupported];
+
+            // Assert
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretBasic, methods);
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretPost, methods);
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_NoClientAuthenticationMethodIsIncludedWhenRevocationEndpointIsDisabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.RevocationEndpointPath = PathString.Empty;
+            });
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+
+            // Assert
+            Assert.False(response.HasParameter(OpenIdConnectConstants.Metadata.RevocationEndpointAuthMethodsSupported));
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_DefaultClientAuthenticationMethodsAreIncludedWhenRevocationEndpointIsEnabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer();
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+            var methods = (string[]) response[OpenIdConnectConstants.Metadata.RevocationEndpointAuthMethodsSupported];
+
+            // Assert
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretBasic, methods);
+            Assert.Contains(OpenIdConnectConstants.ClientAuthenticationMethods.ClientSecretPost, methods);
+        }
+
+        [Fact]
         public async Task InvokeConfigurationEndpointAsync_GrantTypesIncludeCodeWhenAuthorizationEndpointIsEnabled()
         {
             // Arrange
@@ -333,6 +438,59 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
             Assert.Contains(OpenIdConnectConstants.GrantTypes.ClientCredentials, types);
             Assert.Contains(OpenIdConnectConstants.GrantTypes.Password, types);
             Assert.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken, types);
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_NoCodeChallengeMethodIsIncludedWhenAuthorizationEndpointIsDisabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.AuthorizationEndpointPath = PathString.Empty;
+            });
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+
+            // Assert
+            Assert.False(response.HasParameter(OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported));
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_NoCodeChallengeMethodIsIncludedWhenTokenEndpointIsDisabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.TokenEndpointPath = PathString.Empty;
+            });
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+
+            // Assert
+            Assert.False(response.HasParameter(OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported));
+        }
+
+        [Fact]
+        public async Task InvokeConfigurationEndpointAsync_DefaultCodeChallengeMethodsAreCorrectlyReturned()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer();
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+            var methods = (string[]) response[OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported];
+
+            // Assert
+            Assert.Contains(OpenIdConnectConstants.CodeChallengeMethods.Plain, methods);
+            Assert.Contains(OpenIdConnectConstants.CodeChallengeMethods.Sha256, methods);
         }
 
         [Fact]
@@ -533,23 +691,6 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
 
             // Assert
             Assert.Equal(1, algorithms.Count());
-        }
-
-        [Fact]
-        public async Task InvokeConfigurationEndpointAsync_DefaultCodeChallengeMethodsAreCorrectlyReturned()
-        {
-            // Arrange
-            var server = CreateAuthorizationServer();
-
-            var client = new OpenIdConnectClient(server.HttpClient);
-
-            // Act
-            var response = await client.GetAsync(ConfigurationEndpoint);
-            var methods = (string[]) response[OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported];
-
-            // Assert
-            Assert.Contains(OpenIdConnectConstants.CodeChallengeMethods.Plain, methods);
-            Assert.Contains(OpenIdConnectConstants.CodeChallengeMethods.Sha256, methods);
         }
 
         [Theory]


### PR DESCRIPTION
This new feature will be used by the introspection middleware to determine the best client authentication method to use (`client_secret_post` will be preferred when present).