### PR TITLE
Introduce new events to allow controlling the signin, signout and challenge operations

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ProcessChallengeResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ProcessChallengeResponseContext.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using AspNet.Security.OpenIdConnect.Primitives;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+
+namespace AspNet.Security.OpenIdConnect.Server
+{
+    /// <summary>
+    /// Represents the context class associated with the
+    /// <see cref="OpenIdConnectServerProvider.ProcessChallengeResponse"/> event.
+    /// </summary>
+    public class ProcessChallengeResponseContext : BaseControlContext
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ProcessChallengeResponseContext"/> class.
+        /// </summary>
+        public ProcessChallengeResponseContext(
+            HttpContext context,
+            OpenIdConnectServerOptions options,
+            AuthenticationTicket ticket,
+            OpenIdConnectRequest request,
+            OpenIdConnectResponse response)
+            : base(context)
+        {
+            Options = options;
+            Ticket = ticket;
+            Request = request;
+            Response = response;
+        }
+
+        /// <summary>
+        /// Gets the options used by the OpenID Connect server.
+        /// </summary>
+        public OpenIdConnectServerOptions Options { get; }
+
+        /// <summary>
+        /// Gets the authorization or token request.
+        /// </summary>
+        public new OpenIdConnectRequest Request { get; }
+
+        /// <summary>
+        /// Gets the authorization or token response.
+        /// </summary>
+        public new OpenIdConnectResponse Response { get; }
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ProcessSigninResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ProcessSigninResponseContext.cs
@@ -1,0 +1,83 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using AspNet.Security.OpenIdConnect.Primitives;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+
+namespace AspNet.Security.OpenIdConnect.Server
+{
+    /// <summary>
+    /// Represents the context class associated with the
+    /// <see cref="OpenIdConnectServerProvider.ProcessSigninResponse"/> event.
+    /// </summary>
+    public class ProcessSigninResponseContext : BaseControlContext
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ProcessSigninResponseContext"/> class.
+        /// </summary>
+        public ProcessSigninResponseContext(
+            HttpContext context,
+            OpenIdConnectServerOptions options,
+            AuthenticationTicket ticket,
+            OpenIdConnectRequest request,
+            OpenIdConnectResponse response)
+            : base(context)
+        {
+            Options = options;
+            Ticket = ticket;
+            Request = request;
+            Response = response;
+        }
+
+        /// <summary>
+        /// Gets the options used by the OpenID Connect server.
+        /// </summary>
+        public OpenIdConnectServerOptions Options { get; }
+
+        /// <summary>
+        /// Gets the authorization or token request.
+        /// </summary>
+        public new OpenIdConnectRequest Request { get; }
+
+        /// <summary>
+        /// Gets the authorization or token response.
+        /// </summary>
+        public new OpenIdConnectResponse Response { get; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether an access token
+        /// should be returned to the client application.
+        /// Note: overriding the value of this property is generally not
+        /// recommended, except when dealing with non-standard clients.
+        /// </summary>
+        public bool IncludeAccessToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether an authorization code
+        /// should be returned to the client application.
+        /// Note: overriding the value of this property is generally not
+        /// recommended, except when dealing with non-standard clients.
+        /// </summary>
+        public bool IncludeAuthorizationCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether an identity token
+        /// should be returned to the client application.
+        /// Note: overriding the value of this property is generally not
+        /// recommended, except when dealing with non-standard clients.
+        /// </summary>
+        public bool IncludeIdentityToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether a refresh token
+        /// should be returned to the client application.
+        /// Note: overriding the value of this property is generally not
+        /// recommended, except when dealing with non-standard clients.
+        /// </summary>
+        public bool IncludeRefreshToken { get; set; }
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Server/Events/ProcessSignoutResponseContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/ProcessSignoutResponseContext.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using AspNet.Security.OpenIdConnect.Primitives;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+
+namespace AspNet.Security.OpenIdConnect.Server
+{
+    /// <summary>
+    /// Represents the context class associated with the
+    /// <see cref="OpenIdConnectServerProvider.ProcessSignoutResponse"/> event.
+    /// </summary>
+    public class ProcessSignoutResponseContext : BaseControlContext
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ProcessSignoutResponseContext"/> class.
+        /// </summary>
+        public ProcessSignoutResponseContext(
+            HttpContext context,
+            OpenIdConnectServerOptions options,
+            AuthenticationTicket ticket,
+            OpenIdConnectRequest request,
+            OpenIdConnectResponse response)
+            : base(context)
+        {
+            Options = options;
+            Ticket = ticket;
+            Request = request;
+            Response = response;
+        }
+
+        /// <summary>
+        /// Gets the options used by the OpenID Connect server.
+        /// </summary>
+        public OpenIdConnectServerOptions Options { get; }
+
+        /// <summary>
+        /// Gets the logout request.
+        /// </summary>
+        public new OpenIdConnectRequest Request { get; }
+
+        /// <summary>
+        /// Gets the logout response.
+        /// </summary>
+        public new OpenIdConnectResponse Response { get; }
+    }
+}

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -317,8 +317,89 @@ namespace AspNet.Security.OpenIdConnect.Server
                 ticket.SetPresenters(presenter);
             }
 
-            // Only return an authorization code if the request is an authorization request and has response_type=code.
-            if (request.IsAuthorizationRequest() && request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Code))
+            var notification = new ProcessSigninResponseContext(Context, Options, ticket, request, response);
+
+            if (request.IsAuthorizationRequest())
+            {
+                // By default, return an authorization code if a response type containing code was specified.
+                notification.IncludeAuthorizationCode = request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Code);
+
+                // By default, return an access token if a response type containing token was specified.
+                notification.IncludeAccessToken = request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Token);
+
+                // By default, prevent a refresh token from being returned as the OAuth2 specification
+                // explicitly disallows returning a refresh token from the authorization endpoint.
+                // See https://tools.ietf.org/html/rfc6749#section-4.2.2 for more information.
+                notification.IncludeRefreshToken = false;
+
+                // By default, return an identity token if a response type containing code
+                // was specified and if the openid scope was explicitly or implicitly granted.
+                notification.IncludeIdentityToken =
+                    request.HasResponseType(OpenIdConnectConstants.ResponseTypes.IdToken) &&
+                    ticket.HasScope(OpenIdConnectConstants.Scopes.OpenId);
+            }
+
+            else
+            {
+                // By default, prevent an authorization code from being returned as this type of token
+                // cannot be issued from the token endpoint in the standard OAuth2/OpenID Connect flows.
+                notification.IncludeAuthorizationCode = false;
+
+                // By default, always return an access token.
+                notification.IncludeAccessToken = true;
+
+                // By default, only return a refresh token is the offline_access scope was granted and if
+                // sliding expiration is disabled or if the request is not a grant_type=refresh_token request.
+                notification.IncludeRefreshToken =
+                    ticket.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) &&
+                   (Options.UseSlidingExpiration || !request.IsRefreshTokenGrantType());
+
+                // By default, only return an identity token if the openid scope was granted.
+                notification.IncludeIdentityToken = ticket.HasScope(OpenIdConnectConstants.Scopes.OpenId);
+            }
+
+            await Options.Provider.ProcessSigninResponse(notification);
+
+            if (notification.HandledResponse)
+            {
+                Logger.LogDebug("The sign-in response was handled in user code.");
+
+                return true;
+            }
+
+            else if (notification.Skipped)
+            {
+                Logger.LogDebug("The default sign-in handling was skipped from user code.");
+
+                return false;
+            }
+
+            // Flow the changes made to the ticket.
+            ticket = notification.Ticket;
+
+            // Ensure an authentication ticket has been provided or return
+            // an error code indicating that the request was rejected.
+            if (ticket == null)
+            {
+                Logger.LogError("The request was rejected because no authentication ticket was provided.");
+
+                if (request.IsAuthorizationRequest())
+                {
+                    return await SendAuthorizationResponseAsync(new OpenIdConnectResponse
+                    {
+                        Error = OpenIdConnectConstants.Errors.AccessDenied,
+                        ErrorDescription = "The authorization was denied by the resource owner."
+                    });
+                }
+
+                return await SendTokenResponseAsync(new OpenIdConnectResponse
+                {
+                    Error = OpenIdConnectConstants.Errors.InvalidGrant,
+                    ErrorDescription = "The token request was rejected by the authorization server."
+                });
+            }
+
+            if (notification.IncludeAuthorizationCode)
             {
                 // Make sure to create a copy of the authentication properties
                 // to avoid modifying the properties set on the original ticket.
@@ -327,10 +408,7 @@ namespace AspNet.Security.OpenIdConnect.Server
                 response.Code = await SerializeAuthorizationCodeAsync(ticket.Principal, properties, request, response);
             }
 
-            // Only return an access token if the request is a token request
-            // or an authorization request that specifies response_type=token.
-            if (request.IsTokenRequest() || (request.IsAuthorizationRequest() &&
-                                             request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Token)))
+            if (notification.IncludeAccessToken)
             {
                 // Make sure to create a copy of the authentication properties
                 // to avoid modifying the properties set on the original ticket.
@@ -392,35 +470,22 @@ namespace AspNet.Security.OpenIdConnect.Server
                 }
             }
 
-            // Only return a refresh token if the request is a token request that specifies scope=offline_access.
-            if (request.IsTokenRequest() && ticket.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess))
+            if (notification.IncludeRefreshToken)
             {
-                // Note: when sliding expiration is disabled, don't return a new refresh token,
-                // unless the token request is not a grant_type=refresh_token request.
-                if (Options.UseSlidingExpiration || !request.IsRefreshTokenGrantType())
-                {
-                    // Make sure to create a copy of the authentication properties
-                    // to avoid modifying the properties set on the original ticket.
-                    var properties = ticket.Properties.Copy();
+                // Make sure to create a copy of the authentication properties
+                // to avoid modifying the properties set on the original ticket.
+                var properties = ticket.Properties.Copy();
 
-                    response.RefreshToken = await SerializeRefreshTokenAsync(ticket.Principal, properties, request, response);
-                }
+                response.RefreshToken = await SerializeRefreshTokenAsync(ticket.Principal, properties, request, response);
             }
 
-            // Only return an identity token if the openid scope was requested and granted
-            // to avoid generating and returning an unnecessary token to pure OAuth2 clients.
-            if (ticket.HasScope(OpenIdConnectConstants.Scopes.OpenId))
+            if (notification.IncludeIdentityToken)
             {
-                // Note: don't return an identity token if the request is an
-                // authorization request that doesn't use response_type=id_token.
-                if (request.IsTokenRequest() || request.HasResponseType(OpenIdConnectConstants.ResponseTypes.IdToken))
-                {
-                    // Make sure to create a copy of the authentication properties
-                    // to avoid modifying the properties set on the original ticket.
-                    var properties = ticket.Properties.Copy();
+                // Make sure to create a copy of the authentication properties
+                // to avoid modifying the properties set on the original ticket.
+                var properties = ticket.Properties.Copy();
 
-                    response.IdToken = await SerializeIdentityTokenAsync(ticket.Principal, properties, request, response);
-                }
+                response.IdToken = await SerializeIdentityTokenAsync(ticket.Principal, properties, request, response);
             }
 
             if (request.IsAuthorizationRequest())
@@ -432,6 +497,18 @@ namespace AspNet.Security.OpenIdConnect.Server
         }
 
         protected override Task HandleSignOutAsync(SignOutContext context)
+        {
+            // Create a new ticket containing an empty identity and
+            // the authentication properties extracted from the context.
+            var ticket = new AuthenticationTicket(
+                new ClaimsPrincipal(new ClaimsIdentity()),
+                new AuthenticationProperties(context.Properties),
+                context.AuthenticationScheme);
+
+            return HandleSignOutAsync(ticket);
+        }
+
+        private async Task<bool> HandleSignOutAsync(AuthenticationTicket ticket)
         {
             // Extract the OpenID Connect request from the ASP.NET Core context.
             // If it cannot be found or doesn't correspond to a logout request,
@@ -449,14 +526,47 @@ namespace AspNet.Security.OpenIdConnect.Server
                 throw new InvalidOperationException("A response has already been sent.");
             }
 
-            Logger.LogTrace("A log-out operation was triggered: {Properties}.", context.Properties);
+            Logger.LogTrace("A log-out operation was triggered: {Properties}.", ticket.Properties.Items);
 
-            return SendLogoutResponseAsync(new OpenIdConnectResponse());
+            // Prepare a new OpenID Connect response.
+            response = new OpenIdConnectResponse();
+
+            var notification = new ProcessSignoutResponseContext(Context, Options, ticket, request, response);
+            await Options.Provider.ProcessSignoutResponse(notification);
+
+            if (notification.HandledResponse)
+            {
+                Logger.LogDebug("The sign-out response was handled in user code.");
+
+                return true;
+            }
+
+            else if (notification.Skipped)
+            {
+                Logger.LogDebug("The default sign-out handling was skipped from user code.");
+
+                return false;
+            }
+
+            return await SendLogoutResponseAsync(response);
         }
 
-        protected override Task<bool> HandleForbiddenAsync(ChallengeContext context) => HandleUnauthorizedAsync(context);
+        protected override Task<bool> HandleForbiddenAsync(ChallengeContext context)
+            => HandleUnauthorizedAsync(context);
 
-        protected override async Task<bool> HandleUnauthorizedAsync(ChallengeContext context)
+        protected override Task<bool> HandleUnauthorizedAsync(ChallengeContext context)
+        {
+            // Create a new ticket containing an empty identity and
+            // the authentication properties extracted from the context.
+            var ticket = new AuthenticationTicket(
+                new ClaimsPrincipal(new ClaimsIdentity()),
+                new AuthenticationProperties(context.Properties),
+                context.AuthenticationScheme);
+
+            return HandleUnauthorizedAsync(ticket);
+        }
+
+        private async Task<bool> HandleUnauthorizedAsync(AuthenticationTicket ticket)
         {
             // Extract the OpenID Connect request from the ASP.NET Core context.
             // If it cannot be found or doesn't correspond to an authorization
@@ -473,13 +583,6 @@ namespace AspNet.Security.OpenIdConnect.Server
             {
                 throw new InvalidOperationException("A response has already been sent.");
             }
-
-            // Create a new ticket containing an empty identity and
-            // the authentication properties extracted from the challenge.
-            var ticket = new AuthenticationTicket(
-                new ClaimsPrincipal(new ClaimsIdentity()),
-                new AuthenticationProperties(context.Properties),
-                context.AuthenticationScheme);
 
             // Prepare a new OpenID Connect response.
             response = new OpenIdConnectResponse
@@ -508,7 +611,24 @@ namespace AspNet.Security.OpenIdConnect.Server
                     "The token request was rejected by the authorization server.";
             }
 
-            Logger.LogTrace("A challenge operation was triggered: {Properties}.", context.Properties);
+            Logger.LogTrace("A challenge operation was triggered: {Properties}.", ticket.Properties.Items);
+
+            var notification = new ProcessChallengeResponseContext(Context, Options, ticket, request, response);
+            await Options.Provider.ProcessChallengeResponse(notification);
+
+            if (notification.HandledResponse)
+            {
+                Logger.LogDebug("The challenge response was handled in user code.");
+
+                return true;
+            }
+
+            else if (notification.Skipped)
+            {
+                Logger.LogDebug("The default challenge handling was skipped from user code.");
+
+                return false;
+            }
 
             if (request.IsAuthorizationRequest())
             {

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
@@ -193,6 +193,24 @@ namespace AspNet.Security.OpenIdConnect.Server
             = context => Task.FromResult(0);
 
         /// <summary>
+        /// Represents an event called when processing a challenge response.
+        /// </summary>
+        public Func<ProcessChallengeResponseContext, Task> OnProcessChallengeResponse { get; set; }
+            = context => Task.FromResult(0);
+
+        /// <summary>
+        /// Represents an event called when processing a sign-in response.
+        /// </summary>
+        public Func<ProcessSigninResponseContext, Task> OnProcessSigninResponse { get; set; }
+            = context => Task.FromResult(0);
+
+        /// <summary>
+        /// Represents an event called when processing a sign-out response.
+        /// </summary>
+        public Func<ProcessSignoutResponseContext, Task> OnProcessSignoutResponse { get; set; }
+            = context => Task.FromResult(0);
+
+        /// <summary>
         /// Represents an event called before the authorization response is returned to the caller.
         /// </summary>
         public Func<ApplyAuthorizationResponseContext, Task> OnApplyAuthorizationResponse { get; set; }
@@ -512,6 +530,30 @@ namespace AspNet.Security.OpenIdConnect.Server
         /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
         public virtual Task HandleUserinfoRequest(HandleUserinfoRequestContext context)
             => OnHandleUserinfoRequest(context);
+
+        /// <summary>
+        /// Represents an event called when processing a challenge response.
+        /// </summary>
+        /// <param name="context">The context instance associated with this event.</param>
+        /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
+        public virtual Task ProcessChallengeResponse(ProcessChallengeResponseContext context)
+            => OnProcessChallengeResponse(context);
+
+        /// <summary>
+        /// Represents an event called when processing a sign-in response.
+        /// </summary>
+        /// <param name="context">The context instance associated with this event.</param>
+        /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
+        public virtual Task ProcessSigninResponse(ProcessSigninResponseContext context)
+            => OnProcessSigninResponse(context);
+
+        /// <summary>
+        /// Represents an event called when processing a sign-out response.
+        /// </summary>
+        /// <param name="context">The context instance associated with this event.</param>
+        /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
+        public virtual Task ProcessSignoutResponse(ProcessSignoutResponseContext context)
+            => OnProcessSignoutResponse(context);
 
         /// <summary>
         /// Represents an event called before the authorization response is returned to the caller.

--- a/src/Owin.Security.OpenIdConnect.Server/Events/ProcessChallengeResponseContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/ProcessChallengeResponseContext.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using AspNet.Security.OpenIdConnect.Primitives;
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Notifications;
+
+namespace Owin.Security.OpenIdConnect.Server
+{
+    /// <summary>
+    /// Represents the context class associated with the
+    /// <see cref="OpenIdConnectServerProvider.ProcessChallengeResponse"/> event.
+    /// </summary>
+    public class ProcessChallengeResponseContext : BaseNotification<OpenIdConnectServerOptions>
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ProcessChallengeResponseContext"/> class.
+        /// </summary>
+        public ProcessChallengeResponseContext(
+            IOwinContext context,
+            OpenIdConnectServerOptions options,
+            AuthenticationTicket ticket,
+            OpenIdConnectRequest request,
+            OpenIdConnectResponse response)
+            : base(context, options)
+        {
+            Ticket = ticket;
+            Request = request;
+            Response = response;
+        }
+
+        /// <summary>
+        /// Gets the authorization or token request.
+        /// </summary>
+        public new OpenIdConnectRequest Request { get; }
+
+        /// <summary>
+        /// Gets the authorization or token response.
+        /// </summary>
+        public new OpenIdConnectResponse Response { get; }
+
+        /// <summary>
+        /// Gets the authentication ticket.
+        /// </summary>
+        public AuthenticationTicket Ticket { get; }
+    }
+}

--- a/src/Owin.Security.OpenIdConnect.Server/Events/ProcessSigninResponseContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/ProcessSigninResponseContext.cs
@@ -1,0 +1,83 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using AspNet.Security.OpenIdConnect.Primitives;
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Notifications;
+
+namespace Owin.Security.OpenIdConnect.Server
+{
+    /// <summary>
+    /// Represents the context class associated with the
+    /// <see cref="OpenIdConnectServerProvider.ProcessSigninResponse"/> event.
+    /// </summary>
+    public class ProcessSigninResponseContext : BaseNotification<OpenIdConnectServerOptions>
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ProcessSigninResponseContext"/> class.
+        /// </summary>
+        public ProcessSigninResponseContext(
+            IOwinContext context,
+            OpenIdConnectServerOptions options,
+            AuthenticationTicket ticket,
+            OpenIdConnectRequest request,
+            OpenIdConnectResponse response)
+            : base(context, options)
+        {
+            Ticket = ticket;
+            Request = request;
+            Response = response;
+        }
+
+        /// <summary>
+        /// Gets the authorization or token request.
+        /// </summary>
+        public new OpenIdConnectRequest Request { get; }
+
+        /// <summary>
+        /// Gets the authorization or token response.
+        /// </summary>
+        public new OpenIdConnectResponse Response { get; }
+
+        /// <summary>
+        /// Gets the authentication ticket.
+        /// </summary>
+        public AuthenticationTicket Ticket { get; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether an access token
+        /// should be returned to the client application.
+        /// Note: overriding the value of this property is generally not
+        /// recommended, except when dealing with non-standard clients.
+        /// </summary>
+        public bool IncludeAccessToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether an authorization code
+        /// should be returned to the client application.
+        /// Note: overriding the value of this property is generally not
+        /// recommended, except when dealing with non-standard clients.
+        /// </summary>
+        public bool IncludeAuthorizationCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether an identity token
+        /// should be returned to the client application.
+        /// Note: overriding the value of this property is generally not
+        /// recommended, except when dealing with non-standard clients.
+        /// </summary>
+        public bool IncludeIdentityToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether a refresh token
+        /// should be returned to the client application.
+        /// Note: overriding the value of this property is generally not
+        /// recommended, except when dealing with non-standard clients.
+        /// </summary>
+        public bool IncludeRefreshToken { get; set; }
+    }
+}

--- a/src/Owin.Security.OpenIdConnect.Server/Events/ProcessSignoutResponseContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/ProcessSignoutResponseContext.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using AspNet.Security.OpenIdConnect.Primitives;
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Notifications;
+
+namespace Owin.Security.OpenIdConnect.Server
+{
+    /// <summary>
+    /// Represents the context class associated with the
+    /// <see cref="OpenIdConnectServerProvider.ProcessSignoutResponse"/> event.
+    /// </summary>
+    public class ProcessSignoutResponseContext : BaseNotification<OpenIdConnectServerOptions>
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ProcessSignoutResponseContext"/> class.
+        /// </summary>
+        public ProcessSignoutResponseContext(
+            IOwinContext context,
+            OpenIdConnectServerOptions options,
+            AuthenticationTicket ticket,
+            OpenIdConnectRequest request,
+            OpenIdConnectResponse response)
+            : base(context, options)
+        {
+            Ticket = ticket;
+            Request = request;
+            Response = response;
+        }
+
+        /// <summary>
+        /// Gets the logout request.
+        /// </summary>
+        public new OpenIdConnectRequest Request { get; }
+
+        /// <summary>
+        /// Gets the logout response.
+        /// </summary>
+        public new OpenIdConnectResponse Response { get; }
+
+        /// <summary>
+        /// Gets the authentication ticket.
+        /// </summary>
+        public AuthenticationTicket Ticket { get; }
+    }
+}

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerProvider.cs
@@ -193,6 +193,24 @@ namespace Owin.Security.OpenIdConnect.Server
             = context => Task.FromResult(0);
 
         /// <summary>
+        /// Represents an event called when processing a challenge response.
+        /// </summary>
+        public Func<ProcessChallengeResponseContext, Task> OnProcessChallengeResponse { get; set; }
+            = context => Task.FromResult(0);
+
+        /// <summary>
+        /// Represents an event called when processing a sign-in response.
+        /// </summary>
+        public Func<ProcessSigninResponseContext, Task> OnProcessSigninResponse { get; set; }
+            = context => Task.FromResult(0);
+
+        /// <summary>
+        /// Represents an event called when processing a sign-out response.
+        /// </summary>
+        public Func<ProcessSignoutResponseContext, Task> OnProcessSignoutResponse { get; set; }
+            = context => Task.FromResult(0);
+
+        /// <summary>
         /// Represents an event called before the authorization response is returned to the caller.
         /// </summary>
         public Func<ApplyAuthorizationResponseContext, Task> OnApplyAuthorizationResponse { get; set; }
@@ -512,6 +530,30 @@ namespace Owin.Security.OpenIdConnect.Server
         /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
         public virtual Task HandleUserinfoRequest(HandleUserinfoRequestContext context)
             => OnHandleUserinfoRequest(context);
+
+        /// <summary>
+        /// Represents an event called when processing a challenge response.
+        /// </summary>
+        /// <param name="context">The context instance associated with this event.</param>
+        /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
+        public virtual Task ProcessChallengeResponse(ProcessChallengeResponseContext context)
+            => OnProcessChallengeResponse(context);
+
+        /// <summary>
+        /// Represents an event called when processing a sign-in response.
+        /// </summary>
+        /// <param name="context">The context instance associated with this event.</param>
+        /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
+        public virtual Task ProcessSigninResponse(ProcessSigninResponseContext context)
+            => OnProcessSigninResponse(context);
+
+        /// <summary>
+        /// Represents an event called when processing a sign-out response.
+        /// </summary>
+        /// <param name="context">The context instance associated with this event.</param>
+        /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
+        public virtual Task ProcessSignoutResponse(ProcessSignoutResponseContext context)
+            => OnProcessSignoutResponse(context);
 
         /// <summary>
         /// Represents an event called before the authorization response is returned to the caller.


### PR DESCRIPTION
These new events allow adding custom app logic after calling `AuthenticationManager.SignInAsync()/SignOutAsync()/ChallengeAsync()`.

This is particularly useful for the first operation, as the new `ProcessSigninResponse` event can be used to override the tokens selection mechanism applied by ASOS, which is useful when dealing with non-standard clients or when implementing non-standard flows. E.g you can now force ASOS to return a refresh token from the authorization endpoint, even if it's disallowed by the OAuth2 specification (which is unfortunately not a rare case in the wild).

Note: these changes will be ported to ASOS 2.0 and included in the RC1 version.