### PR TITLE
Make AuthorizationCodeLifetime/AccessTokenLifetime/IdentityTokenLifetime/RefreshTokenLifetime nullable to allow issuing tokens that never expire

### DIFF
--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -30,8 +30,13 @@ namespace AspNet.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties.
             var ticket = new AuthenticationTicket(principal, properties, Scheme.Name);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
-            ticket.Properties.ExpiresUtc += ticket.GetAuthorizationCodeLifetime() ?? Options.AuthorizationCodeLifetime;
+
+            // Only set the expiration date if a lifetime was specified in either the ticket or the options.
+            var lifetime = ticket.GetAuthorizationCodeLifetime() ?? Options.AuthorizationCodeLifetime;
+            if (lifetime.HasValue)
+            {
+                ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc + lifetime.Value;
+            }
 
             // Associate a random identifier with the authorization code.
             ticket.SetTokenId(Guid.NewGuid().ToString());
@@ -112,8 +117,13 @@ namespace AspNet.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties and the filtered principal.
             var ticket = new AuthenticationTicket(principal, properties, Scheme.Name);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
-            ticket.Properties.ExpiresUtc += ticket.GetAccessTokenLifetime() ?? Options.AccessTokenLifetime;
+
+            // Only set the expiration date if a lifetime was specified in either the ticket or the options.
+            var lifetime = ticket.GetAccessTokenLifetime() ?? Options.AccessTokenLifetime;
+            if (lifetime.HasValue)
+            {
+                ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc + lifetime.Value;
+            }
 
             // Associate a random identifier with the access token.
             ticket.SetTokenId(Guid.NewGuid().ToString());
@@ -273,8 +283,13 @@ namespace AspNet.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties and the filtered principal.
             var ticket = new AuthenticationTicket(principal, properties, Scheme.Name);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
-            ticket.Properties.ExpiresUtc += ticket.GetIdentityTokenLifetime() ?? Options.IdentityTokenLifetime;
+
+            // Only set the expiration date if a lifetime was specified in either the ticket or the options.
+            var lifetime = ticket.GetIdentityTokenLifetime() ?? Options.IdentityTokenLifetime;
+            if (lifetime.HasValue)
+            {
+                ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc + lifetime.Value;
+            }
 
             // Associate a random identifier with the identity token.
             ticket.SetTokenId(Guid.NewGuid().ToString());
@@ -439,8 +454,13 @@ namespace AspNet.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties.
             var ticket = new AuthenticationTicket(principal, properties, Scheme.Name);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
-            ticket.Properties.ExpiresUtc += ticket.GetRefreshTokenLifetime() ?? Options.RefreshTokenLifetime;
+
+            // Only set the expiration date if a lifetime was specified in either the ticket or the options.
+            var lifetime = ticket.GetRefreshTokenLifetime() ?? Options.RefreshTokenLifetime;
+            if (lifetime.HasValue)
+            {
+                ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc + lifetime.Value;
+            }
 
             // Associate a random identifier with the refresh token.
             ticket.SetTokenId(Guid.NewGuid().ToString());

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
@@ -159,26 +159,30 @@ namespace AspNet.Security.OpenIdConnect.Server
 
         /// <summary>
         /// Gets or sets the period of time the authorization codes remain valid after being issued.
+        /// While not recommended, this property can be set to <c>null</c> to issue codes that never expire.
         /// </summary>
-        public TimeSpan AuthorizationCodeLifetime { get; set; } = TimeSpan.FromMinutes(5);
+        public TimeSpan? AuthorizationCodeLifetime { get; set; } = TimeSpan.FromMinutes(5);
 
         /// <summary>
         /// Gets or sets the period of time access tokens remain valid after being issued. The default value is 1 hour.
         /// The client application is expected to refresh or acquire a new access token after the token has expired.
+        /// While not recommended, this property can be set to <c>null</c> to issue access tokens that never expire.
         /// </summary>
-        public TimeSpan AccessTokenLifetime { get; set; } = TimeSpan.FromHours(1);
+        public TimeSpan? AccessTokenLifetime { get; set; } = TimeSpan.FromHours(1);
 
         /// <summary>
         /// Gets or sets the period of time identity tokens remain valid after being issued. The default value is 20 minutes.
         /// The client application is expected to refresh or acquire a new identity token after the token has expired.
+        /// While not recommended, this property can be set to <c>null</c> to issue identity tokens that never expire.
         /// </summary>
-        public TimeSpan IdentityTokenLifetime { get; set; } = TimeSpan.FromMinutes(20);
+        public TimeSpan? IdentityTokenLifetime { get; set; } = TimeSpan.FromMinutes(20);
 
         /// <summary>
         /// Gets or sets the period of time refresh tokens remain valid after being issued. The default value is 14 days.
         /// The client application is expected to start a whole new authentication flow after the refresh token has expired.
+        /// While not recommended, this property can be set to <c>null</c> to issue refresh tokens that never expire.
         /// </summary>
-        public TimeSpan RefreshTokenLifetime { get; set; } = TimeSpan.FromDays(14);
+        public TimeSpan? RefreshTokenLifetime { get; set; } = TimeSpan.FromDays(14);
 
         /// <summary>
         /// Gets or sets a boolean indicating whether new refresh tokens should be issued during a refresh token request.

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Serialization.cs
@@ -30,8 +30,13 @@ namespace Owin.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties.
             var ticket = new AuthenticationTicket(identity, properties);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
-            ticket.Properties.ExpiresUtc += ticket.GetAuthorizationCodeLifetime() ?? Options.AuthorizationCodeLifetime;
+
+            // Only set the expiration date if a lifetime was specified in either the ticket or the options.
+            var lifetime = ticket.GetAuthorizationCodeLifetime() ?? Options.AuthorizationCodeLifetime;
+            if (lifetime.HasValue)
+            {
+                ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc + lifetime.Value;
+            }
 
             // Associate a random identifier with the authorization code.
             ticket.SetTokenId(Guid.NewGuid().ToString());
@@ -110,8 +115,13 @@ namespace Owin.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties and the filtered identity.
             var ticket = new AuthenticationTicket(identity, properties);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
-            ticket.Properties.ExpiresUtc += ticket.GetAccessTokenLifetime() ?? Options.AccessTokenLifetime;
+
+            // Only set the expiration date if a lifetime was specified in either the ticket or the options.
+            var lifetime = ticket.GetAccessTokenLifetime() ?? Options.AccessTokenLifetime;
+            if (lifetime.HasValue)
+            {
+                ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc + lifetime.Value;
+            }
 
             // Associate a random identifier with the access token.
             ticket.SetTokenId(Guid.NewGuid().ToString());
@@ -266,8 +276,13 @@ namespace Owin.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties and the filtered identity.
             var ticket = new AuthenticationTicket(identity, properties);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
-            ticket.Properties.ExpiresUtc += ticket.GetIdentityTokenLifetime() ?? Options.IdentityTokenLifetime;
+
+            // Only set the expiration date if a lifetime was specified in either the ticket or the options.
+            var lifetime = ticket.GetIdentityTokenLifetime() ?? Options.IdentityTokenLifetime;
+            if (lifetime.HasValue)
+            {
+                ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc + lifetime.Value;
+            }
 
             // Associate a random identifier with the identity token.
             ticket.SetTokenId(Guid.NewGuid().ToString());
@@ -429,8 +444,13 @@ namespace Owin.Security.OpenIdConnect.Server
             // Create a new ticket containing the updated properties.
             var ticket = new AuthenticationTicket(identity, properties);
             ticket.Properties.IssuedUtc = Options.SystemClock.UtcNow;
-            ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc;
-            ticket.Properties.ExpiresUtc += ticket.GetRefreshTokenLifetime() ?? Options.RefreshTokenLifetime;
+
+            // Only set the expiration date if a lifetime was specified in either the ticket or the options.
+            var lifetime = ticket.GetRefreshTokenLifetime() ?? Options.RefreshTokenLifetime;
+            if (lifetime.HasValue)
+            {
+                ticket.Properties.ExpiresUtc = ticket.Properties.IssuedUtc + lifetime.Value;
+            }
 
             // Associate a random identifier with the refresh token.
             ticket.SetTokenId(Guid.NewGuid().ToString());

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerOptions.cs
@@ -144,26 +144,30 @@ namespace Owin.Security.OpenIdConnect.Server
 
         /// <summary>
         /// Gets or sets the period of time the authorization codes remain valid after being issued.
+        /// While not recommended, this property can be set to <c>null</c> to issue codes that never expire.
         /// </summary>
-        public TimeSpan AuthorizationCodeLifetime { get; set; } = TimeSpan.FromMinutes(5);
+        public TimeSpan? AuthorizationCodeLifetime { get; set; } = TimeSpan.FromMinutes(5);
 
         /// <summary>
         /// Gets or sets the period of time access tokens remain valid after being issued. The default value is 1 hour.
         /// The client application is expected to refresh or acquire a new access token after the token has expired.
+        /// While not recommended, this property can be set to <c>null</c> to issue access tokens that never expire.
         /// </summary>
-        public TimeSpan AccessTokenLifetime { get; set; } = TimeSpan.FromHours(1);
+        public TimeSpan? AccessTokenLifetime { get; set; } = TimeSpan.FromHours(1);
 
         /// <summary>
         /// Gets or sets the period of time identity tokens remain valid after being issued. The default value is 20 minutes.
         /// The client application is expected to refresh or acquire a new identity token after the token has expired.
+        /// While not recommended, this property can be set to <c>null</c> to issue identity tokens that never expire.
         /// </summary>
-        public TimeSpan IdentityTokenLifetime { get; set; } = TimeSpan.FromMinutes(20);
+        public TimeSpan? IdentityTokenLifetime { get; set; } = TimeSpan.FromMinutes(20);
 
         /// <summary>
         /// Gets or sets the period of time refresh tokens remain valid after being issued. The default value is 14 days.
         /// The client application is expected to start a whole new authentication flow after the refresh token has expired.
+        /// While not recommended, this property can be set to <c>null</c> to issue refresh tokens that never expire.
         /// </summary>
-        public TimeSpan RefreshTokenLifetime { get; set; } = TimeSpan.FromDays(14);
+        public TimeSpan? RefreshTokenLifetime { get; set; } = TimeSpan.FromDays(14);
 
         /// <summary>
         /// Gets or sets a boolean indicating whether new refresh tokens should be issued during a refresh token request.

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Serialization.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Serialization.cs
@@ -25,6 +25,56 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
     public partial class OpenIdConnectServerHandlerTests
     {
         [Fact]
+        public async Task SerializeAuthorizationCodeAsync_ExpirationDateIsNotAddedWhenLifetimeIsNull()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.AuthorizationCodeLifetime = null;
+
+                options.Provider.OnSerializeAuthorizationCode = context =>
+                {
+                    // Assert
+                    Assert.NotNull(context.Ticket.Properties.IssuedUtc);
+                    Assert.Null(context.Ticket.Properties.ExpiresUtc);
+
+                    return Task.CompletedTask;
+                };
+
+                options.Provider.OnValidateAuthorizationRequest = context =>
+                {
+                    context.Validate();
+
+                    return Task.CompletedTask;
+                };
+
+                options.Provider.OnHandleAuthorizationRequest = context =>
+                {
+                    var identity = new ClaimsIdentity(OpenIdConnectServerDefaults.AuthenticationScheme);
+                    identity.AddClaim(OpenIdConnectConstants.Claims.Subject, "Bob le Magnifique");
+
+                    context.Validate(new ClaimsPrincipal(identity));
+
+                    return Task.CompletedTask;
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.PostAsync(AuthorizationEndpoint, new OpenIdConnectRequest
+            {
+                ClientId = "Fabrikam",
+                RedirectUri = "http://www.fabrikam.com/path",
+                ResponseType = OpenIdConnectConstants.ResponseTypes.Code,
+                Scope = OpenIdConnectConstants.Scopes.OpenId
+            });
+
+            // Assert
+            Assert.NotNull(response.Code);
+        }
+
+        [Fact]
         public async Task SerializeAuthorizationCodeAsync_ExpirationDateIsInferredFromCurrentDatetime()
         {
             // Arrange
@@ -429,6 +479,55 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
             // Assert
             Assert.Equal("7F82F1A3-8C9F-489F-B838-4B644B7C92B2", response.Code);
             format.Verify(mock => mock.Protect(It.IsAny<AuthenticationTicket>()), Times.Once());
+        }
+
+        [Fact]
+        public async Task SerializeAccessTokenAsync_ExpirationDateIsNotAddedWhenLifetimeIsNull()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.AccessTokenLifetime = null;
+
+                options.Provider.OnSerializeAccessToken = context =>
+                {
+                    // Assert
+                    Assert.NotNull(context.Ticket.Properties.IssuedUtc);
+                    Assert.Null(context.Ticket.Properties.ExpiresUtc);
+
+                    return Task.CompletedTask;
+                };
+
+                options.Provider.OnValidateTokenRequest = context =>
+                {
+                    context.Skip();
+
+                    return Task.CompletedTask;
+                };
+
+                options.Provider.OnHandleTokenRequest = context =>
+                {
+                    var identity = new ClaimsIdentity(OpenIdConnectServerDefaults.AuthenticationScheme);
+                    identity.AddClaim(OpenIdConnectConstants.Claims.Subject, "Bob le Magnifique");
+
+                    context.Validate(new ClaimsPrincipal(identity));
+
+                    return Task.CompletedTask;
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.PostAsync(TokenEndpoint, new OpenIdConnectRequest
+            {
+                GrantType = OpenIdConnectConstants.GrantTypes.Password,
+                Username = "johndoe",
+                Password = "A3ddj3w"
+            });
+
+            // Assert
+            Assert.NotNull(response.AccessToken);
         }
 
         [Fact]
@@ -1193,6 +1292,56 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
         }
 
         [Fact]
+        public async Task SerializeIdentityTokenAsync_ExpirationDateIsNotAddedWhenLifetimeIsNull()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.IdentityTokenLifetime = null;
+
+                options.Provider.OnSerializeIdentityToken = context =>
+                {
+                    // Assert
+                    Assert.NotNull(context.Ticket.Properties.IssuedUtc);
+                    Assert.Null(context.Ticket.Properties.ExpiresUtc);
+
+                    return Task.CompletedTask;
+                };
+
+                options.Provider.OnValidateTokenRequest = context =>
+                {
+                    context.Skip();
+
+                    return Task.CompletedTask;
+                };
+
+                options.Provider.OnHandleTokenRequest = context =>
+                {
+                    var identity = new ClaimsIdentity(OpenIdConnectServerDefaults.AuthenticationScheme);
+                    identity.AddClaim(OpenIdConnectConstants.Claims.Subject, "Bob le Magnifique");
+
+                    context.Validate(new ClaimsPrincipal(identity));
+
+                    return Task.CompletedTask;
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.PostAsync(TokenEndpoint, new OpenIdConnectRequest
+            {
+                GrantType = OpenIdConnectConstants.GrantTypes.Password,
+                Username = "johndoe",
+                Password = "A3ddj3w",
+                Scope = OpenIdConnectConstants.Scopes.OpenId
+            });
+
+            // Assert
+            Assert.NotNull(response.IdToken);
+        }
+
+        [Fact]
         public async Task SerializeIdentityTokenAsync_ExpirationDateIsInferredFromCurrentDatetime()
         {
             // Arrange
@@ -1870,6 +2019,63 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
             // Assert
             Assert.Equal("7F82F1A3-8C9F-489F-B838-4B644B7C92B2", response.IdToken);
             format.Verify(mock => mock.CreateEncodedJwt(It.IsAny<SecurityTokenDescriptor>()), Times.Once());
+        }
+
+        [Fact]
+        public async Task SerializeRefreshTokenAsync_ExpirationDateIsNotAddedWhenLifetimeIsNull()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(options =>
+            {
+                options.RefreshTokenLifetime = null;
+
+                options.Provider.OnSerializeRefreshToken = context =>
+                {
+                    // Assert
+                    Assert.NotNull(context.Ticket.Properties.IssuedUtc);
+                    Assert.Null(context.Ticket.Properties.ExpiresUtc);
+
+                    return Task.CompletedTask;
+                };
+
+                options.Provider.OnValidateTokenRequest = context =>
+                {
+                    context.Skip();
+
+                    return Task.CompletedTask;
+                };
+
+                options.Provider.OnHandleTokenRequest = context =>
+                {
+                    var identity = new ClaimsIdentity(OpenIdConnectServerDefaults.AuthenticationScheme);
+                    identity.AddClaim(OpenIdConnectConstants.Claims.Subject, "Bob le Magnifique");
+
+                    var ticket = new AuthenticationTicket(
+                        new ClaimsPrincipal(identity),
+                        new AuthenticationProperties(),
+                        OpenIdConnectServerDefaults.AuthenticationScheme);
+
+                    ticket.SetScopes(OpenIdConnectConstants.Scopes.OfflineAccess);
+
+                    context.Validate(ticket);
+
+                    return Task.CompletedTask;
+                };
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.PostAsync(TokenEndpoint, new OpenIdConnectRequest
+            {
+                GrantType = OpenIdConnectConstants.GrantTypes.Password,
+                Username = "johndoe",
+                Password = "A3ddj3w",
+                Scope = OpenIdConnectConstants.Scopes.OfflineAccess
+            });
+
+            // Assert
+            Assert.NotNull(response.RefreshToken);
         }
 
         [Fact]


### PR DESCRIPTION
Closes https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/524.

Note: this PR won't be backported to the 1.1 bits as it's a binary and source change.

/cc @0xNF