### PR TITLE
Remove the built-in WS-Federation claims support

### DIFF
--- a/samples/Mvc/Mvc.Server/Startup.cs
+++ b/samples/Mvc/Mvc.Server/Startup.cs
@@ -99,8 +99,13 @@ namespace Mvc.Server
                 options.ApplicationCanDisplayErrors = true;
                 options.AllowInsecureHttp = true;
 
-                // Note: to override the default access token format and use JWT, assign AccessTokenHandler.
-                // options.AccessTokenHandler = new JwtSecurityTokenHandler();
+                // Note: to override the default access token format and use JWT, assign AccessTokenHandler:
+                //
+                // options.AccessTokenHandler = new JwtSecurityTokenHandler
+                // {
+                //     InboundClaimTypeMap = new Dictionary<string, string>(),
+                //     OutboundClaimTypeMap = new Dictionary<string, string>()
+                // };
                 //
                 // Note: when using JWT as the access token format, you have to register a signing key.
                 //

--- a/samples/Nancy/Nancy.Server/Modules/AuthenticationModule.cs
+++ b/samples/Nancy/Nancy.Server/Modules/AuthenticationModule.cs
@@ -55,9 +55,6 @@ namespace Nancy.Server.Modules
 
             Get["/signout"] = Post["/signout"] = parameters =>
             {
-                // Instruct the cookies middleware to delete the local cookie created
-                // when the user agent is redirected from the external identity provider
-                // after a successful authentication flow (e.g Google or Facebook).
                 AuthenticationManager.SignOut("ServerCookie");
 
                 return HttpStatusCode.OK;

--- a/samples/Nancy/Nancy.Server/Modules/AuthorizationModule.cs
+++ b/samples/Nancy/Nancy.Server/Modules/AuthorizationModule.cs
@@ -88,22 +88,22 @@ namespace Nancy.Server.Modules
 
                 // Create a new ClaimsIdentity containing the claims that
                 // will be used to create an id_token, a token or a code.
-                var identity = new ClaimsIdentity(OpenIdConnectServerDefaults.AuthenticationType);
+                var identity = new ClaimsIdentity(
+                    OpenIdConnectServerDefaults.AuthenticationType,
+                    OpenIdConnectConstants.Claims.Name,
+                    OpenIdConnectConstants.Claims.Role);
 
-                foreach (var claim in OwinContext.Authentication.User.Claims)
-                {
-                    // Allow ClaimTypes.Name to be added in the id_token.
-                    // ClaimTypes.NameIdentifier is automatically added, even if its
-                    // destination is not defined or doesn't include "id_token".
-                    // The other claims won't be visible for the client application.
-                    if (claim.Type == ClaimTypes.Name)
-                    {
-                        claim.SetDestinations(OpenIdConnectConstants.Destinations.AccessToken,
-                                              OpenIdConnectConstants.Destinations.IdentityToken);
-                    }
+                // Note: the "sub" claim is mandatory and an
+                // exception is thrown if this claim is missing.
+                identity.AddClaim(
+                    new Claim(OpenIdConnectConstants.Claims.Subject, User.FindFirst(ClaimTypes.NameIdentifier).Value)
+                        .SetDestinations(OpenIdConnectConstants.Destinations.AccessToken,
+                                         OpenIdConnectConstants.Destinations.IdentityToken));
 
-                    identity.AddClaim(claim);
-                }
+                identity.AddClaim(
+                    new Claim(OpenIdConnectConstants.Claims.Name, User.FindFirst(ClaimTypes.Name).Value)
+                        .SetDestinations(OpenIdConnectConstants.Destinations.AccessToken,
+                                         OpenIdConnectConstants.Destinations.IdentityToken));
 
                 var application = await GetApplicationAsync(request.ClientId, CancellationToken.None);
                 if (application == null)
@@ -134,8 +134,6 @@ namespace Nancy.Server.Modules
                 ticket.SetResources("resource_server");
 
                 // This call will ask ASOS to serialize the specified identity to build appropriate tokens.
-                // Note: you should always make sure the identities you return contain ClaimTypes.NameIdentifier claim.
-                // In this sample, the identity always contains the name identifier returned by the external provider.
                 OwinContext.Authentication.SignIn(ticket.Properties, ticket.Identity);
 
                 return HttpStatusCode.OK;
@@ -234,6 +232,11 @@ namespace Nancy.Server.Modules
                 return context;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="ClaimsPrincipal"/> instance associated with the current request.
+        /// </summary>
+        protected ClaimsPrincipal User => OwinContext.Authentication.User;
 
         protected async Task<Application> GetApplicationAsync(string identifier, CancellationToken cancellationToken)
         {

--- a/samples/Nancy/Nancy.Server/Startup.cs
+++ b/samples/Nancy/Nancy.Server/Startup.cs
@@ -141,6 +141,9 @@ namespace Nancy.Server
                 //     password: "Owin.Security.OpenIdConnect.Server");
 
                 // Note: to override the default access token format and use JWT, assign AccessTokenHandler:
+                //
+                // JwtSecurityTokenHandler.InboundClaimTypeMap.Clear();
+                // JwtSecurityTokenHandler.OutboundClaimTypeMap.Clear();
                 // options.AccessTokenHandler = new JwtSecurityTokenHandler();
 
                 // Register the logging listeners used by the OpenID Connect server middleware.

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -337,6 +337,7 @@ namespace AspNet.Security.OpenIdConnect.Server
             var notification = new HandleIntrospectionRequestContext(Context, Options, request, ticket);
             notification.Active = true;
             notification.Issuer = Context.GetIssuer(Options);
+            notification.Subject = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Subject);
 
             // Use the unique ticket identifier to populate the "jti" claim.
             notification.TokenId = ticket.GetTicketId();
@@ -348,11 +349,6 @@ namespace AspNet.Security.OpenIdConnect.Server
             {
                 notification.TokenType = OpenIdConnectConstants.TokenTypes.Bearer;
             }
-
-            // Try to resolve the subject using one of the well-known sub/name identifier/upn claims.
-            notification.Subject = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Subject) ??
-                                   ticket.Principal.GetClaim(ClaimTypes.NameIdentifier) ??
-                                   ticket.Principal.GetClaim(ClaimTypes.Upn);
 
             notification.IssuedAt = ticket.Properties.IssuedUtc;
             notification.NotBefore = ticket.Properties.IssuedUtc;
@@ -378,8 +374,6 @@ namespace AspNet.Security.OpenIdConnect.Server
                         // Make sure to always update this list when adding new built-in claim properties.
                         switch (claim.Type)
                         {
-                            case ClaimTypes.NameIdentifier:
-                            case ClaimTypes.Upn:
                             case OpenIdConnectConstants.Claims.Audience:
                             case OpenIdConnectConstants.Claims.ExpiresAt:
                             case OpenIdConnectConstants.Claims.IssuedAt:

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -232,11 +232,7 @@ namespace AspNet.Security.OpenIdConnect.Server
 
             var notification = new HandleUserinfoRequestContext(Context, Options, request, ticket);
             notification.Issuer = Context.GetIssuer(Options);
-
-            // Try to resolve the subject using one of the well-known sub/name identifier/upn claims.
-            notification.Subject = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Subject) ??
-                                   ticket.Principal.GetClaim(ClaimTypes.NameIdentifier) ??
-                                   ticket.Principal.GetClaim(ClaimTypes.Upn);
+            notification.Subject = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Subject);
 
             // Note: when receiving an access token, its audiences list cannot be used for the "aud" claim
             // as the client application is not the intented audience but only an authorized presenter.
@@ -247,28 +243,19 @@ namespace AspNet.Security.OpenIdConnect.Server
             // no corresponding value has been found in the authentication ticket.
             if (ticket.HasScope(OpenIdConnectConstants.Scopes.Profile))
             {
-                notification.FamilyName = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.FamilyName) ??
-                                          ticket.Principal.GetClaim(ClaimTypes.Surname);
-
-                notification.GivenName = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.GivenName) ??
-                                         ticket.Principal.GetClaim(ClaimTypes.GivenName);
-
-                notification.BirthDate = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Birthdate) ??
-                                         ticket.Principal.GetClaim(ClaimTypes.DateOfBirth);
+                notification.FamilyName = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.FamilyName);
+                notification.GivenName = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.GivenName);
+                notification.BirthDate = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Birthdate);
             }
 
             if (ticket.HasScope(OpenIdConnectConstants.Scopes.Email))
             {
-                notification.Email = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Email) ??
-                                     ticket.Principal.GetClaim(ClaimTypes.Email);
+                notification.Email = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Email);
             }
 
             if (ticket.HasScope(OpenIdConnectConstants.Scopes.Phone))
             {
-                notification.PhoneNumber = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.PhoneNumber) ??
-                                           ticket.Principal.GetClaim(ClaimTypes.HomePhone) ??
-                                           ticket.Principal.GetClaim(ClaimTypes.MobilePhone) ??
-                                           ticket.Principal.GetClaim(ClaimTypes.OtherPhone);
+                notification.PhoneNumber = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.PhoneNumber);
             }
 
             await Options.Provider.HandleUserinfoRequest(notification);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -273,9 +273,7 @@ namespace AspNet.Security.OpenIdConnect.Server
                 throw new InvalidOperationException("An OpenID Connect response has already been sent.");
             }
 
-            if (string.IsNullOrEmpty(ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Subject)) &&
-                string.IsNullOrEmpty(ticket.Principal.GetClaim(ClaimTypes.NameIdentifier)) &&
-                string.IsNullOrEmpty(ticket.Principal.GetClaim(ClaimTypes.Upn)))
+            if (string.IsNullOrEmpty(ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Subject)))
             {
                 throw new InvalidOperationException("The authentication ticket was rejected because " +
                                                     "it doesn't contain the mandatory subject claim.");

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
@@ -144,7 +144,11 @@ namespace AspNet.Security.OpenIdConnect.Server
         /// This property is only used when <see cref="OpenIdConnectServerProvider.SerializeIdentityToken"/>
         /// doesn't call <see cref="BaseControlContext.HandleResponse"/>.
         /// </summary>
-        public JwtSecurityTokenHandler IdentityTokenHandler { get; set; } = new JwtSecurityTokenHandler();
+        public JwtSecurityTokenHandler IdentityTokenHandler { get; set; } = new JwtSecurityTokenHandler
+        {
+            InboundClaimTypeMap = new Dictionary<string, string>(),
+            OutboundClaimTypeMap = new Dictionary<string, string>()
+        };
 
         /// <summary>
         /// The period of time the authorization code remains valid after being issued. The default is 5 minutes.

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -336,6 +336,7 @@ namespace Owin.Security.OpenIdConnect.Server
             var notification = new HandleIntrospectionRequestContext(Context, Options, request, ticket);
             notification.Active = true;
             notification.Issuer = Context.GetIssuer(Options);
+            notification.Subject = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.Subject);
 
             // Use the unique ticket identifier to populate the "jti" claim.
             notification.TokenId = ticket.GetTicketId();
@@ -347,11 +348,6 @@ namespace Owin.Security.OpenIdConnect.Server
             {
                 notification.TokenType = OpenIdConnectConstants.TokenTypes.Bearer;
             }
-
-            // Try to resolve the subject using one of the well-known sub/name identifier/upn claims.
-            notification.Subject = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.Subject) ??
-                                   ticket.Identity.GetClaim(ClaimTypes.NameIdentifier) ??
-                                   ticket.Identity.GetClaim(ClaimTypes.Upn);
 
             notification.IssuedAt = ticket.Properties.IssuedUtc;
             notification.NotBefore = ticket.Properties.IssuedUtc;
@@ -377,8 +373,6 @@ namespace Owin.Security.OpenIdConnect.Server
                         // Make sure to always update this list when adding new built-in claim properties.
                         switch (claim.Type)
                         {
-                            case ClaimTypes.NameIdentifier:
-                            case ClaimTypes.Upn:
                             case OpenIdConnectConstants.Claims.Audience:
                             case OpenIdConnectConstants.Claims.ExpiresAt:
                             case OpenIdConnectConstants.Claims.IssuedAt:

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -230,11 +230,7 @@ namespace Owin.Security.OpenIdConnect.Server
 
             var notification = new HandleUserinfoRequestContext(Context, Options, request, ticket);
             notification.Issuer = Context.GetIssuer(Options);
-
-            // Try to resolve the subject using one of the well-known sub/name identifier/upn claims.
-            notification.Subject = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.Subject) ??
-                                   ticket.Identity.GetClaim(ClaimTypes.NameIdentifier) ??
-                                   ticket.Identity.GetClaim(ClaimTypes.Upn);
+            notification.Subject = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.Subject);
 
             // Note: when receiving an access token, its audiences list cannot be used for the "aud" claim
             // as the client application is not the intented audience but only an authorized presenter.
@@ -245,28 +241,19 @@ namespace Owin.Security.OpenIdConnect.Server
             // no corresponding value has been found in the authentication ticket.
             if (ticket.HasScope(OpenIdConnectConstants.Scopes.Profile))
             {
-                notification.FamilyName = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.FamilyName) ??
-                                          ticket.Identity.GetClaim(ClaimTypes.Surname);
-
-                notification.GivenName = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.GivenName) ??
-                                         ticket.Identity.GetClaim(ClaimTypes.GivenName);
-
-                notification.BirthDate = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.Birthdate) ??
-                                         ticket.Identity.GetClaim(ClaimTypes.DateOfBirth);
+                notification.FamilyName = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.FamilyName);
+                notification.GivenName = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.GivenName);
+                notification.BirthDate = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.Birthdate);
             }
 
             if (ticket.HasScope(OpenIdConnectConstants.Scopes.Email))
             {
-                notification.Email = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.Email) ??
-                                     ticket.Identity.GetClaim(ClaimTypes.Email);
+                notification.Email = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.Email);
             }
 
             if (ticket.HasScope(OpenIdConnectConstants.Scopes.Phone))
             {
-                notification.PhoneNumber = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.PhoneNumber) ??
-                                           ticket.Identity.GetClaim(ClaimTypes.HomePhone) ??
-                                           ticket.Identity.GetClaim(ClaimTypes.MobilePhone) ??
-                                           ticket.Identity.GetClaim(ClaimTypes.OtherPhone);
+                notification.PhoneNumber = ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.PhoneNumber);
             }
 
             await Options.Provider.HandleUserinfoRequest(notification);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -304,9 +304,7 @@ namespace Owin.Security.OpenIdConnect.Server
                 throw new InvalidOperationException("An OpenID Connect response has already been sent.");
             }
 
-            if (string.IsNullOrEmpty(ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.Subject)) &&
-                string.IsNullOrEmpty(ticket.Identity.GetClaim(ClaimTypes.NameIdentifier)) &&
-                string.IsNullOrEmpty(ticket.Identity.GetClaim(ClaimTypes.Upn)))
+            if (string.IsNullOrEmpty(ticket.Identity.GetClaim(OpenIdConnectConstants.Claims.Subject)))
             {
                 throw new InvalidOperationException("The authentication ticket was rejected because " +
                                                     "it doesn't contain the mandatory subject claim.");


### PR DESCRIPTION
This PR removes the WS-Federation claims support, which means claims like `ClaimTypes.NameIdentifier` will no longer be considered as an equivalent for `sub`.