### PR TITLE
Avoid returning no-cache directives for discovery, introspection and userinfo responses

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConstants.cs
+++ b/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConstants.cs
@@ -133,13 +133,21 @@ namespace AspNet.Security.OpenIdConnect.Primitives
         public static class MessageTypes
         {
             public const string AuthorizationRequest = "authorization_request";
+            public const string AuthorizationResponse = "authorization_response";
             public const string ConfigurationRequest = "configuration_request";
+            public const string ConfigurationResponse = "configuration_response";
             public const string CryptographyRequest = "cryptography_request";
+            public const string CryptographyResponse = "cryptography_response";
             public const string IntrospectionRequest = "introspection_request";
+            public const string IntrospectionResponse = "introspection_response";
             public const string LogoutRequest = "logout_request";
+            public const string LogoutResponse = "logout_response";
             public const string RevocationRequest = "revocation_request";
+            public const string RevocationResponse = "revocation_response";
             public const string TokenRequest = "token_request";
+            public const string TokenResponse = "token_response";
             public const string UserinfoRequest = "userinfo_request";
+            public const string UserinfoResponse = "userinfo_response";
         }
 
         public static class Metadata

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.Net.Http.Headers;
 
 namespace AspNet.Security.OpenIdConnect.Server
 {
@@ -393,6 +394,9 @@ namespace AspNet.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.AuthorizationResponse);
+
             var notification = new ApplyAuthorizationResponseContext(Context, Options, ticket, request, response);
             await Options.Provider.ApplyAuthorizationResponse(notification);
 
@@ -499,6 +503,10 @@ namespace AspNet.Security.OpenIdConnect.Server
                     Response.StatusCode = 200;
                     Response.ContentLength = buffer.Length;
                     Response.ContentType = "text/html;charset=UTF-8";
+
+                    Response.Headers[HeaderNames.CacheControl] = "no-cache";
+                    Response.Headers[HeaderNames.Pragma] = "no-cache";
+                    Response.Headers[HeaderNames.Expires] = "-1";
 
                     buffer.Seek(offset: 0, loc: SeekOrigin.Begin);
                     await buffer.CopyToAsync(Response.Body, 4096, Context.RequestAborted);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -662,6 +662,9 @@ namespace AspNet.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.ConfigurationResponse);
+
             var notification = new ApplyConfigurationResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyConfigurationResponse(notification);
 
@@ -688,6 +691,9 @@ namespace AspNet.Security.OpenIdConnect.Server
         {
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
+
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.CryptographyResponse);
 
             var notification = new ApplyCryptographyResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyCryptographyResponse(notification);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
@@ -582,6 +582,9 @@ namespace AspNet.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.TokenResponse);
+
             var notification = new ApplyTokenResponseContext(Context, Options, ticket, request, response);
             await Options.Provider.ApplyTokenResponse(notification);
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -505,6 +505,9 @@ namespace AspNet.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.IntrospectionResponse);
+
             var notification = new ApplyIntrospectionResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyIntrospectionResponse(notification);
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -360,6 +360,9 @@ namespace AspNet.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.RevocationResponse);
+
             var notification = new ApplyRevocationResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyRevocationResponse(notification);
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
@@ -187,6 +187,9 @@ namespace AspNet.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.LogoutResponse);
+
             var notification = new ApplyLogoutResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyLogoutResponse(notification);
 

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -345,6 +345,9 @@ namespace AspNet.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.UserinfoResponse);
+
             var notification = new ApplyUserinfoResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyUserinfoResponse(notification);
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -396,6 +396,9 @@ namespace Owin.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.AuthorizationResponse);
+
             var notification = new ApplyAuthorizationResponseContext(Context, Options, ticket, request, response);
             await Options.Provider.ApplyAuthorizationResponse(notification);
 
@@ -504,6 +507,10 @@ namespace Owin.Security.OpenIdConnect.Server
                     Response.StatusCode = 200;
                     Response.ContentLength = buffer.Length;
                     Response.ContentType = "text/html;charset=UTF-8";
+
+                    Response.Headers["Cache-Control"] = "no-cache";
+                    Response.Headers["Pragma"] = "no-cache";
+                    Response.Headers["Expires"] = "-1";
 
                     buffer.Seek(offset: 0, loc: SeekOrigin.Begin);
                     await buffer.CopyToAsync(Response.Body, 4096, Request.CallCancelled);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -619,6 +619,9 @@ namespace Owin.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.ConfigurationResponse);
+
             var notification = new ApplyConfigurationResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyConfigurationResponse(notification);
 
@@ -645,6 +648,9 @@ namespace Owin.Security.OpenIdConnect.Server
         {
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
+
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.CryptographyResponse);
 
             var notification = new ApplyCryptographyResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyCryptographyResponse(notification);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
@@ -580,6 +580,9 @@ namespace Owin.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.TokenResponse);
+
             var notification = new ApplyTokenResponseContext(Context, Options, ticket, request, response);
             await Options.Provider.ApplyTokenResponse(notification);
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -504,6 +504,9 @@ namespace Owin.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.IntrospectionResponse);
+
             var notification = new ApplyIntrospectionResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyIntrospectionResponse(notification);
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -359,6 +359,9 @@ namespace Owin.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.RevocationResponse);
+
             var notification = new ApplyRevocationResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyRevocationResponse(notification);
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
@@ -188,6 +188,9 @@ namespace Owin.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.LogoutResponse);
+
             var notification = new ApplyLogoutResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyLogoutResponse(notification);
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -343,6 +343,9 @@ namespace Owin.Security.OpenIdConnect.Server
             var request = Context.GetOpenIdConnectRequest();
             Context.SetOpenIdConnectResponse(response);
 
+            response.SetProperty(OpenIdConnectConstants.Properties.MessageType,
+                                 OpenIdConnectConstants.MessageTypes.UserinfoResponse);
+
             var notification = new ApplyUserinfoResponseContext(Context, Options, request, response);
             await Options.Provider.ApplyUserinfoResponse(notification);
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -608,9 +608,25 @@ namespace Owin.Security.OpenIdConnect.Server
                 Response.ContentLength = buffer.Length;
                 Response.ContentType = "application/json;charset=UTF-8";
 
-                Response.Headers.Set("Cache-Control", "no-cache");
-                Response.Headers.Set("Pragma", "no-cache");
-                Response.Headers.Set("Expires", "-1");
+                switch (response.GetProperty<string>(OpenIdConnectConstants.Properties.MessageType))
+                {
+                    // Discovery, userinfo and introspection responses can be cached by the client
+                    // or the intermediate proxies. To allow the developer to set up his own response
+                    // caching policy, don't override the Cache-Control, Pragma and Expires headers.
+                    case OpenIdConnectConstants.MessageTypes.ConfigurationResponse:
+                    case OpenIdConnectConstants.MessageTypes.CryptographyResponse:
+                    case OpenIdConnectConstants.MessageTypes.IntrospectionResponse:
+                    case OpenIdConnectConstants.MessageTypes.UserinfoResponse:
+                        break;
+
+                    // Prevent the other responses from being cached.
+                    default:
+                        Response.Headers["Cache-Control"] = "no-cache";
+                        Response.Headers["Pragma"] = "no-cache";
+                        Response.Headers["Expires"] = "-1";
+
+                        break;
+                }
 
                 buffer.Seek(offset: 0, loc: SeekOrigin.Begin);
                 await buffer.CopyToAsync(Response.Body, 4096, Request.CallCancelled);


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/344.