### PR TITLE
Update the Data Protection purposes to force ASOS to reject tokens serialized using the old properties format

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
@@ -103,7 +103,7 @@ namespace AspNet.Security.OpenIdConnect.Server
             {
                 var protector = Options.DataProtectionProvider.CreateProtector(
                     nameof(OpenIdConnectServerMiddleware),
-                    Options.AuthenticationScheme, "Access_Token", "v1");
+                    nameof(Options.AccessTokenFormat), Options.AuthenticationScheme);
 
                 Options.AccessTokenFormat = new TicketDataFormat(protector);
             }
@@ -112,7 +112,7 @@ namespace AspNet.Security.OpenIdConnect.Server
             {
                 var protector = Options.DataProtectionProvider.CreateProtector(
                     nameof(OpenIdConnectServerMiddleware),
-                    Options.AuthenticationScheme, "Authentication_Code", "v1");
+                    nameof(Options.AuthorizationCodeFormat), Options.AuthenticationScheme);
 
                 Options.AuthorizationCodeFormat = new TicketDataFormat(protector);
             }
@@ -121,7 +121,7 @@ namespace AspNet.Security.OpenIdConnect.Server
             {
                 var protector = Options.DataProtectionProvider.CreateProtector(
                     nameof(OpenIdConnectServerMiddleware),
-                    Options.AuthenticationScheme, "Refresh_Token", "v1");
+                    nameof(Options.RefreshTokenFormat), Options.AuthenticationScheme);
 
                 Options.RefreshTokenFormat = new TicketDataFormat(protector);
             }

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerMiddleware.cs
@@ -120,7 +120,7 @@ namespace Owin.Security.OpenIdConnect.Server
             {
                 var protector = Options.DataProtectionProvider.CreateProtector(
                     nameof(OpenIdConnectServerMiddleware),
-                    Options.AuthenticationType, "Access_Token", "v1");
+                    nameof(Options.AccessTokenFormat), Options.AuthenticationType);
 
                 Options.AccessTokenFormat = new AspNetTicketDataFormat(new DataProtectorShim(protector));
             }
@@ -129,7 +129,7 @@ namespace Owin.Security.OpenIdConnect.Server
             {
                 var protector = Options.DataProtectionProvider.CreateProtector(
                     nameof(OpenIdConnectServerMiddleware),
-                    Options.AuthenticationType, "Authorization_Code", "v1");
+                    nameof(Options.AuthorizationCodeFormat), Options.AuthenticationType);
 
                 Options.AuthorizationCodeFormat = new AspNetTicketDataFormat(new DataProtectorShim(protector));
             }
@@ -138,7 +138,7 @@ namespace Owin.Security.OpenIdConnect.Server
             {
                 var protector = Options.DataProtectionProvider.CreateProtector(
                     nameof(OpenIdConnectServerMiddleware),
-                    Options.AuthenticationType, "Refresh_Token", "v1");
+                    nameof(Options.RefreshTokenFormat), Options.AuthenticationType);
 
                 Options.RefreshTokenFormat = new AspNetTicketDataFormat(new DataProtectorShim(protector));
             }


### PR DESCRIPTION
Related ticket: https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions/issues/60.