### PR TITLE
Introduce HandleConfigurationRequestContext.Claims and return a default list of supported protocol claims

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
@@ -78,6 +78,12 @@ namespace AspNet.Security.OpenIdConnect.Server
         public string Issuer { get; set; }
 
         /// <summary>
+        /// Gets the list of claims supported by the authorization server.
+        /// </summary>
+        public ISet<string> Claims { get; } =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets a list of the code challenge methods
         /// supported by the authorization server.
         /// </summary>

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -246,6 +246,13 @@ namespace AspNet.Security.OpenIdConnect.Server
 
             notification.Scopes.Add(OpenIdConnectConstants.Scopes.OpenId);
 
+            notification.Claims.Add(OpenIdConnectConstants.Claims.Audience);
+            notification.Claims.Add(OpenIdConnectConstants.Claims.ExpiresAt);
+            notification.Claims.Add(OpenIdConnectConstants.Claims.IssuedAt);
+            notification.Claims.Add(OpenIdConnectConstants.Claims.Issuer);
+            notification.Claims.Add(OpenIdConnectConstants.Claims.JwtId);
+            notification.Claims.Add(OpenIdConnectConstants.Claims.Subject);
+
             notification.SubjectTypes.Add(OpenIdConnectConstants.SubjectTypes.Public);
 
             foreach (var credentials in Options.SigningCredentials)
@@ -313,6 +320,7 @@ namespace AspNet.Security.OpenIdConnect.Server
                 [OpenIdConnectConstants.Metadata.ResponseTypesSupported] = new JArray(notification.ResponseTypes),
                 [OpenIdConnectConstants.Metadata.ResponseModesSupported] = new JArray(notification.ResponseModes),
                 [OpenIdConnectConstants.Metadata.ScopesSupported] = new JArray(notification.Scopes),
+                [OpenIdConnectConstants.Metadata.ClaimsSupported] = new JArray(notification.Claims),
                 [OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported] = new JArray(notification.IdTokenSigningAlgorithms),
                 [OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported] = new JArray(notification.CodeChallengeMethods),
                 [OpenIdConnectConstants.Metadata.SubjectTypesSupported] = new JArray(notification.SubjectTypes),

--- a/src/Owin.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/Events/HandleConfigurationRequestContext.cs
@@ -76,6 +76,12 @@ namespace Owin.Security.OpenIdConnect.Server
         public string Issuer { get; set; }
 
         /// <summary>
+        /// Gets the list of claims supported by the authorization server.
+        /// </summary>
+        public ISet<string> Claims { get; } =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets a list of the code challenge methods
         /// supported by the authorization server.
         /// </summary>

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Discovery.cs
@@ -238,6 +238,13 @@ namespace Owin.Security.OpenIdConnect.Server
 
             notification.Scopes.Add(OpenIdConnectConstants.Scopes.OpenId);
 
+            notification.Claims.Add(OpenIdConnectConstants.Claims.Audience);
+            notification.Claims.Add(OpenIdConnectConstants.Claims.ExpiresAt);
+            notification.Claims.Add(OpenIdConnectConstants.Claims.IssuedAt);
+            notification.Claims.Add(OpenIdConnectConstants.Claims.Issuer);
+            notification.Claims.Add(OpenIdConnectConstants.Claims.JwtId);
+            notification.Claims.Add(OpenIdConnectConstants.Claims.Subject);
+
             notification.SubjectTypes.Add(OpenIdConnectConstants.SubjectTypes.Public);
 
             foreach (var credentials in Options.SigningCredentials)
@@ -302,6 +309,7 @@ namespace Owin.Security.OpenIdConnect.Server
                 [OpenIdConnectConstants.Metadata.ResponseTypesSupported] = new JArray(notification.ResponseTypes),
                 [OpenIdConnectConstants.Metadata.ResponseModesSupported] = new JArray(notification.ResponseModes),
                 [OpenIdConnectConstants.Metadata.ScopesSupported] = new JArray(notification.Scopes),
+                [OpenIdConnectConstants.Metadata.ClaimsSupported] = new JArray(notification.Claims),
                 [OpenIdConnectConstants.Metadata.IdTokenSigningAlgValuesSupported] = new JArray(notification.IdTokenSigningAlgorithms),
                 [OpenIdConnectConstants.Metadata.CodeChallengeMethodsSupported] = new JArray(notification.CodeChallengeMethods),
                 [OpenIdConnectConstants.Metadata.SubjectTypesSupported] = new JArray(notification.SubjectTypes),

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
@@ -608,6 +608,27 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
         }
 
         [Fact]
+        public async Task InvokeConfigurationEndpointAsync_DefaultClaimsAreCorrectlyReturned()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer();
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+            var claims = (string[]) response[OpenIdConnectConstants.Metadata.ClaimsSupported];
+
+            // Assert
+            Assert.Contains(OpenIdConnectConstants.Claims.Audience, claims);
+            Assert.Contains(OpenIdConnectConstants.Claims.ExpiresAt, claims);
+            Assert.Contains(OpenIdConnectConstants.Claims.IssuedAt, claims);
+            Assert.Contains(OpenIdConnectConstants.Claims.Issuer, claims);
+            Assert.Contains(OpenIdConnectConstants.Claims.JwtId, claims);
+            Assert.Contains(OpenIdConnectConstants.Claims.Subject, claims);
+        }
+
+        [Fact]
         public async Task InvokeConfigurationEndpointAsync_DefaultSubjectTypesAreCorrectlyReturned()
         {
             // Arrange

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Discovery.cs
@@ -609,6 +609,27 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
         }
 
         [Fact]
+        public async Task InvokeConfigurationEndpointAsync_DefaultClaimsAreCorrectlyReturned()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer();
+
+            var client = new OpenIdConnectClient(server.HttpClient);
+
+            // Act
+            var response = await client.GetAsync(ConfigurationEndpoint);
+            var claims = (string[]) response[OpenIdConnectConstants.Metadata.ClaimsSupported];
+
+            // Assert
+            Assert.Contains(OpenIdConnectConstants.Claims.Audience, claims);
+            Assert.Contains(OpenIdConnectConstants.Claims.ExpiresAt, claims);
+            Assert.Contains(OpenIdConnectConstants.Claims.IssuedAt, claims);
+            Assert.Contains(OpenIdConnectConstants.Claims.Issuer, claims);
+            Assert.Contains(OpenIdConnectConstants.Claims.JwtId, claims);
+            Assert.Contains(OpenIdConnectConstants.Claims.Subject, claims);
+        }
+
+        [Fact]
         public async Task InvokeConfigurationEndpointAsync_DefaultSubjectTypesAreCorrectlyReturned()
         {
             // Arrange


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/522.

/cc @NinoFloris