### PR TITLE
Reject token/introspection/revocation requests that use more than one client authentication method

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -503,17 +503,17 @@ namespace AspNet.Security.OpenIdConnect.Server
                         // by OpenIdConnectServerProvider.ValidateAuthorizationRequest,
                         // it's still safer to encode it to avoid cross-site scripting attacks
                         // if the authorization server has a relaxed policy concerning redirect URIs.
-                        writer.WriteLine($"<form name='form' method='post' action='{Options.HtmlEncoder.Encode(response.RedirectUri)}'>");
+                        writer.WriteLine($@"<form name=""form"" method=""post"" action=""{Options.HtmlEncoder.Encode(response.RedirectUri)}"">");
 
                         foreach (var parameter in parameters)
                         {
                             var key = Options.HtmlEncoder.Encode(parameter.Key);
                             var value = Options.HtmlEncoder.Encode(parameter.Value);
 
-                            writer.WriteLine($"<input type='hidden' name='{key}' value='{value}' />");
+                            writer.WriteLine($@"<input type=""hidden"" name=""{key}"" value=""{value}"" />");
                         }
 
-                        writer.WriteLine("<noscript>Click here to finish the authorization process: <input type='submit' /></noscript>");
+                        writer.WriteLine(@"<noscript>Click here to finish the authorization process: <input type=""submit"" /></noscript>");
                         writer.WriteLine("</form>");
                         writer.WriteLine("<script>document.form.submit();</script>");
                         writer.WriteLine("</body>");

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -6,8 +6,6 @@
 
 using System;
 using System.Linq;
-using System.Security.Claims;
-using System.Text;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;
@@ -15,7 +13,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OpenIdConnect.Server
@@ -131,30 +128,27 @@ namespace AspNet.Security.OpenIdConnect.Server
                 });
             }
 
-            // When client_id and client_secret are both null, try to extract them from the Authorization header.
-            // See http://tools.ietf.org/html/rfc6749#section-2.3.1 and
-            // http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
-            if (string.IsNullOrEmpty(request.ClientId) && string.IsNullOrEmpty(request.ClientSecret))
+            // Try to resolve the client credentials specified in the 'Authorization' header.
+            // If they cannot be extracted, fallback to the client_id/client_secret parameters.
+            var credentials = Request.Headers.GetClientCredentials();
+            if (credentials != null)
             {
-                string header = Request.Headers[HeaderNames.Authorization];
-                if (!string.IsNullOrEmpty(header) && header.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+                // Reject requests that use multiple client authentication methods.
+                // See https://tools.ietf.org/html/rfc6749#section-2.3 for more information.
+                if (!string.IsNullOrEmpty(request.ClientSecret))
                 {
-                    try
+                    Logger.LogError("The introspection request was rejected because " +
+                                    "multiple client credentials were specified.");
+
+                    return await SendTokenResponseAsync(new OpenIdConnectResponse
                     {
-                        var value = header.Substring("Basic ".Length).Trim();
-                        var data = Encoding.UTF8.GetString(Convert.FromBase64String(value));
-
-                        var index = data.IndexOf(':');
-                        if (index >= 0)
-                        {
-                            request.ClientId = data.Substring(0, index);
-                            request.ClientSecret = data.Substring(index + 1);
-                        }
-                    }
-
-                    catch (FormatException) { }
-                    catch (ArgumentException) { }
+                        Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                        ErrorDescription = "Multiple client credentials cannot be specified."
+                    });
                 }
+
+                request.ClientId = credentials?.Key;
+                request.ClientSecret = credentials?.Value;
             }
 
             var context = new ValidateIntrospectionRequestContext(Context, Options, request);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -5,14 +5,12 @@
  */
 
 using System;
-using System.Text;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Logging;
-using Microsoft.Net.Http.Headers;
 
 namespace AspNet.Security.OpenIdConnect.Server
 {
@@ -115,30 +113,27 @@ namespace AspNet.Security.OpenIdConnect.Server
                 });
             }
 
-            // When client_id and client_secret are both null, try to extract them from the Authorization header.
-            // See http://tools.ietf.org/html/rfc6749#section-2.3.1 and
-            // http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
-            if (string.IsNullOrEmpty(request.ClientId) && string.IsNullOrEmpty(request.ClientSecret))
+            // Try to resolve the client credentials specified in the 'Authorization' header.
+            // If they cannot be extracted, fallback to the client_id/client_secret parameters.
+            var credentials = Request.Headers.GetClientCredentials();
+            if (credentials != null)
             {
-                string header = Request.Headers[HeaderNames.Authorization];
-                if (!string.IsNullOrEmpty(header) && header.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+                // Reject requests that use multiple client authentication methods.
+                // See https://tools.ietf.org/html/rfc6749#section-2.3 for more information.
+                if (!string.IsNullOrEmpty(request.ClientSecret))
                 {
-                    try
+                    Logger.LogError("The revocation request was rejected because " +
+                                    "multiple client credentials were specified.");
+
+                    return await SendTokenResponseAsync(new OpenIdConnectResponse
                     {
-                        var value = header.Substring("Basic ".Length).Trim();
-                        var data = Encoding.UTF8.GetString(Convert.FromBase64String(value));
-
-                        var index = data.IndexOf(':');
-                        if (index >= 0)
-                        {
-                            request.ClientId = data.Substring(0, index);
-                            request.ClientSecret = data.Substring(index + 1);
-                        }
-                    }
-
-                    catch (FormatException) { }
-                    catch (ArgumentException) { }
+                        Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                        ErrorDescription = "Multiple client credentials cannot be specified."
+                    });
                 }
+
+                request.ClientId = credentials?.Key;
+                request.ClientSecret = credentials?.Value;
             }
 
             var context = new ValidateRevocationRequestContext(Context, Options, request);

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -31,8 +31,8 @@ namespace AspNet.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties.
             var ticket = new AuthenticationTicket(principal, properties, Options.AuthenticationScheme);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc +
-                (ticket.GetAuthorizationCodeLifetime() ?? Options.AuthorizationCodeLifetime);
+            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
+            ticket.Properties.ExpiresUtc += ticket.GetAuthorizationCodeLifetime() ?? Options.AuthorizationCodeLifetime;
 
             ticket.SetUsage(OpenIdConnectConstants.Usages.AuthorizationCode);
 
@@ -119,8 +119,8 @@ namespace AspNet.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties and the filtered principal.
             var ticket = new AuthenticationTicket(principal, properties, Options.AuthenticationScheme);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc +
-                (ticket.GetAccessTokenLifetime() ?? Options.AccessTokenLifetime);
+            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
+            ticket.Properties.ExpiresUtc += ticket.GetAccessTokenLifetime() ?? Options.AccessTokenLifetime;
 
             ticket.SetUsage(OpenIdConnectConstants.Usages.AccessToken);
             ticket.SetAudiences(ticket.GetResources());
@@ -274,8 +274,8 @@ namespace AspNet.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties and the filtered principal.
             var ticket = new AuthenticationTicket(principal, properties, Options.AuthenticationScheme);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc +
-                (ticket.GetIdentityTokenLifetime() ?? Options.IdentityTokenLifetime);
+            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
+            ticket.Properties.ExpiresUtc += ticket.GetIdentityTokenLifetime() ?? Options.IdentityTokenLifetime;
 
             ticket.SetUsage(OpenIdConnectConstants.Usages.IdentityToken);
 
@@ -446,8 +446,8 @@ namespace AspNet.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties.
             var ticket = new AuthenticationTicket(principal, properties, Options.AuthenticationScheme);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc +
-                (ticket.GetRefreshTokenLifetime() ?? Options.RefreshTokenLifetime);
+            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
+            ticket.Properties.ExpiresUtc += ticket.GetRefreshTokenLifetime() ?? Options.RefreshTokenLifetime;
 
             ticket.SetUsage(OpenIdConnectConstants.Usages.RefreshToken);
 
@@ -658,7 +658,9 @@ namespace AspNet.Security.OpenIdConnect.Server
             // in InvokeIntrospectionEndpointAsync or InvokeTokenEndpointAsync.
             notification.TokenValidationParameters = new TokenValidationParameters
             {
-                IssuerSigningKeys = Options.SigningCredentials.Select(credentials => credentials.Key),
+                IssuerSigningKeys = Options.SigningCredentials.Select(credentials => credentials.Key)
+                                                              .Where(key => key is AsymmetricSecurityKey),
+
                 NameClaimType = OpenIdConnectConstants.Claims.Name,
                 RoleClaimType = OpenIdConnectConstants.Claims.Role,
                 ValidIssuer = Context.GetIssuer(Options),

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
@@ -7,9 +8,11 @@ using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -314,6 +317,46 @@ namespace AspNet.Security.OpenIdConnect.Server
                 }
 
                 default: return new OpenIdConnectParameter(claim.Value);
+            }
+        }
+
+        public static KeyValuePair<string, string>? GetClientCredentials(this IHeaderDictionary headers)
+        {
+            if (headers == null)
+            {
+                throw new ArgumentNullException(nameof(headers));
+            }
+
+            string header = headers[HeaderNames.Authorization];
+            if (string.IsNullOrEmpty(header))
+            {
+                return null;
+            }
+
+            if (!header.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            try
+            {
+                var value = header.Substring("Basic ".Length).Trim();
+                var data = Encoding.ASCII.GetString(Convert.FromBase64String(value));
+
+                var index = data.IndexOf(':');
+                if (index < 0)
+                {
+                    return null;
+                }
+
+                return new KeyValuePair<string, string>(
+                    /* client_id: */ data.Substring(0, index),
+                    /* client_secret: */ data.Substring(index + 1));
+            }
+
+            catch
+            {
+                return null;
             }
         }
 

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Authentication.cs
@@ -506,17 +506,17 @@ namespace Owin.Security.OpenIdConnect.Server
                         // by OpenIdConnectServerProvider.ValidateAuthorizationRequest,
                         // it's still safer to encode it to avoid cross-site scripting attacks
                         // if the authorization server has a relaxed policy concerning redirect URIs.
-                        writer.WriteLine($"<form name='form' method='post' action='{Options.HtmlEncoder.Encode(response.RedirectUri)}'>");
+                        writer.WriteLine($@"<form name=""form"" method=""post"" action=""{Options.HtmlEncoder.Encode(response.RedirectUri)}"">");
 
                         foreach (var parameter in parameters)
                         {
                             var key = Options.HtmlEncoder.Encode(parameter.Key);
                             var value = Options.HtmlEncoder.Encode(parameter.Value);
 
-                            writer.WriteLine($"<input type='hidden' name='{key}' value='{value}' />");
+                            writer.WriteLine($@"<input type=""hidden"" name=""{key}"" value=""{value}"" />");
                         }
 
-                        writer.WriteLine("<noscript>Click here to finish the authorization process: <input type='submit' /></noscript>");
+                        writer.WriteLine(@"<noscript>Click here to finish the authorization process: <input type=""submit"" /></noscript>");
                         writer.WriteLine("</form>");
                         writer.WriteLine("<script>document.form.submit();</script>");
                         writer.WriteLine("</body>");

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Exchange.cs
@@ -173,30 +173,26 @@ namespace Owin.Security.OpenIdConnect.Server
                 });
             }
 
-            // When client_id and client_secret are both null, try to extract them from the Authorization header.
-            // See http://tools.ietf.org/html/rfc6749#section-2.3.1 and
-            // http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
-            if (string.IsNullOrEmpty(request.ClientId) && string.IsNullOrEmpty(request.ClientSecret))
+            // Try to resolve the client credentials specified in the 'Authorization' header.
+            // If they cannot be extracted, fallback to the client_id/client_secret parameters.
+            var credentials = Request.Headers.GetClientCredentials();
+            if (credentials != null)
             {
-                var header = Request.Headers.Get("Authorization");
-                if (!string.IsNullOrEmpty(header) && header.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+                // Reject requests that use multiple client authentication methods.
+                // See https://tools.ietf.org/html/rfc6749#section-2.3 for more information.
+                if (!string.IsNullOrEmpty(request.ClientSecret))
                 {
-                    try
+                    Logger.LogError("The token request was rejected because multiple client credentials were specified.");
+
+                    return await SendTokenResponseAsync(new OpenIdConnectResponse
                     {
-                        var value = header.Substring("Basic ".Length).Trim();
-                        var data = Encoding.UTF8.GetString(Convert.FromBase64String(value));
-
-                        var index = data.IndexOf(':');
-                        if (index >= 0)
-                        {
-                            request.ClientId = data.Substring(0, index);
-                            request.ClientSecret = data.Substring(index + 1);
-                        }
-                    }
-
-                    catch (FormatException) { }
-                    catch (ArgumentException) { }
+                        Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                        ErrorDescription = "Multiple client credentials cannot be specified."
+                    });
                 }
+
+                request.ClientId = credentials?.Key;
+                request.ClientSecret = credentials?.Value;
             }
 
             var context = new ValidateTokenRequestContext(Context, Options, request);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -7,8 +7,6 @@
 using System;
 using System.IdentityModel.Tokens;
 using System.Linq;
-using System.Security.Claims;
-using System.Text;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.Extensions.Logging;
@@ -130,30 +128,27 @@ namespace Owin.Security.OpenIdConnect.Server
                 });
             }
 
-            // When client_id and client_secret are both null, try to extract them from the Authorization header.
-            // See http://tools.ietf.org/html/rfc6749#section-2.3.1 and
-            // http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
-            if (string.IsNullOrEmpty(request.ClientId) && string.IsNullOrEmpty(request.ClientSecret))
+            // Try to resolve the client credentials specified in the 'Authorization' header.
+            // If they cannot be extracted, fallback to the client_id/client_secret parameters.
+            var credentials = Request.Headers.GetClientCredentials();
+            if (credentials != null)
             {
-                var header = Request.Headers.Get("Authorization");
-                if (!string.IsNullOrEmpty(header) && header.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+                // Reject requests that use multiple client authentication methods.
+                // See https://tools.ietf.org/html/rfc6749#section-2.3 for more information.
+                if (!string.IsNullOrEmpty(request.ClientSecret))
                 {
-                    try
+                    Logger.LogError("The introspection request was rejected because " +
+                                    "multiple client credentials were specified.");
+
+                    return await SendTokenResponseAsync(new OpenIdConnectResponse
                     {
-                        var value = header.Substring("Basic ".Length).Trim();
-                        var data = Encoding.UTF8.GetString(Convert.FromBase64String(value));
-
-                        var index = data.IndexOf(':');
-                        if (index >= 0)
-                        {
-                            request.ClientId = data.Substring(0, index);
-                            request.ClientSecret = data.Substring(index + 1);
-                        }
-                    }
-
-                    catch (FormatException) { }
-                    catch (ArgumentException) { }
+                        Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                        ErrorDescription = "Multiple client credentials cannot be specified."
+                    });
                 }
+
+                request.ClientId = credentials?.Key;
+                request.ClientSecret = credentials?.Value;
             }
 
             var context = new ValidateIntrospectionRequestContext(Context, Options, request);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -5,7 +5,6 @@
  */
 
 using System;
-using System.Text;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.Extensions.Logging;
@@ -114,30 +113,27 @@ namespace Owin.Security.OpenIdConnect.Server
                 });
             }
 
-            // When client_id and client_secret are both null, try to extract them from the Authorization header.
-            // See http://tools.ietf.org/html/rfc6749#section-2.3.1 and
-            // http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
-            if (string.IsNullOrEmpty(request.ClientId) && string.IsNullOrEmpty(request.ClientSecret))
+            // Try to resolve the client credentials specified in the 'Authorization' header.
+            // If they cannot be extracted, fallback to the client_id/client_secret parameters.
+            var credentials = Request.Headers.GetClientCredentials();
+            if (credentials != null)
             {
-                var header = Request.Headers.Get("Authorization");
-                if (!string.IsNullOrEmpty(header) && header.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+                // Reject requests that use multiple client authentication methods.
+                // See https://tools.ietf.org/html/rfc6749#section-2.3 for more information.
+                if ( !string.IsNullOrEmpty(request.ClientSecret))
                 {
-                    try
+                    Logger.LogError("The revocation request was rejected because " +
+                                    "multiple client credentials were specified.");
+
+                    return await SendTokenResponseAsync(new OpenIdConnectResponse
                     {
-                        var value = header.Substring("Basic ".Length).Trim();
-                        var data = Encoding.UTF8.GetString(Convert.FromBase64String(value));
-
-                        var index = data.IndexOf(':');
-                        if (index >= 0)
-                        {
-                            request.ClientId = data.Substring(0, index);
-                            request.ClientSecret = data.Substring(index + 1);
-                        }
-                    }
-
-                    catch (FormatException) { }
-                    catch (ArgumentException) { }
+                        Error = OpenIdConnectConstants.Errors.InvalidRequest,
+                        ErrorDescription = "Multiple client credentials cannot be specified."
+                    });
                 }
+
+                request.ClientId = credentials?.Key;
+                request.ClientSecret = credentials?.Value;
             }
 
             var context = new ValidateRevocationRequestContext(Context, Options, request);

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -33,8 +33,8 @@ namespace Owin.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties.
             var ticket = new AuthenticationTicket(identity, properties);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc +
-                (ticket.GetAuthorizationCodeLifetime() ?? Options.AuthorizationCodeLifetime);
+            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
+            ticket.Properties.ExpiresUtc += ticket.GetAuthorizationCodeLifetime() ?? Options.AuthorizationCodeLifetime;
 
             ticket.SetUsage(OpenIdConnectConstants.Usages.AuthorizationCode);
 
@@ -114,8 +114,8 @@ namespace Owin.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties and the filtered identity.
             var ticket = new AuthenticationTicket(identity, properties);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc +
-                (ticket.GetAccessTokenLifetime() ?? Options.AccessTokenLifetime);
+            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
+            ticket.Properties.ExpiresUtc += ticket.GetAccessTokenLifetime() ?? Options.AccessTokenLifetime;
 
             ticket.SetUsage(OpenIdConnectConstants.Usages.AccessToken);
             ticket.SetAudiences(ticket.GetResources());
@@ -268,8 +268,8 @@ namespace Owin.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties and the filtered identity.
             var ticket = new AuthenticationTicket(identity, properties);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc +
-                (ticket.GetIdentityTokenLifetime() ?? Options.IdentityTokenLifetime);
+            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
+            ticket.Properties.ExpiresUtc += ticket.GetIdentityTokenLifetime() ?? Options.IdentityTokenLifetime;
 
             ticket.SetUsage(OpenIdConnectConstants.Usages.IdentityToken);
 
@@ -440,8 +440,8 @@ namespace Owin.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties.
             var ticket = new AuthenticationTicket(identity, properties);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc +
-                (ticket.GetRefreshTokenLifetime() ?? Options.RefreshTokenLifetime);
+            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
+            ticket.Properties.ExpiresUtc += ticket.GetRefreshTokenLifetime() ?? Options.RefreshTokenLifetime;
 
             ticket.SetUsage(OpenIdConnectConstants.Usages.RefreshToken);
 
@@ -647,7 +647,9 @@ namespace Owin.Security.OpenIdConnect.Server
             // in InvokeIntrospectionEndpointAsync or InvokeTokenEndpointAsync.
             notification.TokenValidationParameters = new TokenValidationParameters
             {
-                IssuerSigningKeys = Options.SigningCredentials.Select(credentials => credentials.SigningKey),
+                IssuerSigningKeys = Options.SigningCredentials.Select(credentials => credentials.SigningKey)
+                                                              .Where(key => key is AsymmetricSecurityKey),
+
                 NameClaimType = OpenIdConnectConstants.Claims.Name,
                 RoleClaimType = OpenIdConnectConstants.Claims.Role,
                 ValidIssuer = Context.GetIssuer(Options),

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.Extensions.Logging;

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Exchange.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Exchange.cs
@@ -234,6 +234,37 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
                          "was/were missing from the request message.", response.ErrorDescription);
         }
 
+        [Fact]
+        public async Task InvokeTokenEndpointAsync_MultipleClientCredentialsCauseAnError()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.Provider.OnExtractTokenRequest = context =>
+                {
+                    context.HttpContext.Request.Headers[HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.PostAsync(TokenEndpoint, new OpenIdConnectRequest
+            {
+                ClientId = "Fabrikam",
+                ClientSecret = "7Fjfp0ZBr1KtDRbnfVdmIw",
+                GrantType = OpenIdConnectConstants.GrantTypes.Password,
+                Username = "johndoe",
+                Password = "A3ddj3w"
+            });
+
+            // Assert
+            Assert.Equal(OpenIdConnectConstants.Errors.InvalidRequest, response.Error);
+            Assert.Equal("Multiple client credentials cannot be specified.", response.ErrorDescription);
+        }
+
         [Theory]
         [InlineData("custom_error", null, null)]
         [InlineData("custom_error", "custom_description", null)]

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Introspection.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Introspection.cs
@@ -151,6 +151,35 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
                          "with an access, refresh, or identity token is required.", response.ErrorDescription);
         }
 
+        [Fact]
+        public async Task InvokeIntrospectionEndpointAsync_MultipleClientCredentialsCauseAnError()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.Provider.OnExtractIntrospectionRequest = context =>
+                {
+                    context.HttpContext.Request.Headers[HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.PostAsync(IntrospectionEndpoint, new OpenIdConnectRequest
+            {
+                ClientId = "Fabrikam",
+                ClientSecret = "7Fjfp0ZBr1KtDRbnfVdmIw",
+                Token = "2YotnFZFEjr1zCsicMWpAA"
+            });
+
+            // Assert
+            Assert.Equal(OpenIdConnectConstants.Errors.InvalidRequest, response.Error);
+            Assert.Equal("Multiple client credentials cannot be specified.", response.ErrorDescription);
+        }
+
         [Theory]
         [InlineData("custom_error", null, null)]
         [InlineData("custom_error", "custom_description", null)]

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Revocation.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Revocation.cs
@@ -148,6 +148,35 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
                          "with an access or refresh token is required.", response.ErrorDescription);
         }
 
+        [Fact]
+        public async Task InvokeRevocationEndpointAsync_MultipleClientCredentialsCauseAnError()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.Provider.OnExtractRevocationRequest = context =>
+                {
+                    context.HttpContext.Request.Headers[HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.PostAsync(RevocationEndpoint, new OpenIdConnectRequest
+            {
+                ClientId = "Fabrikam",
+                ClientSecret = "7Fjfp0ZBr1KtDRbnfVdmIw",
+                Token = "2YotnFZFEjr1zCsicMWpAA"
+            });
+
+            // Assert
+            Assert.Equal(OpenIdConnectConstants.Errors.InvalidRequest, response.Error);
+            Assert.Equal("Multiple client credentials cannot be specified.", response.ErrorDescription);
+        }
+
         [Theory]
         [InlineData("custom_error", null, null)]
         [InlineData("custom_error", "custom_description", null)]

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Revocation.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Revocation.cs
@@ -145,6 +145,35 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
                          "with an access or refresh token is required.", response.ErrorDescription);
         }
 
+        [Fact]
+        public async Task InvokeRevocationEndpointAsync_MultipleClientCredentialsCauseAnError()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.Provider.OnExtractRevocationRequest = context =>
+                {
+                    context.OwinContext.Request.Headers["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.PostAsync(RevocationEndpoint, new OpenIdConnectRequest
+            {
+                ClientId = "Fabrikam",
+                ClientSecret = "7Fjfp0ZBr1KtDRbnfVdmIw",
+                Token = "2YotnFZFEjr1zCsicMWpAA"
+            });
+
+            // Assert
+            Assert.Equal(OpenIdConnectConstants.Errors.InvalidRequest, response.Error);
+            Assert.Equal("Multiple client credentials cannot be specified.", response.ErrorDescription);
+        }
+
         [Theory]
         [InlineData("custom_error", null, null)]
         [InlineData("custom_error", "custom_description", null)]


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/403.