### PR TITLE
Prevent the deserialization methods from being called twice when receiving an introspection or revocation request with a token_type_hint

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -219,10 +219,42 @@ namespace AspNet.Security.OpenIdConnect.Server
             // See https://tools.ietf.org/html/rfc7662#section-2.1
             if (ticket == null)
             {
-                ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
-                         await DeserializeAuthorizationCodeAsync(request.Token, request) ??
-                         await DeserializeIdentityTokenAsync(request.Token, request) ??
-                         await DeserializeRefreshTokenAsync(request.Token, request);
+                // To avoid calling the same deserialization methods twice,
+                // an additional check is made to exclude the corresponding
+                // method when an explicit token_type_hint was specified.
+                switch (request.TokenTypeHint)
+                {
+                    case OpenIdConnectConstants.TokenTypeHints.AccessToken:
+                        ticket = await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.AuthorizationCode:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.IdToken:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.RefreshToken:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request);
+                        break;
+
+                    default:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+                }
             }
 
             if (ticket == null)

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -204,10 +204,42 @@ namespace AspNet.Security.OpenIdConnect.Server
             // See https://tools.ietf.org/html/rfc7009#section-2.1
             if (ticket == null)
             {
-                ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
-                         await DeserializeAuthorizationCodeAsync(request.Token, request) ??
-                         await DeserializeIdentityTokenAsync(request.Token, request) ??
-                         await DeserializeRefreshTokenAsync(request.Token, request);
+                // To avoid calling the same deserialization methods twice,
+                // an additional check is made to exclude the corresponding
+                // method when an explicit token_type_hint was specified.
+                switch (request.TokenTypeHint)
+                {
+                    case OpenIdConnectConstants.TokenTypeHints.AccessToken:
+                        ticket = await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.AuthorizationCode:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.IdToken:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.RefreshToken:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request);
+                        break;
+
+                    default:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+                }
             }
 
             if (ticket == null)

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Introspection.cs
@@ -219,10 +219,42 @@ namespace Owin.Security.OpenIdConnect.Server
             // See https://tools.ietf.org/html/rfc7662#section-2.1
             if (ticket == null)
             {
-                ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
-                         await DeserializeAuthorizationCodeAsync(request.Token, request) ??
-                         await DeserializeIdentityTokenAsync(request.Token, request) ??
-                         await DeserializeRefreshTokenAsync(request.Token, request);
+                // To avoid calling the same deserialization methods twice,
+                // an additional check is made to exclude the corresponding
+                // method when an explicit token_type_hint was specified.
+                switch (request.TokenTypeHint)
+                {
+                    case OpenIdConnectConstants.TokenTypeHints.AccessToken:
+                        ticket = await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.AuthorizationCode:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.IdToken:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.RefreshToken:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request);
+                        break;
+
+                    default:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+                }
             }
 
             if (ticket == null)

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Revocation.cs
@@ -204,10 +204,42 @@ namespace Owin.Security.OpenIdConnect.Server
             // See https://tools.ietf.org/html/rfc7009#section-2.1
             if (ticket == null)
             {
-                ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
-                         await DeserializeAuthorizationCodeAsync(request.Token, request) ??
-                         await DeserializeIdentityTokenAsync(request.Token, request) ??
-                         await DeserializeRefreshTokenAsync(request.Token, request);
+                // To avoid calling the same deserialization methods twice,
+                // an additional check is made to exclude the corresponding
+                // method when an explicit token_type_hint was specified.
+                switch (request.TokenTypeHint)
+                {
+                    case OpenIdConnectConstants.TokenTypeHints.AccessToken:
+                        ticket = await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.AuthorizationCode:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.IdToken:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+
+                    case OpenIdConnectConstants.TokenTypeHints.RefreshToken:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request);
+                        break;
+
+                    default:
+                        ticket = await DeserializeAccessTokenAsync(request.Token, request) ??
+                                 await DeserializeAuthorizationCodeAsync(request.Token, request) ??
+                                 await DeserializeIdentityTokenAsync(request.Token, request) ??
+                                 await DeserializeRefreshTokenAsync(request.Token, request);
+                        break;
+                }
             }
 
             if (ticket == null)

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Revocation.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Revocation.cs
@@ -327,8 +327,71 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
                          "client_id was specified by the client application.", exception.Message);
         }
 
+        [Theory]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.AccessToken)]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode)]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.IdToken)]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.RefreshToken)]
+        public async Task InvokeRevocationEndpointAsync_TokenIsNotDeserializedTwice(string hint)
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.Provider.OnDeserializeAccessToken = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeAccessToken)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeAccessToken), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnDeserializeAuthorizationCode = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeAuthorizationCode)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeAuthorizationCode), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnDeserializeIdentityToken = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeIdentityToken)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeIdentityToken), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnDeserializeRefreshToken = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeRefreshToken)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeRefreshToken), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnValidateRevocationRequest = context =>
+                {
+                    context.Validate("Contoso");
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.PostAsync(RevocationEndpoint, new OpenIdConnectRequest
+            {
+                Token = "SlAV32hkKG",
+                TokenTypeHint = hint
+            });
+
+            // Assert
+            Assert.Empty(response.GetParameters());
+        }
+
         [Fact]
-        public async Task InvokeRevocationEndpointAsync_ValidateRevocationRequest_ConfidentialTokenCausesAnErrorWhenValidationIsSkipped()
+        public async Task InvokeRevocationEndpointAsync_ConfidentialTokenCausesAnErrorWhenValidationIsSkipped()
         {
             // Arrange
             var server = CreateAuthorizationServer(options =>
@@ -686,6 +749,90 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
 
             // Assert
             Assert.Equal("Bob le Magnifique", (string) response["name"]);
+        }
+
+        [Fact]
+        public async Task InvokeRevocationEndpointAsync_EmptyResponseIsReturnedForRevokedToken()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.Provider.OnDeserializeAuthorizationCode = context =>
+                {
+                    Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.AuthorizationCode);
+
+                    context.Ticket = new AuthenticationTicket(
+                        new ClaimsPrincipal(),
+                        new AuthenticationProperties(),
+                        context.Options.AuthenticationScheme);
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnValidateRevocationRequest = context =>
+                {
+                    context.Validate("Contoso");
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnHandleRevocationRequest = context =>
+                {
+                    context.Revoked = true;
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.PostAsync(RevocationEndpoint, new OpenIdConnectRequest
+            {
+                Token = "2YotnFZFEjr1zCsicMWpAA"
+            });
+
+            // Assert
+            Assert.Empty(response.GetParameters());
+        }
+
+        [Fact]
+        public async Task InvokeRevocationEndpointAsync_ErrorResponseIsReturnedForNonRevokedToken()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.Provider.OnDeserializeAuthorizationCode = context =>
+                {
+                    Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.AuthorizationCode);
+
+                    context.Ticket = new AuthenticationTicket(
+                        new ClaimsPrincipal(),
+                        new AuthenticationProperties(),
+                        context.Options.AuthenticationScheme);
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnValidateRevocationRequest = context =>
+                {
+                    context.Validate("Contoso");
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.PostAsync(RevocationEndpoint, new OpenIdConnectRequest
+            {
+                Token = "2YotnFZFEjr1zCsicMWpAA"
+            });
+
+            // Assert
+            Assert.Equal(OpenIdConnectConstants.Errors.UnsupportedTokenType, response.Error);
+            Assert.Equal("The specified token cannot be revoked.", response.ErrorDescription);
         }
 
         [Fact]

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Introspection.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Introspection.cs
@@ -354,6 +354,69 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
             Assert.False((bool) response[OpenIdConnectConstants.Parameters.Active]);
         }
 
+        [Theory]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.AccessToken)]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode)]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.IdToken)]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.RefreshToken)]
+        public async Task InvokeIntrospectionEndpointAsync_TokenIsNotDeserializedTwice(string hint)
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.Provider.OnDeserializeAccessToken = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeAccessToken)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeAccessToken), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnDeserializeAuthorizationCode = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeAuthorizationCode)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeAuthorizationCode), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnDeserializeIdentityToken = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeIdentityToken)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeIdentityToken), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnDeserializeRefreshToken = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeRefreshToken)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeRefreshToken), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnValidateIntrospectionRequest = context =>
+                {
+                    context.Skip();
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.PostAsync(IntrospectionEndpoint, new OpenIdConnectRequest
+            {
+                Token = "SlAV32hkKG",
+                TokenTypeHint = hint
+            });
+
+            // Assert
+            Assert.False((bool) response[OpenIdConnectConstants.Parameters.Active]);
+        }
+
         [Fact]
         public async Task InvokeIntrospectionEndpointAsync_ConfidentialTokenCausesAnErrorWhenValidationIsSkipped()
         {

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Revocation.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Revocation.cs
@@ -324,8 +324,71 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
                          "client_id was specified by the client application.", exception.Message);
         }
 
+        [Theory]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.AccessToken)]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode)]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.IdToken)]
+        [InlineData(OpenIdConnectConstants.TokenTypeHints.RefreshToken)]
+        public async Task InvokeRevocationEndpointAsync_TokenIsNotDeserializedTwice(string hint)
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.Provider.OnDeserializeAccessToken = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeAccessToken)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeAccessToken), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnDeserializeAuthorizationCode = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeAuthorizationCode)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeAuthorizationCode), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnDeserializeIdentityToken = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeIdentityToken)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeIdentityToken), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnDeserializeRefreshToken = context =>
+                {
+                    Assert.False(context.Request.HasProperty(nameof(options.Provider.OnDeserializeRefreshToken)));
+                    context.Request.AddProperty(nameof(options.Provider.OnDeserializeRefreshToken), new object());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnValidateRevocationRequest = context =>
+                {
+                    context.Validate("Contoso");
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.PostAsync(RevocationEndpoint, new OpenIdConnectRequest
+            {
+                Token = "SlAV32hkKG",
+                TokenTypeHint = hint
+            });
+
+            // Assert
+            Assert.Empty(response.GetParameters());
+        }
+
         [Fact]
-        public async Task InvokeRevocationEndpointAsync_ValidateRevocationRequest_ConfidentialTokenCausesAnErrorWhenValidationIsSkipped()
+        public async Task InvokeRevocationEndpointAsync_ConfidentialTokenCausesAnErrorWhenValidationIsSkipped()
         {
             // Arrange
             var server = CreateAuthorizationServer(options =>
@@ -675,6 +738,88 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
 
             // Assert
             Assert.Equal("Bob le Magnifique", (string) response["name"]);
+        }
+
+        [Fact]
+        public async Task InvokeRevocationEndpointAsync_EmptyResponseIsReturnedForRevokedToken()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.Provider.OnDeserializeAuthorizationCode = context =>
+                {
+                    Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.AuthorizationCode);
+
+                    context.Ticket = new AuthenticationTicket(
+                        new ClaimsIdentity(context.Options.AuthenticationType),
+                        new AuthenticationProperties());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnValidateRevocationRequest = context =>
+                {
+                    context.Validate("Contoso");
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnHandleRevocationRequest = context =>
+                {
+                    context.Revoked = true;
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.PostAsync(RevocationEndpoint, new OpenIdConnectRequest
+            {
+                Token = "2YotnFZFEjr1zCsicMWpAA"
+            });
+
+            // Assert
+            Assert.Empty(response.GetParameters());
+        }
+
+        [Fact]
+        public async Task InvokeRevocationEndpointAsync_ErrorResponseIsReturnedForNonRevokedToken()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.Provider.OnDeserializeAuthorizationCode = context =>
+                {
+                    Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.AuthorizationCode);
+
+                    context.Ticket = new AuthenticationTicket(
+                        new ClaimsIdentity(context.Options.AuthenticationType),
+                        new AuthenticationProperties());
+
+                    return Task.FromResult(0);
+                };
+
+                options.Provider.OnValidateRevocationRequest = context =>
+                {
+                    context.Validate("Contoso");
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.PostAsync(RevocationEndpoint, new OpenIdConnectRequest
+            {
+                Token = "2YotnFZFEjr1zCsicMWpAA"
+            });
+
+            // Assert
+            Assert.Equal(OpenIdConnectConstants.Errors.UnsupportedTokenType, response.Error);
+            Assert.Equal("The specified token cannot be revoked.", response.ErrorDescription);
         }
 
         [Fact]


### PR DESCRIPTION
Note: this PR will be merged to the `rel/2.0.0-rc1` branch too.