### PR TITLE
Update the non-interactive endpoints to return a 401 response for invalid client credentials when basic authentication is used

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Package Versions">
     <AngleSharpVersion>0.9.9</AngleSharpVersion>
-    <AspNetContribOpenIdExtensionsVersion>2.0.0-rc2-final</AspNetContribOpenIdExtensionsVersion>
+    <AspNetContribOpenIdExtensionsVersion>2.0.0-rc3-final</AspNetContribOpenIdExtensionsVersion>
     <AspNetCoreVersion>2.0.0</AspNetCoreVersion>
     <CoreFxVersion>4.4.0</CoreFxVersion>
     <EntityFrameworkVersion>6.1.3</EntityFrameworkVersion>

--- a/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConstants.cs
+++ b/src/AspNet.Security.OpenIdConnect.Primitives/OpenIdConnectConstants.cs
@@ -112,6 +112,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives
             public const string InvalidRequestObject = "invalid_request_object";
             public const string InvalidRequestUri = "invalid_request_uri";
             public const string InvalidScope = "invalid_scope";
+            public const string InvalidToken = "invalid_token";
             public const string LoginRequired = "login_required";
             public const string RegistrationNotSupported = "registration_not_supported";
             public const string RequestNotSupported = "request_not_supported";
@@ -232,6 +233,7 @@ namespace AspNet.Security.OpenIdConnect.Primitives
             public const string Password = "password";
             public const string PostLogoutRedirectUri = "post_logout_redirect_uri";
             public const string Prompt = "prompt";
+            public const string Realm = "realm";
             public const string RedirectUri = "redirect_uri";
             public const string RefreshToken = "refresh_token";
             public const string Registration = "registration";
@@ -304,6 +306,12 @@ namespace AspNet.Security.OpenIdConnect.Primitives
         {
             public static readonly char[] Ampersand = { '&' };
             public static readonly char[] Space = { ' ' };
+        }
+
+        public static class Schemes
+        {
+            public const string Basic = "Basic";
+            public const string Bearer = "Bearer";
         }
 
         public static class Scopes

--- a/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/AspNet.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -191,14 +191,9 @@ namespace AspNet.Security.OpenIdConnect.Server
             {
                 Logger.LogError("The userinfo request was rejected because the access token was invalid.");
 
-                // Note: an invalid token should result in an unauthorized response
-                // but returning a 401 status would invoke the previously registered
-                // authentication middleware and potentially replace it by a 302 response.
-                // To work around this limitation, a 400 error is returned instead.
-                // See http://openid.net/specs/openid-connect-core-1_0.html#UserInfoError
                 return await SendUserinfoResponseAsync(new OpenIdConnectResponse
                 {
-                    Error = OpenIdConnectConstants.Errors.InvalidGrant,
+                    Error = OpenIdConnectConstants.Errors.InvalidToken,
                     ErrorDescription = "The specified access token is not valid."
                 });
             }
@@ -208,14 +203,9 @@ namespace AspNet.Security.OpenIdConnect.Server
             {
                 Logger.LogError("The userinfo request was rejected because the access token was expired.");
 
-                // Note: an invalid token should result in an unauthorized response
-                // but returning a 401 status would invoke the previously registered
-                // authentication middleware and potentially replace it by a 302 response.
-                // To work around this limitation, a 400 error is returned instead.
-                // See http://openid.net/specs/openid-connect-core-1_0.html#UserInfoError
                 return await SendUserinfoResponseAsync(new OpenIdConnectResponse
                 {
-                    Error = OpenIdConnectConstants.Errors.InvalidGrant,
+                    Error = OpenIdConnectConstants.Errors.InvalidToken,
                     ErrorDescription = "The specified access token is no longer valid."
                 });
             }

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.Userinfo.cs
@@ -189,7 +189,7 @@ namespace Owin.Security.OpenIdConnect.Server
                 // See http://openid.net/specs/openid-connect-core-1_0.html#UserInfoError
                 return await SendUserinfoResponseAsync(new OpenIdConnectResponse
                 {
-                    Error = OpenIdConnectConstants.Errors.InvalidGrant,
+                    Error = OpenIdConnectConstants.Errors.InvalidToken,
                     ErrorDescription = "The specified access token is not valid."
                 });
             }
@@ -206,7 +206,7 @@ namespace Owin.Security.OpenIdConnect.Server
                 // See http://openid.net/specs/openid-connect-core-1_0.html#UserInfoError
                 return await SendUserinfoResponseAsync(new OpenIdConnectResponse
                 {
-                    Error = OpenIdConnectConstants.Errors.InvalidGrant,
+                    Error = OpenIdConnectConstants.Errors.InvalidToken,
                     ErrorDescription = "The specified access token is no longer valid."
                 });
             }

--- a/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
+++ b/src/Owin.Security.OpenIdConnect.Server/OpenIdConnectServerHandler.cs
@@ -745,6 +745,10 @@ namespace Owin.Security.OpenIdConnect.Server
 
                 writer.Flush();
 
+                // Note: when using basic authentication, returning an invalid_client error MUST result in
+                // an unauthorized response but returning a 401 status code would invoke the previously
+                // registered authentication middleware and potentially replace it by a 302 response.
+                // To work around this OWIN/Katana limitation, a 400 response code is always returned.
                 if (!string.IsNullOrEmpty(response.Error))
                 {
                     Response.StatusCode = 400;

--- a/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Userinfo.cs
+++ b/test/AspNet.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Userinfo.cs
@@ -252,7 +252,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
             });
 
             // Assert
-            Assert.Equal(OpenIdConnectConstants.Errors.InvalidGrant, response.Error);
+            Assert.Equal(OpenIdConnectConstants.Errors.InvalidToken, response.Error);
             Assert.Equal("The specified access token is not valid.", response.ErrorDescription);
         }
 
@@ -286,7 +286,7 @@ namespace AspNet.Security.OpenIdConnect.Server.Tests
             });
 
             // Assert
-            Assert.Equal(OpenIdConnectConstants.Errors.InvalidGrant, response.Error);
+            Assert.Equal(OpenIdConnectConstants.Errors.InvalidToken, response.Error);
             Assert.Equal("The specified access token is no longer valid.", response.ErrorDescription);
         }
 

--- a/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Userinfo.cs
+++ b/test/Owin.Security.OpenIdConnect.Server.Tests/OpenIdConnectServerHandlerTests.Userinfo.cs
@@ -250,7 +250,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
             });
 
             // Assert
-            Assert.Equal(OpenIdConnectConstants.Errors.InvalidGrant, response.Error);
+            Assert.Equal(OpenIdConnectConstants.Errors.InvalidToken, response.Error);
             Assert.Equal("The specified access token is not valid.", response.ErrorDescription);
         }
 
@@ -283,7 +283,7 @@ namespace Owin.Security.OpenIdConnect.Server.Tests
             });
 
             // Assert
-            Assert.Equal(OpenIdConnectConstants.Errors.InvalidGrant, response.Error);
+            Assert.Equal(OpenIdConnectConstants.Errors.InvalidToken, response.Error);
             Assert.Equal("The specified access token is no longer valid.", response.ErrorDescription);
         }
 


### PR DESCRIPTION
Note: this PR won't be backported to ASOS 1.1.0 nor to the OWIN version due to the automatic 401 -> 302 conversion used by the ASP.NET Core 1.x and Katana 3.x/4.x authentication stacks.