### PR TITLE
Use a compliant Expires header value for uncached responses

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -721,7 +721,7 @@ namespace AspNet.Security.OpenIdConnect.Server
 
                 Response.Headers[HeaderNames.CacheControl] = "no-cache";
                 Response.Headers[HeaderNames.Pragma] = "no-cache";
-                Response.Headers[HeaderNames.Expires] = "-1";
+                Response.Headers[HeaderNames.Expires] = "Thu, 01 Jan 1970 00:00:00 GMT";
 
                 buffer.Seek(offset: 0, loc: SeekOrigin.Begin);
                 await buffer.CopyToAsync(Response.Body, 4096, Context.RequestAborted);
@@ -764,7 +764,7 @@ namespace AspNet.Security.OpenIdConnect.Server
                     default:
                         Response.Headers[HeaderNames.CacheControl] = "no-cache";
                         Response.Headers[HeaderNames.Pragma] = "no-cache";
-                        Response.Headers[HeaderNames.Expires] = "-1";
+                        Response.Headers[HeaderNames.Expires] = "Thu, 01 Jan 1970 00:00:00 GMT";
 
                         break;
                 }

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -747,7 +747,7 @@ namespace Owin.Security.OpenIdConnect.Server
 
                 Response.Headers.Set("Cache-Control", "no-cache");
                 Response.Headers.Set("Pragma", "no-cache");
-                Response.Headers.Set("Expires", "-1");
+                Response.Headers.Set("Expires", "Thu, 01 Jan 1970 00:00:00 GMT");
 
                 buffer.Seek(offset: 0, loc: SeekOrigin.Begin);
                 await buffer.CopyToAsync(Response.Body, 4096, Request.CallCancelled);
@@ -790,7 +790,7 @@ namespace Owin.Security.OpenIdConnect.Server
                     default:
                         Response.Headers["Cache-Control"] = "no-cache";
                         Response.Headers["Pragma"] = "no-cache";
-                        Response.Headers["Expires"] = "-1";
+                        Response.Headers["Expires"] = "Thu, 01 Jan 1970 00:00:00 GMT";
 
                         break;
                 }


### PR DESCRIPTION
The same fix was added to the OIDC handler developed by MSFT and 1.0.2 is a good opportunity to introduce it in ASOS too.

Note: this will be ported to the rel/2.0.0-rc1 branch.