### PR TITLE
Exclude unnecessary properties from the authorization code/access token/identity token/refresh token authentication tickets

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -19,7 +19,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace AspNet.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeAuthorizationEndpointAsync()
         {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -19,7 +19,7 @@ using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeConfigurationEndpointAsync()
         {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
@@ -21,7 +21,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace AspNet.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeTokenEndpointAsync()
         {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -20,7 +20,7 @@ using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeIntrospectionEndpointAsync()
         {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -16,7 +16,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace AspNet.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeRevocationEndpointAsync()
         {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -39,6 +39,15 @@ namespace AspNet.Security.OpenIdConnect.Server
             // Associate a random identifier with the authorization code.
             ticket.SetTicketId(Guid.NewGuid().ToString());
 
+            // Store the code_challenge, code_challenge_method, nonce and redirect_uri parameters for later comparison.
+            ticket.SetProperty(OpenIdConnectConstants.Properties.CodeChallenge, request.CodeChallenge)
+                  .SetProperty(OpenIdConnectConstants.Properties.CodeChallengeMethod, request.CodeChallengeMethod)
+                  .SetProperty(OpenIdConnectConstants.Properties.Nonce, request.Nonce)
+                  .SetProperty(OpenIdConnectConstants.Properties.RedirectUri, request.RedirectUri);
+
+            // Remove the unwanted properties from the authentication ticket.
+            ticket.RemoveProperty(OpenIdConnectConstants.Properties.AuthorizationCodeLifetime);
+
             // By default, add the client_id to the list of the
             // presenters allowed to use the authorization code.
             if (!string.IsNullOrEmpty(request.ClientId))
@@ -102,6 +111,12 @@ namespace AspNet.Security.OpenIdConnect.Server
                 return true;
             });
 
+            // Remove the destinations from the claim properties.
+            foreach (var claim in principal.Claims)
+            {
+                claim.Properties.Remove(OpenIdConnectConstants.Properties.Destinations);
+            }
+
             var identity = (ClaimsIdentity) principal.Identity;
 
             // Create a new ticket containing the updated properties and the filtered principal.
@@ -115,6 +130,16 @@ namespace AspNet.Security.OpenIdConnect.Server
 
             // Associate a random identifier with the access token.
             ticket.SetTicketId(Guid.NewGuid().ToString());
+
+            // Remove the unwanted properties from the authentication ticket.
+            ticket.RemoveProperty(OpenIdConnectConstants.Properties.AccessTokenLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.AuthorizationCodeLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallenge)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallengeMethod)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.IdentityTokenLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.Nonce)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.RedirectUri)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.RefreshTokenLifetime);
 
             // By default, add the client_id to the list of the
             // presenters allowed to use the access token.
@@ -247,6 +272,12 @@ namespace AspNet.Security.OpenIdConnect.Server
                 return true;
             });
 
+            // Remove the destinations from the claim properties.
+            foreach (var claim in principal.Claims)
+            {
+                claim.Properties.Remove(OpenIdConnectConstants.Properties.Destinations);
+            }
+
             var identity = (ClaimsIdentity) principal.Identity;
 
             // Create a new ticket containing the updated properties and the filtered principal.
@@ -259,6 +290,15 @@ namespace AspNet.Security.OpenIdConnect.Server
 
             // Associate a random identifier with the identity token.
             ticket.SetTicketId(Guid.NewGuid().ToString());
+
+            // Remove the unwanted properties from the authentication ticket.
+            ticket.RemoveProperty(OpenIdConnectConstants.Properties.AccessTokenLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.AuthorizationCodeLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallenge)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallengeMethod)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.IdentityTokenLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.RedirectUri)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.RefreshTokenLifetime);
 
             // By default, add the client_id to the list of the
             // presenters allowed to use the identity token.
@@ -427,6 +467,13 @@ namespace AspNet.Security.OpenIdConnect.Server
 
             // Associate a random identifier with the refresh token.
             ticket.SetTicketId(Guid.NewGuid().ToString());
+
+            // Remove the unwanted properties from the authentication ticket.
+            ticket.RemoveProperty(OpenIdConnectConstants.Properties.AuthorizationCodeLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallenge)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallengeMethod)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.Nonce)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.RedirectUri);
 
             // By default, add the client_id to the list of the
             // presenters allowed to use the refresh token.

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -18,7 +18,7 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace AspNet.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<string> SerializeAuthorizationCodeAsync(
             ClaimsPrincipal principal, AuthenticationProperties properties,

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 
 namespace AspNet.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeLogoutEndpointAsync()
         {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -18,7 +18,7 @@ using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeUserinfoEndpointAsync()
         {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -22,7 +22,7 @@ using Newtonsoft.Json;
 
 namespace AspNet.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         public override async Task<bool> HandleRequestAsync()
         {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -286,12 +286,6 @@ namespace AspNet.Security.OpenIdConnect.Server
             {
                 response.RedirectUri = request.RedirectUri;
                 response.State = request.State;
-
-                // Keep the code_challenge, code_challenge_method, nonce and redirect_uri parameters for later comparison.
-                ticket.SetProperty(OpenIdConnectConstants.Properties.CodeChallenge, request.CodeChallenge)
-                      .SetProperty(OpenIdConnectConstants.Properties.CodeChallengeMethod, request.CodeChallengeMethod)
-                      .SetProperty(OpenIdConnectConstants.Properties.Nonce, request.Nonce)
-                      .SetProperty(OpenIdConnectConstants.Properties.RedirectUri, request.RedirectUri);
             }
 
             // Copy the confidentiality level associated with the request to the authentication ticket.

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -19,7 +19,7 @@ using Owin.Security.OpenIdConnect.Extensions;
 
 namespace Owin.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeAuthorizationEndpointAsync()
         {

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -21,7 +21,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Owin.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeConfigurationEndpointAsync()
         {

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
@@ -20,7 +20,7 @@ using Owin.Security.OpenIdConnect.Extensions;
 
 namespace Owin.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeTokenEndpointAsync()
         {

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -19,7 +19,7 @@ using Owin.Security.OpenIdConnect.Extensions;
 
 namespace Owin.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeIntrospectionEndpointAsync()
         {

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -15,7 +15,7 @@ using Owin.Security.OpenIdConnect.Extensions;
 
 namespace Owin.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeRevocationEndpointAsync()
         {

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -41,6 +41,15 @@ namespace Owin.Security.OpenIdConnect.Server
             // Associate a random identifier with the authorization code.
             ticket.SetTicketId(Guid.NewGuid().ToString());
 
+            // Store the code_challenge, code_challenge_method, nonce and redirect_uri parameters for later comparison.
+            ticket.SetProperty(OpenIdConnectConstants.Properties.CodeChallenge, request.CodeChallenge)
+                  .SetProperty(OpenIdConnectConstants.Properties.CodeChallengeMethod, request.CodeChallengeMethod)
+                  .SetProperty(OpenIdConnectConstants.Properties.Nonce, request.Nonce)
+                  .SetProperty(OpenIdConnectConstants.Properties.RedirectUri, request.RedirectUri);
+
+            // Remove the unwanted properties from the authentication ticket.
+            ticket.RemoveProperty(OpenIdConnectConstants.Properties.AuthorizationCodeLifetime);
+
             // By default, add the client_id to the list of the
             // presenters allowed to use the authorization code.
             if (!string.IsNullOrEmpty(request.ClientId))
@@ -99,6 +108,12 @@ namespace Owin.Security.OpenIdConnect.Server
                 return true;
             });
 
+            // Remove the destinations from the claim properties.
+            foreach (var claim in identity.Claims)
+            {
+                claim.Properties.Remove(OpenIdConnectConstants.Properties.Destinations);
+            }
+
             // Create a new ticket containing the updated properties and the filtered identity.
             var ticket = new AuthenticationTicket(identity, properties);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
@@ -110,6 +125,16 @@ namespace Owin.Security.OpenIdConnect.Server
 
             // Associate a random identifier with the access token.
             ticket.SetTicketId(Guid.NewGuid().ToString());
+
+            // Remove the unwanted properties from the authentication ticket.
+            ticket.RemoveProperty(OpenIdConnectConstants.Properties.AccessTokenLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.AuthorizationCodeLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallenge)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallengeMethod)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.IdentityTokenLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.Nonce)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.RedirectUri)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.RefreshTokenLifetime);
 
             // By default, add the client_id to the list of the
             // presenters allowed to use the access token.
@@ -243,6 +268,12 @@ namespace Owin.Security.OpenIdConnect.Server
                 return true;
             });
 
+            // Remove the destinations from the claim properties.
+            foreach (var claim in identity.Claims)
+            {
+                claim.Properties.Remove(OpenIdConnectConstants.Properties.Destinations);
+            }
+
             // Create a new ticket containing the updated properties and the filtered identity.
             var ticket = new AuthenticationTicket(identity, properties);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
@@ -253,6 +284,15 @@ namespace Owin.Security.OpenIdConnect.Server
 
             // Associate a random identifier with the identity token.
             ticket.SetTicketId(Guid.NewGuid().ToString());
+
+            // Remove the unwanted properties from the authentication ticket.
+            ticket.RemoveProperty(OpenIdConnectConstants.Properties.AccessTokenLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.AuthorizationCodeLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallenge)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallengeMethod)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.IdentityTokenLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.RedirectUri)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.RefreshTokenLifetime);
 
             // By default, add the client_id to the list of the
             // presenters allowed to use the identity token.
@@ -421,6 +461,13 @@ namespace Owin.Security.OpenIdConnect.Server
 
             // Associate a random identifier with the refresh token.
             ticket.SetTicketId(Guid.NewGuid().ToString());
+
+            // Remove the unwanted properties from the authentication ticket.
+            ticket.RemoveProperty(OpenIdConnectConstants.Properties.AuthorizationCodeLifetime)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallenge)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.CodeChallengeMethod)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.Nonce)
+                  .RemoveProperty(OpenIdConnectConstants.Properties.RedirectUri);
 
             // By default, add the client_id to the list of the
             // presenters allowed to use the refresh token.

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -20,7 +20,7 @@ using Owin.Security.OpenIdConnect.Extensions;
 
 namespace Owin.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<string> SerializeAuthorizationCodeAsync(
             ClaimsIdentity identity, AuthenticationProperties properties,

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Session.cs
@@ -14,7 +14,7 @@ using Microsoft.Owin.Security.Infrastructure;
 
 namespace Owin.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeLogoutEndpointAsync()
         {

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -16,7 +16,7 @@ using Owin.Security.OpenIdConnect.Extensions;
 
 namespace Owin.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         private async Task<bool> InvokeUserinfoEndpointAsync()
         {

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -19,7 +19,7 @@ using Owin.Security.OpenIdConnect.Extensions;
 
 namespace Owin.Security.OpenIdConnect.Server
 {
-    internal partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
+    public partial class OpenIdConnectServerHandler : AuthenticationHandler<OpenIdConnectServerOptions>
     {
         public override async Task<bool> InvokeAsync()
         {

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -317,12 +317,6 @@ namespace Owin.Security.OpenIdConnect.Server
             {
                 response.RedirectUri = request.RedirectUri;
                 response.State = request.State;
-
-                // Keep the code_challenge, code_challenge_method, nonce and redirect_uri parameters for later comparison.
-                ticket.SetProperty(OpenIdConnectConstants.Properties.CodeChallenge, request.CodeChallenge)
-                      .SetProperty(OpenIdConnectConstants.Properties.CodeChallengeMethod, request.CodeChallengeMethod)
-                      .SetProperty(OpenIdConnectConstants.Properties.Nonce, request.Nonce)
-                      .SetProperty(OpenIdConnectConstants.Properties.RedirectUri, request.RedirectUri);
             }
 
             // Copy the confidentiality level associated with the request to the authentication ticket.


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/370.