### PR TITLE
Update AddCertificate() to avoid using the unnecessary X509KeyStorage.Flags.Exportable flag

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
@@ -429,6 +429,12 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(key));
             }
 
+            // If the signing key is an asymmetric security key, ensure it has a private key.
+            if (key is AsymmetricSecurityKey && !((AsymmetricSecurityKey) key).HasPrivateKey)
+            {
+                throw new InvalidOperationException("The asymmetric signing key doesn't contain the required private key.");
+            }
+
             // When no key identifier can be retrieved from the security key, a value is automatically
             // inferred from the hexadecimal representation of the certificate thumbprint (SHA-1)
             // when the key is bound to a X.509 certificate or from the public part of the signing key.
@@ -453,19 +459,22 @@ namespace Microsoft.AspNetCore.Builder
 
 #if SUPPORTS_ECDSA
             // Note: ECDSA algorithms are bound to specific curves and must be treated separately.
-            else if (key.IsSupportedAlgorithm(SecurityAlgorithms.EcdsaSha256Signature)) {
+            else if (key.IsSupportedAlgorithm(SecurityAlgorithms.EcdsaSha256Signature))
+            {
                 credentials.Add(new SigningCredentials(key, SecurityAlgorithms.EcdsaSha256Signature));
 
                 return credentials;
             }
 
-            else if (key.IsSupportedAlgorithm(SecurityAlgorithms.EcdsaSha384Signature)) {
+            else if (key.IsSupportedAlgorithm(SecurityAlgorithms.EcdsaSha384Signature))
+            {
                 credentials.Add(new SigningCredentials(key, SecurityAlgorithms.EcdsaSha384Signature));
 
                 return credentials;
             }
 
-            else if (key.IsSupportedAlgorithm(SecurityAlgorithms.EcdsaSha512Signature)) {
+            else if (key.IsSupportedAlgorithm(SecurityAlgorithms.EcdsaSha512Signature))
+            {
                 credentials.Add(new SigningCredentials(key, SecurityAlgorithms.EcdsaSha512Signature));
 
                 return credentials;

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
@@ -162,8 +162,7 @@ namespace Microsoft.AspNetCore.Builder
             [NotNull] this IList<SigningCredentials> credentials,
             [NotNull] Stream stream, [NotNull] string password)
         {
-            return credentials.AddCertificate(stream, password, X509KeyStorageFlags.Exportable |
-                                                                X509KeyStorageFlags.MachineKeySet);
+            return credentials.AddCertificate(stream, password, X509KeyStorageFlags.MachineKeySet);
         }
 
         /// <summary>

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
@@ -176,8 +176,7 @@ namespace Owin
         public static IList<SigningCredentials> AddCertificate(
             [NotNull] this IList<SigningCredentials> credentials, [NotNull] Stream stream, [NotNull] string password)
         {
-            return credentials.AddCertificate(stream, password, X509KeyStorageFlags.Exportable |
-                                                                X509KeyStorageFlags.MachineKeySet);
+            return credentials.AddCertificate(stream, password, X509KeyStorageFlags.MachineKeySet);
         }
 
         /// <summary>

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerExtensions.cs
@@ -99,7 +99,7 @@ namespace Owin
                 throw new ArgumentNullException(nameof(certificate));
             }
 
-            if (certificate.PrivateKey == null)
+            if (!certificate.HasPrivateKey)
             {
                 throw new InvalidOperationException("The certificate doesn't contain the required private key.");
             }
@@ -370,6 +370,12 @@ namespace Owin
             if (key == null)
             {
                 throw new ArgumentNullException(nameof(key));
+            }
+
+            // If the signing key is an asymmetric security key, ensure it has a private key.
+            if (key is AsymmetricSecurityKey && !((AsymmetricSecurityKey) key).HasPrivateKey())
+            {
+                throw new InvalidOperationException("The asymmetric signing key doesn't contain the required private key.");
             }
 
             if (key.IsSupportedAlgorithm(SecurityAlgorithms.RsaSha256Signature))


### PR DESCRIPTION
`X509KeyStorage.Flags.Exportable` is not necessary as ASOS never exports the private key associated with .pfx certificate.